### PR TITLE
Add layout example pages

### DIFF
--- a/layout-examples/accordion-layout.html
+++ b/layout-examples/accordion-layout.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Accordion Layout</title>
+  <meta name="description" content="Mobile-First FAQ Muster mit semantischen Details-Elementen und progressiver Offenlegung." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-accordion {
+      display: grid;
+      gap: clamp(1.25rem, 4vw, 2rem);
+    }
+
+    #preview.layout-accordion details {
+      border-radius: var(--radius-lg);
+      background: var(--color-card);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    #preview.layout-accordion details[open] {
+      border-color: color-mix(in srgb, var(--color-primary) 55%, var(--color-border));
+      box-shadow: var(--shadow-hard);
+    }
+
+    #preview.layout-accordion summary {
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      padding: clamp(1rem, 3vw, 1.5rem) clamp(1rem, 3vw, 1.75rem);
+      font-weight: 600;
+    }
+
+    #preview.layout-accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    #preview.layout-accordion .summary-icon {
+      inline-size: 1.5rem;
+      block-size: 1.5rem;
+      border-radius: 999px;
+      display: grid;
+      place-items: center;
+      background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+      color: var(--color-primary);
+      transition: transform 0.3s ease, background 0.3s ease, color 0.3s ease;
+    }
+
+    #preview.layout-accordion details[open] .summary-icon {
+      transform: rotate(45deg);
+      background: var(--color-primary);
+      color: var(--color-primary-contrast);
+    }
+
+    #preview.layout-accordion details p {
+      padding: 0 clamp(1.25rem, 4vw, 2rem) clamp(1.25rem, 4vw, 2rem);
+      color: var(--color-muted);
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/accordion-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Interaktives Layout</p>
+      <h1 class="section-title">Accordion Layout</h1>
+      <p class="prose">Dieses Muster eignet sich für umfangreiche FAQ oder Richtlinien. Es nutzt native Details-Elemente, deaktiviert parallele Öffnungen und bleibt komplett tastaturbedienbar.</p>
+    </section>
+
+    <section id="preview" class="layout-accordion" data-accordion aria-labelledby="accordion-heading">
+      <h2 id="accordion-heading" class="sr-only">Akkordeon Beispiel</h2>
+      <details open>
+        <summary>
+          <span>Wie stelle ich Barrierefreiheit sicher?</span>
+          <span class="summary-icon" aria-hidden="true">+</span>
+        </summary>
+        <p>
+          Verwenden Sie native HTML-Elemente, definieren Sie logische Überschriften und stellen Sie sicher, dass jeweils nur
+          eine Sektion geöffnet ist. Fokuszustände werden automatisch berücksichtigt.
+        </p>
+      </details>
+      <details>
+        <summary>
+          <span>Welche Inhalte eignen sich?</span>
+          <span class="summary-icon" aria-hidden="true">+</span>
+        </summary>
+        <p>
+          Richtlinien, Support-Fragen oder Tutorial-Schritte lassen sich modular strukturieren. Jede Einheit bleibt unabhängig
+          adressierbar.
+        </p>
+      </details>
+      <details>
+        <summary>
+          <span>Wie skaliert das Layout?</span>
+          <span class="summary-icon" aria-hidden="true">+</span>
+        </summary>
+        <p>
+          Mobile-First vollbreit, ab größeren Viewports sorgt <code>clamp()</code> für eine maximale Breite von 72ch und
+          großzügige Weißräume.
+        </p>
+      </details>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Accordion Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/assets/base.css
+++ b/layout-examples/assets/base.css
@@ -1,0 +1,289 @@
+:root {
+  color-scheme: light dark;
+  --font-sans: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: "Fira Code", "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+  --color-bg: #f8f9fb;
+  --color-surface: #ffffffcc;
+  --color-card: #ffffff;
+  --color-border: #d0d7de;
+  --color-text: #1f2933;
+  --color-muted: #52606d;
+  --color-primary: #2563eb;
+  --color-primary-contrast: #ffffff;
+  --shadow-soft: 0 20px 45px -20px rgba(15, 23, 42, 0.25);
+  --shadow-hard: 0 24px 60px -25px rgba(15, 23, 42, 0.35);
+  --radius-sm: 0.5rem;
+  --radius-lg: 1rem;
+  --container-max: min(96vw, 78rem);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #0f172a;
+    --color-surface: #0b1220f2;
+    --color-card: #111c33;
+    --color-border: #1f2a40;
+    --color-text: #e2e8f0;
+    --color-muted: #94a3b8;
+    --color-primary: #60a5fa;
+    --shadow-soft: 0 20px 40px -25px rgba(8, 47, 73, 0.6);
+    --shadow-hard: 0 24px 55px -20px rgba(37, 99, 235, 0.35);
+  }
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: clamp(15px, 1.6vw, 18px);
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: linear-gradient(180deg, var(--color-bg), color-mix(in srgb, var(--color-bg) 75%, var(--color-card)));
+  color: var(--color-text);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--color-primary);
+}
+
+a:hover,
+a:focus-visible {
+  color: color-mix(in srgb, var(--color-primary) 85%, var(--color-primary-contrast));
+}
+
+.skip-link {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+  z-index: 1000;
+  transform: translateY(-200%);
+  transition: transform 0.3s ease;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-soft);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header,
+.site-footer {
+  background: var(--color-surface);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--color-border);
+  padding: clamp(1rem, 3vw, 1.75rem) clamp(1rem, 5vw, 2.5rem);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 500;
+}
+
+.site-header__brand {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.site-header__logo {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+  font-weight: 700;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: var(--container-max);
+  margin: 0 auto;
+}
+
+.site-nav__links {
+  display: flex;
+  gap: clamp(0.75rem, 3vw, 1.5rem);
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-nav__toggle {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+}
+
+.site-nav__toggle svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+@media (max-width: 60rem) {
+  .site-nav__links {
+    position: fixed;
+    inset: 4.5rem 1rem auto;
+    background: var(--color-card);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-hard);
+    padding: 1.25rem;
+    flex-direction: column;
+    align-items: stretch;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-1rem);
+    transition: 0.3s ease;
+  }
+
+  .site-nav__links[aria-expanded="true"] {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+}
+
+main {
+  flex: 1;
+}
+
+.layout-page {
+  display: grid;
+  gap: clamp(2rem, 6vw, 4rem);
+  padding-block: clamp(2.5rem, 6vw, 5rem);
+}
+
+.layout-intro {
+  display: grid;
+  gap: 1rem;
+  text-align: left;
+}
+
+.layout-intro .prose {
+  margin: 0;
+}
+
+.section-title {
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  margin-block: clamp(1.5rem, 4vw, 2.5rem) clamp(1rem, 3vw, 2rem);
+  text-wrap: balance;
+}
+
+.content-width {
+  width: min(100%, var(--container-max));
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 4vw, 2.5rem);
+}
+
+.prose {
+  max-width: clamp(45ch, 65ch, 72ch);
+  margin-inline: auto;
+}
+
+.card {
+  background: var(--color-card);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1rem, 4vw, 2rem);
+}
+
+button,
+[role="button"],
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:focus-visible,
+a:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--color-primary) 70%, white 30%);
+  outline-offset: 3px;
+}
+
+figure {
+  margin: 0;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  height: auto;
+}
+
+[data-grid] {
+  display: grid;
+  gap: clamp(1rem, 3vw, 2rem);
+}
+
+[data-grid="2"] {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+}
+
+[data-grid="3"] {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  color: var(--color-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/layout-examples/assets/base.js
+++ b/layout-examples/assets/base.js
@@ -1,0 +1,209 @@
+const initNavigation = () => {
+  const toggle = document.querySelector('[data-nav-toggle]');
+  const list = document.querySelector('[data-nav-list]');
+  if (!toggle || !list) return;
+
+  const closeMenu = () => {
+    list.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-expanded', 'false');
+  };
+
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    list.setAttribute('aria-expanded', String(!expanded));
+  });
+
+  list.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeMenu();
+      toggle.focus();
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 960) {
+      closeMenu();
+    }
+  });
+};
+
+const initAccordions = (root = document) => {
+  root.querySelectorAll('[data-accordion] details').forEach((details) => {
+    details.addEventListener('toggle', () => {
+      if (details.open) {
+        root
+          .querySelectorAll('[data-accordion] details')
+          .forEach((item) => {
+            if (item !== details) item.removeAttribute('open');
+          });
+      }
+    });
+  });
+};
+
+const initTabs = (root = document) => {
+  root.querySelectorAll('[role="tablist"]').forEach((tabList) => {
+    const tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
+    const panels = tabs.map((tab) => document.getElementById(tab.getAttribute('aria-controls')));
+
+    const activateTab = (tab) => {
+      tabs.forEach((item) => {
+        const isSelected = item === tab;
+        item.setAttribute('aria-selected', String(isSelected));
+        item.tabIndex = isSelected ? 0 : -1;
+      });
+
+      panels.forEach((panel) => {
+        panel.hidden = panel.id !== tab.getAttribute('aria-controls');
+      });
+
+      tab.focus();
+    };
+
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => activateTab(tab));
+      tab.addEventListener('keydown', (event) => {
+        const index = tabs.indexOf(tab);
+        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+          event.preventDefault();
+          activateTab(tabs[(index + 1) % tabs.length]);
+        }
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+          event.preventDefault();
+          activateTab(tabs[(index - 1 + tabs.length) % tabs.length]);
+        }
+      });
+    });
+
+    const selected = tabs.find((tab) => tab.getAttribute('aria-selected') === 'true') || tabs[0];
+    activateTab(selected);
+  });
+};
+
+const initOverlayToggle = () => {
+  const triggers = document.querySelectorAll('[data-overlay-target]');
+  triggers.forEach((trigger) => {
+    const targetId = trigger.getAttribute('data-overlay-target');
+    const overlay = document.getElementById(targetId);
+    if (!overlay) return;
+
+    const closeOverlay = () => {
+      overlay.setAttribute('aria-hidden', 'true');
+      document.body.style.removeProperty('overflow');
+      trigger.focus();
+    };
+
+    trigger.addEventListener('click', () => {
+      const hidden = overlay.getAttribute('aria-hidden') === 'true';
+      overlay.setAttribute('aria-hidden', String(!hidden));
+      document.body.style.setProperty('overflow', hidden ? 'hidden' : '');
+      if (!hidden) {
+        trigger.focus();
+      } else {
+        overlay.querySelector('[data-overlay-close]')?.focus();
+      }
+    });
+
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        closeOverlay();
+      }
+    });
+
+    overlay.querySelectorAll('[data-overlay-close]').forEach((closeButton) => {
+      closeButton.addEventListener('click', closeOverlay);
+    });
+
+    overlay.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeOverlay();
+      }
+    });
+  });
+};
+
+const initDropdownButtons = () => {
+  document.querySelectorAll('[data-dropdown-button]').forEach((button) => {
+    const menu = document.getElementById(button.getAttribute('aria-controls'));
+    if (!menu) return;
+
+    const close = () => {
+      button.setAttribute('aria-expanded', 'false');
+      menu.hidden = true;
+    };
+
+    button.addEventListener('click', () => {
+      const expanded = button.getAttribute('aria-expanded') === 'true';
+      button.setAttribute('aria-expanded', String(!expanded));
+      menu.hidden = expanded;
+      if (!expanded) {
+        const firstLink = menu.querySelector('a, button, [tabindex="0"]');
+        firstLink?.focus();
+      }
+    });
+
+    button.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        const firstLink = menu.querySelector('a, button, [tabindex="0"]');
+        firstLink?.focus();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!button.contains(event.target) && !menu.contains(event.target)) {
+        close();
+      }
+    });
+
+    menu.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        close();
+        button.focus();
+      }
+    });
+
+    close();
+  });
+};
+
+const initScrollSpy = () => {
+  const spyNav = document.querySelector('[data-scrollspy]');
+  if (!spyNav) return;
+  const links = spyNav.querySelectorAll('a[href^="#"]');
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        const id = entry.target.getAttribute('id');
+        const link = spyNav.querySelector(`a[href="#${id}"]`);
+        if (link) {
+          link.setAttribute('aria-current', entry.isIntersecting ? 'true' : 'false');
+        }
+      });
+    },
+    { rootMargin: '-40% 0px -55% 0px', threshold: [0, 1] }
+  );
+
+  links.forEach((link) => {
+    const target = document.querySelector(link.getAttribute('href'));
+    if (target) {
+      observer.observe(target);
+    }
+  });
+};
+
+const initProgressiveEnhancements = () => {
+  initNavigation();
+  initAccordions();
+  initTabs();
+  initOverlayToggle();
+  initDropdownButtons();
+  initScrollSpy();
+};
+
+if (document.readyState !== 'loading') {
+  initProgressiveEnhancements();
+} else {
+  document.addEventListener('DOMContentLoaded', initProgressiveEnhancements);
+}

--- a/layout-examples/asymmetric-layout.html
+++ b/layout-examples/asymmetric-layout.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Asymmetrisches Layout</title>
+  <meta name="description" content="Asymmetrische Grid-Struktur mit dominanter Story-Spalte und begleitenden Insights." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-asymmetric {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 3rem);
+    }
+
+    @media (min-width: 56rem) {
+      #preview.layout-asymmetric {
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.8fr);
+        align-items: start;
+      }
+    }
+
+    #preview.layout-asymmetric figure {
+      position: relative;
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      isolation: isolate;
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-asymmetric figcaption {
+      position: absolute;
+      inset: auto clamp(1rem, 4vw, 2rem) clamp(1rem, 4vw, 2rem);
+      background: color-mix(in srgb, var(--color-card) 82%, transparent);
+      backdrop-filter: blur(16px);
+      border-radius: var(--radius-lg);
+      padding: clamp(0.75rem, 3vw, 1.25rem);
+      box-shadow: var(--shadow-soft);
+      max-width: min(20rem, 80%);
+    }
+
+    #preview.layout-asymmetric aside {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+    }
+
+    #preview.layout-asymmetric .insight {
+      background: var(--color-card);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border-radius: var(--radius-lg);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/asymmetric-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Editorial Layout</p>
+      <h1 class="section-title">Asymmetrisches Layout</h1>
+      <p class="prose">Ideal für Feature-Artikel oder Produktgeschichten: Die Hauptspalte nutzt großzügige Typografie, die Nebenspalte fasst Kennzahlen und Learnings zusammen.</p>
+    </section>
+
+    <section id="preview" class="layout-asymmetric" aria-labelledby="asymmetric-heading">
+      <div>
+        <h2 id="asymmetric-heading">Fallstudie: Circular Design Sprint</h2>
+        <p>
+          Ein interdisziplinäres Team entwickelte in fünf Tagen eine nachhaltige Produktvision. Das Hauptnarrativ nutzt eine
+          breite Spalte mit großzügiger Typografie und Illustrationen.
+        </p>
+        <figure>
+          <img src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1400&q=80" alt="Designteam arbeitet gemeinsam am Whiteboard" />
+          <figcaption>
+            Prototyping Tag 3: Moderierte Remote-Tests, dokumentiert via Live-Notetaking.
+          </figcaption>
+        </figure>
+        <p>
+          Die Bildunterschrift setzt auf Glas-Morphism, der sowohl in hellen als auch dunklen Themes funktioniert.
+        </p>
+      </div>
+      <aside aria-label="Insights">
+        <article class="insight">
+          <h3>Impact Kennzahlen</h3>
+          <p>+34% Conversion im Beta-Test, 92% Completion-Rate beim Onboarding.</p>
+        </article>
+        <article class="insight">
+          <h3>Team Setup</h3>
+          <p>Service Design, Research, Produkt, Engineering und Circular-Economy-Expertise.</p>
+        </article>
+        <article class="insight">
+          <h3>Lessons Learned</h3>
+          <p>Asymmetrische Layouts lenken Aufmerksamkeit und bleiben dennoch gut lesbar.</p>
+        </article>
+      </aside>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Asymmetrisches Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/blog-layout.html
+++ b/layout-examples/blog-layout.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Blog Layout</title>
+  <meta name="description" content="Klassisches Blog-Layout mit Featured-Artikel, Beitragssammlung und Sticky-Metadaten." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-blog {
+      display: grid;
+      gap: clamp(2rem, 5vw, 3rem);
+    }
+
+    #preview.layout-blog .feature {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-blog .feature figure {
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+    }
+
+    #preview.layout-blog .posts {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2rem);
+    }
+
+    @media (min-width: 62rem) {
+      #preview.layout-blog .posts {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-blog article {
+      display: grid;
+      gap: 0.75rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-blog .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1rem;
+      color: var(--color-muted);
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/blog-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Publikationslayout</p>
+      <h1 class="section-title">Blog Layout</h1>
+      <p class="prose">Die Startseite bündelt einen herausgehobenen Artikel und listet weitere Beiträge in einer flexiblen Kartenansicht.</p>
+    </section>
+
+    <section id="preview" class="layout-blog" aria-labelledby="blog-heading">
+      <div class="feature">
+        <p class="badge">Featured</p>
+        <h2 id="blog-heading">Designsysteme im Regelbetrieb</h2>
+        <div class="meta">
+          <span>12. Februar 2025</span>
+          <span>6 Min. Lesezeit</span>
+          <span>Produkt &amp; Design</span>
+        </div>
+        <figure>
+          <img src="https://images.unsplash.com/photo-1551434678-e076c223a692?auto=format&fit=crop&w=1400&q=80" alt="Laptop mit Interface-Design" />
+        </figure>
+        <p>
+          Wie Design- und Engineering-Teams kollaborative Workflows etablieren, um Komponentenbibliotheken nachhaltig zu pflegen.
+        </p>
+        <a href="#" class="badge">Weiterlesen</a>
+      </div>
+      <div class="posts" aria-label="Weitere Beiträge">
+        <article>
+          <h3>Content Ops in 8 Wochen</h3>
+          <p>Ein Erfahrungsbericht, wie strukturierte Content-Modelle Launches beschleunigen.</p>
+          <div class="meta">
+            <span>Content Strategy</span>
+            <span>4 Min.</span>
+          </div>
+        </article>
+        <article>
+          <h3>Research Backlog Priorisieren</h3>
+          <p>Frameworks, um Hypothesen datenbasiert zu bewerten und Tests zu planen.</p>
+          <div class="meta">
+            <span>User Research</span>
+            <span>7 Min.</span>
+          </div>
+        </article>
+        <article>
+          <h3>Accessible Dark Mode</h3>
+          <p>Kontraste, Farbsemantik und Motion-Guidelines für Dunkelmodus-Designs.</p>
+          <div class="meta">
+            <span>Design Systems</span>
+            <span>5 Min.</span>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Blog Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/card-layout.html
+++ b/layout-examples/card-layout.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Card Layout</title>
+  <meta name="description" content="Karten-basierte Präsentation von Inhalten mit responsiver Grid-Anordnung." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-card {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-card .cards {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    }
+
+    #preview.layout-card article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-card .card-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      font-size: 0.9rem;
+      color: var(--color-muted);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/card-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Komponentenlayout</p>
+      <h1 class="section-title">Card Layout</h1>
+      <p class="prose">Karten-basierte Präsentation von Inhalten mit responsiver Grid-Anordnung.</p>
+    </section>
+
+    <section id="preview" class="layout-card" aria-labelledby="card-heading">
+      <h2 id="card-heading">Produkt-Features</h2>
+      <div class="cards">
+        <article>
+          <h3>Collaborative Docs</h3>
+          <p>Kommentieren, Versionieren und Zuständigkeiten direkt im Dokument verwalten.</p>
+          <div class="card-footer">
+            <span>Beta</span>
+            <a href="#">Mehr erfahren</a>
+          </div>
+        </article>
+        <article>
+          <h3>Automationen</h3>
+          <p>Arbeitsabläufe mit No-Code-Regeln automatisieren und Statusänderungen melden.</p>
+          <div class="card-footer">
+            <span>Stabil</span>
+            <a href="#">Mehr erfahren</a>
+          </div>
+        </article>
+        <article>
+          <h3>Insights Dashboard</h3>
+          <p>KPIs in Echtzeit verfolgen und mit Stakeholdern teilen.</p>
+          <div class="card-footer">
+            <span>Neu</span>
+            <a href="#">Mehr erfahren</a>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Card Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/centered-content.html
+++ b/layout-examples/centered-content.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Centered Content</title>
+  <meta name="description" content="Maximale Lesbarkeit durch zentrierte Inhaltsbreite und großzügige Weißräume." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-centered {
+      display: grid;
+      justify-items: center;
+      text-align: center;
+      gap: clamp(1.5rem, 5vw, 2.5rem);
+    }
+
+    #preview.layout-centered .prose {
+      max-width: clamp(42ch, 68ch, 74ch);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/centered-content.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Leselayout</p>
+      <h1 class="section-title">Centered Content</h1>
+      <p class="prose">Maximale Lesbarkeit durch zentrierte Inhaltsbreite und großzügige Weißräume.</p>
+    </section>
+
+    <section id="preview" class="layout-centered" aria-labelledby="centered-heading">
+      <h2 id="centered-heading">Mission Statement</h2>
+      <p class="prose">
+        Wir entwerfen digitale Produkte, die komplexe Abläufe in einfache Routinen verwandeln. Fokus, Klarheit und Empathie
+        sind die Basis für jedes Erlebnis.
+      </p>
+      <div class="cards" role="list" aria-label="Schwerpunkte">
+        <div class="badge" role="listitem">Research driven</div>
+        <div class="badge" role="listitem">Accessible by default</div>
+        <div class="badge" role="listitem">Continuous Discovery</div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Centered Content</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/chat-interface.html
+++ b/layout-examples/chat-interface.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Chat Interface</title>
+  <meta name="description" content="Conversational UI mit Nachrichtenspuren, Composer und Präsenzinformationen." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-chat {
+      display: grid;
+      gap: clamp(1.25rem, 4vw, 2rem);
+      background: var(--color-card);
+      padding: clamp(1.25rem, 4vw, 2rem);
+      border-radius: var(--radius-lg);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-chat .conversation {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-chat .bubble {
+      max-width: min(80%, 32ch);
+      padding: 0.75rem 1rem;
+      border-radius: 1.25rem;
+      position: relative;
+      line-height: 1.45;
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-chat .bubble[data-variant="sent"] {
+      justify-self: end;
+      background: var(--color-primary);
+      color: var(--color-primary-contrast);
+    }
+
+    #preview.layout-chat .bubble[data-variant="received"] {
+      justify-self: start;
+      background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+      color: var(--color-text);
+    }
+
+    #preview.layout-chat .composer {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      border-radius: 999px;
+      padding: 0.75rem 1rem;
+      background: var(--color-bg);
+    }
+
+    #preview.layout-chat input[type="text"] {
+      flex: 1;
+      border: 0;
+      background: transparent;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/chat-interface.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Realtime Layout</p>
+      <h1 class="section-title">Chat Interface</h1>
+      <p class="prose">Das Layout demonstriert ein mobiles Messaging-Interface inklusive Schreibstatus und Reaktionsmöglichkeiten.</p>
+    </section>
+
+    <section id="preview" class="layout-chat" aria-labelledby="chat-heading">
+      <header aria-live="polite">Team Space · <span class="badge">3 online</span></header>
+      <div class="conversation" role="log" aria-live="polite">
+        <p class="bubble" data-variant="received">
+          Hey! Ich teile gleich das neue Dashboard-Konzept. Fokus auf Informationshierarchie.
+        </p>
+        <p class="bubble" data-variant="sent">
+          Super, ich habe direkt Feedback aus dem Research-Playback dabei.
+        </p>
+        <p class="bubble" data-variant="received">
+          Perfekt. Lass uns auf Kontraste achten – wir hatten Hinweise von Screenreader-Usern.
+        </p>
+      </div>
+      <form class="composer" aria-label="Nachricht senden">
+        <label for="chat-message" class="sr-only">Nachricht</label>
+        <input id="chat-message" type="text" name="message" placeholder="Antwort verfassen…" required />
+        <button type="submit">Senden</button>
+      </form>
+      <p aria-live="polite">Lisa tippt …</p>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Chat Interface</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+  <script>
+const form = document.querySelector('.composer');
+    form?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const input = form.querySelector('input');
+      if (!input?.value.trim()) return;
+      const conversation = form.previousElementSibling;
+      const bubble = document.createElement('p');
+      bubble.className = 'bubble';
+      bubble.dataset.variant = 'sent';
+      bubble.textContent = input.value;
+      conversation.appendChild(bubble);
+      bubble.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      input.value = '';
+    });
+  </script>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/cover-page.html
+++ b/layout-examples/cover-page.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Cover Page</title>
+  <meta name="description" content="Hero-Cover mit großflächigem Visual, Kernbotschaft und Call-to-Action." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-cover {
+      position: relative;
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      padding: clamp(3rem, 8vw, 6rem);
+      color: var(--color-primary-contrast);
+      display: grid;
+      gap: clamp(1rem, 4vw, 2rem);
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.8), rgba(76, 29, 149, 0.8));
+    }
+
+    #preview.layout-cover::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1600&q=80') center/cover;
+      opacity: 0.35;
+      mix-blend-mode: screen;
+      pointer-events: none;
+    }
+
+    #preview.layout-cover > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    #preview.layout-cover .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    #preview.layout-cover a {
+      padding: 0.85rem 1.75rem;
+      border-radius: 999px;
+      background: var(--color-primary-contrast);
+      color: var(--color-primary);
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/cover-page.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Hero Layout</p>
+      <h1 class="section-title">Cover Page</h1>
+      <p class="prose">Hero-Cover mit großflächigem Visual, Kernbotschaft und Call-to-Action.</p>
+    </section>
+
+    <section id="preview" class="layout-cover" aria-labelledby="cover-heading">
+      <p class="badge">New Release</p>
+      <h2 id="cover-heading">Experience Design Summit 2025</h2>
+      <p>
+        Drei Tage voller Keynotes, Masterclasses und Clinics rund um nachhaltige digitale Produkte.
+      </p>
+      <div class="actions">
+        <a href="#">Ticket sichern</a>
+        <a href="#" aria-label="Agenda herunterladen">Agenda (PDF)</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Cover Page</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/dashboard-layout.html
+++ b/layout-examples/dashboard-layout.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Dashboard Layout</title>
+  <meta name="description" content="Analytics-Dashboard mit Kacheln, Chart-Gitter und responsiven Panels." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-dashboard {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-dashboard .kpi-grid {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.5rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+    }
+
+    #preview.layout-dashboard .panel {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 3vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-dashboard .grid-visuals {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.5rem);
+    }
+
+    @media (min-width: 70rem) {
+      #preview.layout-dashboard .grid-visuals {
+        grid-template-columns: 2fr 1fr;
+      }
+    }
+
+    #preview.layout-dashboard svg {
+      width: 100%;
+      height: auto;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/dashboard-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Data Layout</p>
+      <h1 class="section-title">Dashboard Layout</h1>
+      <p class="prose">Ein flexibles Grid kombiniert Kennzahlen, Diagramme und Listen für die tägliche Steuerung.</p>
+    </section>
+
+    <section id="preview" class="layout-dashboard" aria-labelledby="dashboard-heading">
+      <h2 id="dashboard-heading">Team Performance</h2>
+      <div class="kpi-grid">
+        <article class="panel">
+          <h3>MRR</h3>
+          <p class="section-title" style="margin:0">€ 128.400</p>
+          <p class="badge">+12% MoM</p>
+        </article>
+        <article class="panel">
+          <h3>Aktive Accounts</h3>
+          <p class="section-title" style="margin:0">4.829</p>
+          <p class="badge">Retention 93%</p>
+        </article>
+        <article class="panel">
+          <h3>NPS</h3>
+          <p class="section-title" style="margin:0">48</p>
+          <p class="badge">+6 Punkte</p>
+        </article>
+      </div>
+      <div class="grid-visuals">
+        <article class="panel" aria-label="Umsatzentwicklung">
+          <h3>Revenue Trend</h3>
+          <svg viewBox="0 0 240 120" role="img" aria-labelledby="revenue-chart">
+            <title id="revenue-chart">Line Chart der letzten 6 Monate</title>
+            <polyline fill="none" stroke="currentColor" stroke-width="4" points="0,90 40,80 80,65 120,70 160,50 200,35 240,45"></polyline>
+          </svg>
+        </article>
+        <article class="panel">
+          <h3>Aktuelle Aufgaben</h3>
+          <ul>
+            <li>Discovery Call vorbereiten</li>
+            <li>Feedbackrunde Alpha 2</li>
+            <li>Design QA Sprint 14</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Dashboard Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/ecommerce-product-grid.html
+++ b/layout-examples/ecommerce-product-grid.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – E-Commerce Produktgrid</title>
+  <meta name="description" content="Produktübersicht mit Filterleiste, adaptivem Grid und Fokus auf Conversion." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-shop {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-shop .filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-shop .filters button {
+      border-radius: 999px;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      padding: 0.5rem 1.25rem;
+      background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+    }
+
+    #preview.layout-shop .products {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
+    }
+
+    #preview.layout-shop article {
+      display: grid;
+      gap: 0.75rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-shop img {
+      border-radius: var(--radius-lg);
+    }
+
+    #preview.layout-shop .price {
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/ecommerce-product-grid.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Commerce Layout</p>
+      <h1 class="section-title">E-Commerce Produktgrid</h1>
+      <p class="prose">Produktübersicht mit Filterleiste, adaptivem Grid und Fokus auf Conversion.</p>
+    </section>
+
+    <section id="preview" class="layout-shop" aria-labelledby="shop-heading">
+      <header>
+        <h2 id="shop-heading">Designer Essentials</h2>
+        <div class="filters" role="list">
+          <button type="button">Neu</button>
+          <button type="button">Beliebt</button>
+          <button type="button">Unter €50</button>
+          <button type="button">Nachhaltig</button>
+        </div>
+      </header>
+      <div class="products">
+        <article>
+          <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=800&q=80" alt="Notizbuch aus recyceltem Papier" />
+          <h3>Notizbuch Re:think</h3>
+          <p class="price">€ 32</p>
+        </article>
+        <article>
+          <img src="https://images.unsplash.com/photo-1559050019-31e2a4f0b77b?auto=format&fit=crop&w=800&q=80" alt="Minimalistische Trinkflasche" />
+          <h3>Hydrate Bottle</h3>
+          <p class="price">€ 26</p>
+        </article>
+        <article>
+          <img src="https://images.unsplash.com/photo-1505740420928-5e560c06d30e?auto=format&fit=crop&w=800&q=80" alt="Kabellose Kopfhörer" />
+          <h3>Focus Headphones</h3>
+          <p class="price">€ 189</p>
+        </article>
+        <article>
+          <img src="https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=800&q=80" alt="Ergonomische Lampe" />
+          <h3>Glow Desk Lamp</h3>
+          <p class="price">€ 119</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · E-Commerce Produktgrid</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/fixed-footer.html
+++ b/layout-examples/fixed-footer.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Fixed Footer</title>
+  <meta name="description" content="Layout mit fixiertem Footer für permanente Aktionen." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-fixed-footer {
+      min-height: 18rem;
+      padding-bottom: 4rem;
+      position: relative;
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-fixed-footer footer {
+      position: sticky;
+      bottom: 0;
+      border-radius: var(--radius-lg);
+      background: var(--color-card);
+      padding: 1rem 1.5rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-hard);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/deprecated/fixed-footer.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Deprecated</p>
+      <h1 class="section-title">Fixed Footer</h1>
+      <p class="prose">Layout mit fixiertem Footer für permanente Aktionen.</p>
+    </section>
+
+    <section id="preview" class="layout-fixed-footer" aria-labelledby="fixed-footer-heading">
+      <h2 id="fixed-footer-heading">Fixierter Footer</h2>
+      <p>Wird auf kleinen Screens oft als störend wahrgenommen, daher obsolet.</p>
+      <footer>
+        <button type="button">Jetzt kaufen</button>
+      </footer>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Fixed Footer</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/full-height-layout.html
+++ b/layout-examples/full-height-layout.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Full Height Layout</title>
+  <meta name="description" content="Layout mit 100vh-Abschnitten, Sticky-CTA und Scroll-Indikatoren." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-full-height {
+      display: grid;
+      gap: clamp(2rem, 6vw, 3.5rem);
+    }
+
+    #preview.layout-full-height section {
+      min-height: min(75vh, 42rem);
+      border-radius: var(--radius-lg);
+      padding: clamp(2rem, 5vw, 4rem);
+      background: var(--color-card);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-full-height .scroll-indicator {
+      justify-self: center;
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--color-muted);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/full-height-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Viewport Layout</p>
+      <h1 class="section-title">Full Height Layout</h1>
+      <p class="prose">Layout mit 100vh-Abschnitten, Sticky-CTA und Scroll-Indikatoren.</p>
+    </section>
+
+    <div id="preview" class="layout-full-height" aria-labelledby="fullheight-heading">
+      <section aria-labelledby="fullheight-heading">
+        <h2 id="fullheight-heading">Kick-off Sprint</h2>
+        <p>Einführung, Erwartungsabgleich und Roadmap-Überblick.</p>
+        <a class="badge" href="#">Agenda öffnen</a>
+      </section>
+      <p class="scroll-indicator" aria-hidden="true">⬇︎ Scroll</p>
+      <section>
+        <h3>Discovery Workshop</h3>
+        <p>Hypothesen, Personas und Journey Mapping kollaborativ erarbeiten.</p>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Full Height Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/full-width-hero.html
+++ b/layout-examples/full-width-hero.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Full Width Hero</title>
+  <meta name="description" content="Hero-Sektion über die gesamte Breite mit Medien und CTA." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-hero {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 58rem) {
+      #preview.layout-hero {
+        grid-template-columns: 1.1fr 1fr;
+        align-items: center;
+      }
+    }
+
+    #preview.layout-hero .media {
+      position: relative;
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--shadow-hard);
+    }
+
+    #preview.layout-hero .media img {
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+    }
+
+    #preview.layout-hero .media::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.25));
+    }
+
+    #preview.layout-hero .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/full-width-hero.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Hero Layout</p>
+      <h1 class="section-title">Full Width Hero</h1>
+      <p class="prose">Hero-Sektion über die gesamte Breite mit Medien und CTA.</p>
+    </section>
+
+    <section id="preview" class="layout-hero" aria-labelledby="hero-heading">
+      <div>
+        <h2 id="hero-heading">Produktivitätsplattform für hybride Teams</h2>
+        <p>
+          Verbinden Sie Wissensmanagement, Projekte und Kommunikation in einem zentralen Workspace.
+        </p>
+        <div class="actions">
+          <a class="badge" href="#">Kostenlos testen</a>
+          <a href="#">Video ansehen</a>
+        </div>
+      </div>
+      <figure class="media">
+        <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1400&q=80" alt="Team arbeitet gemeinsam am Laptop" />
+      </figure>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Full Width Hero</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/fullscreen-layout.html
+++ b/layout-examples/fullscreen-layout.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Fullscreen Layout</title>
+  <meta name="description" content="Abschnitte im Vollbild, die per Scroll oder Pfeiltasten gewechselt werden." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-fullscreen {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-fullscreen section {
+      min-height: min(85vh, 48rem);
+      border-radius: var(--radius-lg);
+      padding: clamp(2rem, 5vw, 4rem);
+      background: var(--color-card);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      align-content: center;
+      gap: 1.5rem;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/fullscreen-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Immersives Layout</p>
+      <h1 class="section-title">Fullscreen Layout</h1>
+      <p class="prose">Abschnitte im Vollbild, die per Scroll oder Pfeiltasten gewechselt werden.</p>
+    </section>
+
+    <div id="preview" class="layout-fullscreen" aria-labelledby="fullscreen-heading">
+      <section>
+        <h2 id="fullscreen-heading">Willkommen</h2>
+        <p>Scrollen Sie für Highlights des Produktes. Jede Sektion füllt nahezu das gesamte Viewport.</p>
+      </section>
+      <section>
+        <h3>Schneller Einstieg</h3>
+        <p>Interaktive Touren, Onboarding-Checklisten und Guided Tasks helfen bei der Adoption.</p>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Fullscreen Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/gallery-layout.html
+++ b/layout-examples/gallery-layout.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Gallery Layout</title>
+  <meta name="description" content="Responsive Galerie mit adaptiven Spalten und Lightbox-Triggern." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-gallery {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+    }
+
+    #preview.layout-gallery ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: clamp(0.75rem, 2vw, 1.5rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
+    }
+
+    #preview.layout-gallery li {
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-gallery img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/gallery-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Visual Layout</p>
+      <h1 class="section-title">Gallery Layout</h1>
+      <p class="prose">Responsive Galerie mit adaptiven Spalten und Lightbox-Triggern.</p>
+    </section>
+
+    <section id="preview" class="layout-gallery" aria-labelledby="gallery-heading">
+      <h2 id="gallery-heading">Moodboard</h2>
+      <ul>
+        <li><img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=800&q=80" alt="Lichtdurchflutetes Büro" /></li>
+        <li><img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=800&q=80" alt="Moodboard mit Materialien" /></li>
+        <li><img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80" alt="Workshop Szene" /></li>
+        <li><img src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=800&q=80" alt="Person arbeitet auf Tablet" /></li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Gallery Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/generate_pages.py
+++ b/layout-examples/generate_pages.py
@@ -1,0 +1,2365 @@
+"""Generate layout example pages from descriptors."""
+from __future__ import annotations
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = BASE_DIR.parent
+
+BASE_TEMPLATE = """<!DOCTYPE html>
+<html lang=\"de\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>Layout Beispiel – {title}</title>
+  <meta name=\"description\" content=\"{description}\" />
+  <link rel=\"preconnect\" href=\"https://fonts.googleapis.com\" />
+  <link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin />
+  <link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap\" rel=\"stylesheet\" />
+  <link rel=\"stylesheet\" href=\"assets/base.css\" />
+{style_block}
+</head>
+<body>
+  <a class=\"skip-link\" href=\"#main\">Zum Inhalt springen</a>
+  <header class=\"site-header\" role=\"banner\">
+    <nav class=\"site-nav\" aria-label=\"Hauptnavigation\">
+      <a class=\"site-header__brand\" href=\"#\">
+        <span class=\"site-header__logo\" aria-hidden=\"true\">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class=\"site-nav__toggle\" type=\"button\" data-nav-toggle aria-expanded=\"false\">
+        <svg aria-hidden=\"true\" viewBox=\"0 0 24 24\" fill=\"none\">
+          <path stroke=\"currentColor\" stroke-width=\"1.6\" stroke-linecap=\"round\" d=\"M4 6h16M4 12h16M4 18h16\" />
+        </svg>
+        Menü
+      </button>
+      <ul class=\"site-nav__links\" data-nav-list aria-expanded=\"false\">
+        <li><a href=\"{markdown_link}\">Markdown</a></li>
+        <li><a href=\"index.html\">Übersicht</a></li>
+        <li><a href=\"#preview\">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id=\"main\" class=\"content-width layout-page\" tabindex=\"-1\">
+    <section class=\"layout-intro\">
+      <p class=\"badge\">{badge}</p>
+      <h1 class=\"section-title\">{title}</h1>
+      <p class=\"prose\">{intro}</p>
+    </section>
+{main}
+  </main>
+
+  <footer class=\"site-footer site-header\" role=\"contentinfo\">
+    <div class=\"site-nav\">
+      <p>&copy; <span id=\"year\">2025</span> Randnotizen · {title}</p>
+      <a href=\"#main\">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src=\"assets/base.js\"></script>
+{script_block}
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>
+"""
+
+STYLE_TEMPLATE = "  <style>\n{styles}\n  </style>"
+SCRIPT_TEMPLATE = "  <script>\n{script}\n  </script>"
+
+LAYOUTS: dict[str, dict[str, str]] = {
+    "accordion-layout": {
+        "title": "Accordion Layout",
+        "description": "Mobile-First FAQ Muster mit semantischen Details-Elementen und progressiver Offenlegung.",
+        "intro": (
+            "Dieses Muster eignet sich für umfangreiche FAQ oder Richtlinien. Es nutzt native Details-Elemente, "
+            "deaktiviert parallele Öffnungen und bleibt komplett tastaturbedienbar."
+        ),
+        "badge": "Interaktives Layout",
+        "markdown_link": "../layouts/relevant/accordion-layout.md",
+        "styles": """
+    #preview.layout-accordion {
+      display: grid;
+      gap: clamp(1.25rem, 4vw, 2rem);
+    }
+
+    #preview.layout-accordion details {
+      border-radius: var(--radius-lg);
+      background: var(--color-card);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    #preview.layout-accordion details[open] {
+      border-color: color-mix(in srgb, var(--color-primary) 55%, var(--color-border));
+      box-shadow: var(--shadow-hard);
+    }
+
+    #preview.layout-accordion summary {
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      padding: clamp(1rem, 3vw, 1.5rem) clamp(1rem, 3vw, 1.75rem);
+      font-weight: 600;
+    }
+
+    #preview.layout-accordion summary::-webkit-details-marker {
+      display: none;
+    }
+
+    #preview.layout-accordion .summary-icon {
+      inline-size: 1.5rem;
+      block-size: 1.5rem;
+      border-radius: 999px;
+      display: grid;
+      place-items: center;
+      background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+      color: var(--color-primary);
+      transition: transform 0.3s ease, background 0.3s ease, color 0.3s ease;
+    }
+
+    #preview.layout-accordion details[open] .summary-icon {
+      transform: rotate(45deg);
+      background: var(--color-primary);
+      color: var(--color-primary-contrast);
+    }
+
+    #preview.layout-accordion details p {
+      padding: 0 clamp(1.25rem, 4vw, 2rem) clamp(1.25rem, 4vw, 2rem);
+      color: var(--color-muted);
+      margin: 0;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-accordion\" data-accordion aria-labelledby=\"accordion-heading\">
+      <h2 id=\"accordion-heading\" class=\"sr-only\">Akkordeon Beispiel</h2>
+      <details open>
+        <summary>
+          <span>Wie stelle ich Barrierefreiheit sicher?</span>
+          <span class=\"summary-icon\" aria-hidden=\"true\">+</span>
+        </summary>
+        <p>
+          Verwenden Sie native HTML-Elemente, definieren Sie logische Überschriften und stellen Sie sicher, dass jeweils nur
+          eine Sektion geöffnet ist. Fokuszustände werden automatisch berücksichtigt.
+        </p>
+      </details>
+      <details>
+        <summary>
+          <span>Welche Inhalte eignen sich?</span>
+          <span class=\"summary-icon\" aria-hidden=\"true\">+</span>
+        </summary>
+        <p>
+          Richtlinien, Support-Fragen oder Tutorial-Schritte lassen sich modular strukturieren. Jede Einheit bleibt unabhängig
+          adressierbar.
+        </p>
+      </details>
+      <details>
+        <summary>
+          <span>Wie skaliert das Layout?</span>
+          <span class=\"summary-icon\" aria-hidden=\"true\">+</span>
+        </summary>
+        <p>
+          Mobile-First vollbreit, ab größeren Viewports sorgt <code>clamp()</code> für eine maximale Breite von 72ch und
+          großzügige Weißräume.
+        </p>
+      </details>
+    </section>
+        """,
+    },
+    "asymmetric-layout": {
+        "title": "Asymmetrisches Layout",
+        "description": "Asymmetrische Grid-Struktur mit dominanter Story-Spalte und begleitenden Insights.",
+        "intro": (
+            "Ideal für Feature-Artikel oder Produktgeschichten: Die Hauptspalte nutzt großzügige Typografie, die Nebenspalte "
+            "fasst Kennzahlen und Learnings zusammen."
+        ),
+        "badge": "Editorial Layout",
+        "markdown_link": "../layouts/relevant/asymmetric-layout.md",
+        "styles": """
+    #preview.layout-asymmetric {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 3rem);
+    }
+
+    @media (min-width: 56rem) {
+      #preview.layout-asymmetric {
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.8fr);
+        align-items: start;
+      }
+    }
+
+    #preview.layout-asymmetric figure {
+      position: relative;
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      isolation: isolate;
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-asymmetric figcaption {
+      position: absolute;
+      inset: auto clamp(1rem, 4vw, 2rem) clamp(1rem, 4vw, 2rem);
+      background: color-mix(in srgb, var(--color-card) 82%, transparent);
+      backdrop-filter: blur(16px);
+      border-radius: var(--radius-lg);
+      padding: clamp(0.75rem, 3vw, 1.25rem);
+      box-shadow: var(--shadow-soft);
+      max-width: min(20rem, 80%);
+    }
+
+    #preview.layout-asymmetric aside {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+    }
+
+    #preview.layout-asymmetric .insight {
+      background: var(--color-card);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border-radius: var(--radius-lg);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-asymmetric\" aria-labelledby=\"asymmetric-heading\">
+      <div>
+        <h2 id=\"asymmetric-heading\">Fallstudie: Circular Design Sprint</h2>
+        <p>
+          Ein interdisziplinäres Team entwickelte in fünf Tagen eine nachhaltige Produktvision. Das Hauptnarrativ nutzt eine
+          breite Spalte mit großzügiger Typografie und Illustrationen.
+        </p>
+        <figure>
+          <img src=\"https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1400&q=80\" alt=\"Designteam arbeitet gemeinsam am Whiteboard\" />
+          <figcaption>
+            Prototyping Tag 3: Moderierte Remote-Tests, dokumentiert via Live-Notetaking.
+          </figcaption>
+        </figure>
+        <p>
+          Die Bildunterschrift setzt auf Glas-Morphism, der sowohl in hellen als auch dunklen Themes funktioniert.
+        </p>
+      </div>
+      <aside aria-label=\"Insights\">
+        <article class=\"insight\">
+          <h3>Impact Kennzahlen</h3>
+          <p>+34% Conversion im Beta-Test, 92% Completion-Rate beim Onboarding.</p>
+        </article>
+        <article class=\"insight\">
+          <h3>Team Setup</h3>
+          <p>Service Design, Research, Produkt, Engineering und Circular-Economy-Expertise.</p>
+        </article>
+        <article class=\"insight\">
+          <h3>Lessons Learned</h3>
+          <p>Asymmetrische Layouts lenken Aufmerksamkeit und bleiben dennoch gut lesbar.</p>
+        </article>
+      </aside>
+    </section>
+        """,
+    },
+    "blog-layout": {
+        "title": "Blog Layout",
+        "description": "Klassisches Blog-Layout mit Featured-Artikel, Beitragssammlung und Sticky-Metadaten.",
+        "intro": (
+            "Die Startseite bündelt einen herausgehobenen Artikel und listet weitere Beiträge in einer flexiblen Kartenansicht."
+        ),
+        "badge": "Publikationslayout",
+        "markdown_link": "../layouts/relevant/blog-layout.md",
+        "styles": """
+    #preview.layout-blog {
+      display: grid;
+      gap: clamp(2rem, 5vw, 3rem);
+    }
+
+    #preview.layout-blog .feature {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-blog .feature figure {
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+    }
+
+    #preview.layout-blog .posts {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2rem);
+    }
+
+    @media (min-width: 62rem) {
+      #preview.layout-blog .posts {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-blog article {
+      display: grid;
+      gap: 0.75rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-blog .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1rem;
+      color: var(--color-muted);
+      font-size: 0.9rem;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-blog\" aria-labelledby=\"blog-heading\">
+      <div class=\"feature\">
+        <p class=\"badge\">Featured</p>
+        <h2 id=\"blog-heading\">Designsysteme im Regelbetrieb</h2>
+        <div class=\"meta\">
+          <span>12. Februar 2025</span>
+          <span>6 Min. Lesezeit</span>
+          <span>Produkt &amp; Design</span>
+        </div>
+        <figure>
+          <img src=\"https://images.unsplash.com/photo-1551434678-e076c223a692?auto=format&fit=crop&w=1400&q=80\" alt=\"Laptop mit Interface-Design\" />
+        </figure>
+        <p>
+          Wie Design- und Engineering-Teams kollaborative Workflows etablieren, um Komponentenbibliotheken nachhaltig zu pflegen.
+        </p>
+        <a href=\"#\" class=\"badge\">Weiterlesen</a>
+      </div>
+      <div class=\"posts\" aria-label=\"Weitere Beiträge\">
+        <article>
+          <h3>Content Ops in 8 Wochen</h3>
+          <p>Ein Erfahrungsbericht, wie strukturierte Content-Modelle Launches beschleunigen.</p>
+          <div class=\"meta\">
+            <span>Content Strategy</span>
+            <span>4 Min.</span>
+          </div>
+        </article>
+        <article>
+          <h3>Research Backlog Priorisieren</h3>
+          <p>Frameworks, um Hypothesen datenbasiert zu bewerten und Tests zu planen.</p>
+          <div class=\"meta\">
+            <span>User Research</span>
+            <span>7 Min.</span>
+          </div>
+        </article>
+        <article>
+          <h3>Accessible Dark Mode</h3>
+          <p>Kontraste, Farbsemantik und Motion-Guidelines für Dunkelmodus-Designs.</p>
+          <div class=\"meta\">
+            <span>Design Systems</span>
+            <span>5 Min.</span>
+          </div>
+        </article>
+      </div>
+    </section>
+        """,
+    },
+    "card-layout": {
+        "title": "Card Layout",
+        "description": "Karten-basierte Präsentation von Inhalten mit responsiver Grid-Anordnung.",
+        "badge": "Komponentenlayout",
+        "markdown_link": "../layouts/relevant/card-layout.md",
+        "styles": """
+    #preview.layout-card {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-card .cards {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    }
+
+    #preview.layout-card article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-card .card-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      font-size: 0.9rem;
+      color: var(--color-muted);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-card\" aria-labelledby=\"card-heading\">
+      <h2 id=\"card-heading\">Produkt-Features</h2>
+      <div class=\"cards\">
+        <article>
+          <h3>Collaborative Docs</h3>
+          <p>Kommentieren, Versionieren und Zuständigkeiten direkt im Dokument verwalten.</p>
+          <div class=\"card-footer\">
+            <span>Beta</span>
+            <a href=\"#\">Mehr erfahren</a>
+          </div>
+        </article>
+        <article>
+          <h3>Automationen</h3>
+          <p>Arbeitsabläufe mit No-Code-Regeln automatisieren und Statusänderungen melden.</p>
+          <div class=\"card-footer\">
+            <span>Stabil</span>
+            <a href=\"#\">Mehr erfahren</a>
+          </div>
+        </article>
+        <article>
+          <h3>Insights Dashboard</h3>
+          <p>KPIs in Echtzeit verfolgen und mit Stakeholdern teilen.</p>
+          <div class=\"card-footer\">
+            <span>Neu</span>
+            <a href=\"#\">Mehr erfahren</a>
+          </div>
+        </article>
+      </div>
+    </section>
+        """,
+    },
+    "centered-content": {
+        "title": "Centered Content",
+        "description": "Maximale Lesbarkeit durch zentrierte Inhaltsbreite und großzügige Weißräume.",
+        "badge": "Leselayout",
+        "markdown_link": "../layouts/relevant/centered-content.md",
+        "styles": """
+    #preview.layout-centered {
+      display: grid;
+      justify-items: center;
+      text-align: center;
+      gap: clamp(1.5rem, 5vw, 2.5rem);
+    }
+
+    #preview.layout-centered .prose {
+      max-width: clamp(42ch, 68ch, 74ch);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-centered\" aria-labelledby=\"centered-heading\">
+      <h2 id=\"centered-heading\">Mission Statement</h2>
+      <p class=\"prose\">
+        Wir entwerfen digitale Produkte, die komplexe Abläufe in einfache Routinen verwandeln. Fokus, Klarheit und Empathie
+        sind die Basis für jedes Erlebnis.
+      </p>
+      <div class=\"cards\" role=\"list\" aria-label=\"Schwerpunkte\">
+        <div class=\"badge\" role=\"listitem\">Research driven</div>
+        <div class=\"badge\" role=\"listitem\">Accessible by default</div>
+        <div class=\"badge\" role=\"listitem\">Continuous Discovery</div>
+      </div>
+    </section>
+        """,
+    },
+    "chat-interface": {
+        "title": "Chat Interface",
+        "description": "Conversational UI mit Nachrichtenspuren, Composer und Präsenzinformationen.",
+        "intro": "Das Layout demonstriert ein mobiles Messaging-Interface inklusive Schreibstatus und Reaktionsmöglichkeiten.",
+        "badge": "Realtime Layout",
+        "markdown_link": "../layouts/relevant/chat-interface.md",
+        "styles": """
+    #preview.layout-chat {
+      display: grid;
+      gap: clamp(1.25rem, 4vw, 2rem);
+      background: var(--color-card);
+      padding: clamp(1.25rem, 4vw, 2rem);
+      border-radius: var(--radius-lg);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-chat .conversation {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-chat .bubble {
+      max-width: min(80%, 32ch);
+      padding: 0.75rem 1rem;
+      border-radius: 1.25rem;
+      position: relative;
+      line-height: 1.45;
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-chat .bubble[data-variant="sent"] {
+      justify-self: end;
+      background: var(--color-primary);
+      color: var(--color-primary-contrast);
+    }
+
+    #preview.layout-chat .bubble[data-variant="received"] {
+      justify-self: start;
+      background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+      color: var(--color-text);
+    }
+
+    #preview.layout-chat .composer {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      border-radius: 999px;
+      padding: 0.75rem 1rem;
+      background: var(--color-bg);
+    }
+
+    #preview.layout-chat input[type="text"] {
+      flex: 1;
+      border: 0;
+      background: transparent;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-chat\" aria-labelledby=\"chat-heading\">
+      <header aria-live=\"polite\">Team Space · <span class=\"badge\">3 online</span></header>
+      <div class=\"conversation\" role=\"log\" aria-live=\"polite\">
+        <p class=\"bubble\" data-variant=\"received\">
+          Hey! Ich teile gleich das neue Dashboard-Konzept. Fokus auf Informationshierarchie.
+        </p>
+        <p class=\"bubble\" data-variant=\"sent\">
+          Super, ich habe direkt Feedback aus dem Research-Playback dabei.
+        </p>
+        <p class=\"bubble\" data-variant=\"received\">
+          Perfekt. Lass uns auf Kontraste achten – wir hatten Hinweise von Screenreader-Usern.
+        </p>
+      </div>
+      <form class=\"composer\" aria-label=\"Nachricht senden\">
+        <label for=\"chat-message\" class=\"sr-only\">Nachricht</label>
+        <input id=\"chat-message\" type=\"text\" name=\"message\" placeholder=\"Antwort verfassen…\" required />
+        <button type=\"submit\">Senden</button>
+      </form>
+      <p aria-live=\"polite\">Lisa tippt …</p>
+    </section>
+        """,
+        "script": """
+    const form = document.querySelector('.composer');
+    form?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const input = form.querySelector('input');
+      if (!input?.value.trim()) return;
+      const conversation = form.previousElementSibling;
+      const bubble = document.createElement('p');
+      bubble.className = 'bubble';
+      bubble.dataset.variant = 'sent';
+      bubble.textContent = input.value;
+      conversation.appendChild(bubble);
+      bubble.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      input.value = '';
+    });
+        """,
+    },
+    "cover-page": {
+        "title": "Cover Page",
+        "description": "Hero-Cover mit großflächigem Visual, Kernbotschaft und Call-to-Action.",
+        "badge": "Hero Layout",
+        "markdown_link": "../layouts/relevant/cover-page.md",
+        "styles": """
+    #preview.layout-cover {
+      position: relative;
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      padding: clamp(3rem, 8vw, 6rem);
+      color: var(--color-primary-contrast);
+      display: grid;
+      gap: clamp(1rem, 4vw, 2rem);
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.8), rgba(76, 29, 149, 0.8));
+    }
+
+    #preview.layout-cover::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1600&q=80') center/cover;
+      opacity: 0.35;
+      mix-blend-mode: screen;
+      pointer-events: none;
+    }
+
+    #preview.layout-cover > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    #preview.layout-cover .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    #preview.layout-cover a {
+      padding: 0.85rem 1.75rem;
+      border-radius: 999px;
+      background: var(--color-primary-contrast);
+      color: var(--color-primary);
+      font-weight: 600;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-cover\" aria-labelledby=\"cover-heading\">
+      <p class=\"badge\">New Release</p>
+      <h2 id=\"cover-heading\">Experience Design Summit 2025</h2>
+      <p>
+        Drei Tage voller Keynotes, Masterclasses und Clinics rund um nachhaltige digitale Produkte.
+      </p>
+      <div class=\"actions\">
+        <a href=\"#\">Ticket sichern</a>
+        <a href=\"#\" aria-label=\"Agenda herunterladen\">Agenda (PDF)</a>
+      </div>
+    </section>
+        """,
+    },
+    "dashboard-layout": {
+        "title": "Dashboard Layout",
+        "description": "Analytics-Dashboard mit Kacheln, Chart-Gitter und responsiven Panels.",
+        "intro": "Ein flexibles Grid kombiniert Kennzahlen, Diagramme und Listen für die tägliche Steuerung.",
+        "badge": "Data Layout",
+        "markdown_link": "../layouts/relevant/dashboard-layout.md",
+        "styles": """
+    #preview.layout-dashboard {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-dashboard .kpi-grid {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.5rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+    }
+
+    #preview.layout-dashboard .panel {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 3vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-dashboard .grid-visuals {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.5rem);
+    }
+
+    @media (min-width: 70rem) {
+      #preview.layout-dashboard .grid-visuals {
+        grid-template-columns: 2fr 1fr;
+      }
+    }
+
+    #preview.layout-dashboard svg {
+      width: 100%;
+      height: auto;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-dashboard\" aria-labelledby=\"dashboard-heading\">
+      <h2 id=\"dashboard-heading\">Team Performance</h2>
+      <div class=\"kpi-grid\">
+        <article class=\"panel\">
+          <h3>MRR</h3>
+          <p class=\"section-title\" style=\"margin:0\">€ 128.400</p>
+          <p class=\"badge\">+12% MoM</p>
+        </article>
+        <article class=\"panel\">
+          <h3>Aktive Accounts</h3>
+          <p class=\"section-title\" style=\"margin:0\">4.829</p>
+          <p class=\"badge\">Retention 93%</p>
+        </article>
+        <article class=\"panel\">
+          <h3>NPS</h3>
+          <p class=\"section-title\" style=\"margin:0\">48</p>
+          <p class=\"badge\">+6 Punkte</p>
+        </article>
+      </div>
+      <div class=\"grid-visuals\">
+        <article class=\"panel\" aria-label=\"Umsatzentwicklung\">
+          <h3>Revenue Trend</h3>
+          <svg viewBox=\"0 0 240 120\" role=\"img\" aria-labelledby=\"revenue-chart\">
+            <title id=\"revenue-chart\">Line Chart der letzten 6 Monate</title>
+            <polyline fill=\"none\" stroke=\"currentColor\" stroke-width=\"4\" points=\"0,90 40,80 80,65 120,70 160,50 200,35 240,45\"></polyline>
+          </svg>
+        </article>
+        <article class=\"panel\">
+          <h3>Aktuelle Aufgaben</h3>
+          <ul>
+            <li>Discovery Call vorbereiten</li>
+            <li>Feedbackrunde Alpha 2</li>
+            <li>Design QA Sprint 14</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+        """,
+    },
+    "ecommerce-product-grid": {
+        "title": "E-Commerce Produktgrid",
+        "description": "Produktübersicht mit Filterleiste, adaptivem Grid und Fokus auf Conversion.",
+        "badge": "Commerce Layout",
+        "markdown_link": "../layouts/relevant/ecommerce-product-grid.md",
+        "styles": """
+    #preview.layout-shop {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-shop .filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-shop .filters button {
+      border-radius: 999px;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      padding: 0.5rem 1.25rem;
+      background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+    }
+
+    #preview.layout-shop .products {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
+    }
+
+    #preview.layout-shop article {
+      display: grid;
+      gap: 0.75rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-shop img {
+      border-radius: var(--radius-lg);
+    }
+
+    #preview.layout-shop .price {
+      font-weight: 600;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-shop\" aria-labelledby=\"shop-heading\">
+      <header>
+        <h2 id=\"shop-heading\">Designer Essentials</h2>
+        <div class=\"filters\" role=\"list\">
+          <button type=\"button\">Neu</button>
+          <button type=\"button\">Beliebt</button>
+          <button type=\"button\">Unter €50</button>
+          <button type=\"button\">Nachhaltig</button>
+        </div>
+      </header>
+      <div class=\"products\">
+        <article>
+          <img src=\"https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=800&q=80\" alt=\"Notizbuch aus recyceltem Papier\" />
+          <h3>Notizbuch Re:think</h3>
+          <p class=\"price\">€ 32</p>
+        </article>
+        <article>
+          <img src=\"https://images.unsplash.com/photo-1559050019-31e2a4f0b77b?auto=format&fit=crop&w=800&q=80\" alt=\"Minimalistische Trinkflasche\" />
+          <h3>Hydrate Bottle</h3>
+          <p class=\"price\">€ 26</p>
+        </article>
+        <article>
+          <img src=\"https://images.unsplash.com/photo-1505740420928-5e560c06d30e?auto=format&fit=crop&w=800&q=80\" alt=\"Kabellose Kopfhörer\" />
+          <h3>Focus Headphones</h3>
+          <p class=\"price\">€ 189</p>
+        </article>
+        <article>
+          <img src=\"https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=800&q=80\" alt=\"Ergonomische Lampe\" />
+          <h3>Glow Desk Lamp</h3>
+          <p class=\"price\">€ 119</p>
+        </article>
+      </div>
+    </section>
+        """,
+    },
+    "full-height-layout": {
+        "title": "Full Height Layout",
+        "description": "Layout mit 100vh-Abschnitten, Sticky-CTA und Scroll-Indikatoren.",
+        "badge": "Viewport Layout",
+        "markdown_link": "../layouts/relevant/full-height-layout.md",
+        "styles": """
+    #preview.layout-full-height {
+      display: grid;
+      gap: clamp(2rem, 6vw, 3.5rem);
+    }
+
+    #preview.layout-full-height section {
+      min-height: min(75vh, 42rem);
+      border-radius: var(--radius-lg);
+      padding: clamp(2rem, 5vw, 4rem);
+      background: var(--color-card);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-full-height .scroll-indicator {
+      justify-self: center;
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--color-muted);
+    }
+        """,
+        "main": """
+    <div id=\"preview\" class=\"layout-full-height\" aria-labelledby=\"fullheight-heading\">
+      <section aria-labelledby=\"fullheight-heading\">
+        <h2 id=\"fullheight-heading\">Kick-off Sprint</h2>
+        <p>Einführung, Erwartungsabgleich und Roadmap-Überblick.</p>
+        <a class=\"badge\" href=\"#\">Agenda öffnen</a>
+      </section>
+      <p class=\"scroll-indicator\" aria-hidden=\"true\">⬇︎ Scroll</p>
+      <section>
+        <h3>Discovery Workshop</h3>
+        <p>Hypothesen, Personas und Journey Mapping kollaborativ erarbeiten.</p>
+      </section>
+    </div>
+        """,
+    },
+    "full-width-hero": {
+        "title": "Full Width Hero",
+        "description": "Hero-Sektion über die gesamte Breite mit Medien und CTA.",
+        "badge": "Hero Layout",
+        "markdown_link": "../layouts/relevant/full-width-hero.md",
+        "styles": """
+    #preview.layout-hero {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 58rem) {
+      #preview.layout-hero {
+        grid-template-columns: 1.1fr 1fr;
+        align-items: center;
+      }
+    }
+
+    #preview.layout-hero .media {
+      position: relative;
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--shadow-hard);
+    }
+
+    #preview.layout-hero .media img {
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+    }
+
+    #preview.layout-hero .media::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.25));
+    }
+
+    #preview.layout-hero .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-hero\" aria-labelledby=\"hero-heading\">
+      <div>
+        <h2 id=\"hero-heading\">Produktivitätsplattform für hybride Teams</h2>
+        <p>
+          Verbinden Sie Wissensmanagement, Projekte und Kommunikation in einem zentralen Workspace.
+        </p>
+        <div class=\"actions\">
+          <a class=\"badge\" href=\"#\">Kostenlos testen</a>
+          <a href=\"#\">Video ansehen</a>
+        </div>
+      </div>
+      <figure class=\"media\">
+        <img src=\"https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1400&q=80\" alt=\"Team arbeitet gemeinsam am Laptop\" />
+      </figure>
+    </section>
+        """,
+    },
+    "fullscreen-layout": {
+        "title": "Fullscreen Layout",
+        "description": "Abschnitte im Vollbild, die per Scroll oder Pfeiltasten gewechselt werden.",
+        "badge": "Immersives Layout",
+        "markdown_link": "../layouts/relevant/fullscreen-layout.md",
+        "styles": """
+    #preview.layout-fullscreen {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-fullscreen section {
+      min-height: min(85vh, 48rem);
+      border-radius: var(--radius-lg);
+      padding: clamp(2rem, 5vw, 4rem);
+      background: var(--color-card);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      align-content: center;
+      gap: 1.5rem;
+      text-align: center;
+    }
+        """,
+        "main": """
+    <div id=\"preview\" class=\"layout-fullscreen\" aria-labelledby=\"fullscreen-heading\">
+      <section>
+        <h2 id=\"fullscreen-heading\">Willkommen</h2>
+        <p>Scrollen Sie für Highlights des Produktes. Jede Sektion füllt nahezu das gesamte Viewport.</p>
+      </section>
+      <section>
+        <h3>Schneller Einstieg</h3>
+        <p>Interaktive Touren, Onboarding-Checklisten und Guided Tasks helfen bei der Adoption.</p>
+      </section>
+    </div>
+        """,
+    },
+    "gallery-layout": {
+        "title": "Gallery Layout",
+        "description": "Responsive Galerie mit adaptiven Spalten und Lightbox-Triggern.",
+        "badge": "Visual Layout",
+        "markdown_link": "../layouts/relevant/gallery-layout.md",
+        "styles": """
+    #preview.layout-gallery {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+    }
+
+    #preview.layout-gallery ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: clamp(0.75rem, 2vw, 1.5rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
+    }
+
+    #preview.layout-gallery li {
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-gallery img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-gallery\" aria-labelledby=\"gallery-heading\">
+      <h2 id=\"gallery-heading\">Moodboard</h2>
+      <ul>
+        <li><img src=\"https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=800&q=80\" alt=\"Lichtdurchflutetes Büro\" /></li>
+        <li><img src=\"https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=800&q=80\" alt=\"Moodboard mit Materialien\" /></li>
+        <li><img src=\"https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80\" alt=\"Workshop Szene\" /></li>
+        <li><img src=\"https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=800&q=80\" alt=\"Person arbeitet auf Tablet\" /></li>
+      </ul>
+    </section>
+        """,
+    },
+    "grid-layout": {
+        "title": "Grid Layout",
+        "description": "Flexible CSS-Grid-Startseite mit modularem Aufbau über mehrere Zeilen und Spalten.",
+        "badge": "Struktur Layout",
+        "markdown_link": "../layouts/relevant/grid-layout.md",
+        "styles": """
+    #preview.layout-grid {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+      grid-auto-rows: minmax(12rem, auto);
+    }
+
+    #preview.layout-grid article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-grid .wide {
+      grid-column: span 2;
+    }
+
+    @media (max-width: 60rem) {
+      #preview.layout-grid .wide {
+        grid-column: span 1;
+      }
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-grid\" aria-labelledby=\"grid-heading\">
+      <article class=\"wide\">
+        <h2 id=\"grid-heading\">Hero Update</h2>
+        <p>Highlights, Teaser oder Releases erhalten eine doppelte Spaltenbreite.</p>
+      </article>
+      <article>
+        <h3>Community</h3>
+        <p>Beiträge, Events und Diskussionen.</p>
+      </article>
+      <article>
+        <h3>Guides</h3>
+        <p>Schritt-für-Schritt Anleitungen für neue Features.</p>
+      </article>
+      <article class=\"wide\">
+        <h3>Case Study</h3>
+        <p>Vertiefende Insights oder Success Stories mit mehr Fläche.</p>
+      </article>
+    </section>
+        """,
+    },
+    "header-content-footer": {
+        "title": "Header Content Footer",
+        "description": "Klassisches Dreiteiler-Layout mit Header, flexiblem Content und Footer.",
+        "badge": "Standard Layout",
+        "markdown_link": "../layouts/relevant/header-content-footer.md",
+        "styles": """
+    #preview.layout-hcf {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-hcf header,
+    #preview.layout-hcf main,
+    #preview.layout-hcf footer {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-hcf main {
+      min-height: 12rem;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-hcf\" aria-labelledby=\"hcf-heading\">
+      <header>
+        <h2 id=\"hcf-heading\">Header</h2>
+        <p>Logo, Navigation, Utility-Links.</p>
+      </header>
+      <main>
+        <h3>Hauptbereich</h3>
+        <p>Semantisch korrekt mit <code>&lt;main&gt;</code> ausgezeichnet.</p>
+      </main>
+      <footer>
+        <h3>Footer</h3>
+        <p>Kontakt, rechtliche Hinweise und sekundäre Navigation.</p>
+      </footer>
+    </section>
+        """,
+    },
+    "header-footer": {
+        "title": "Header Footer",
+        "description": "Layout mit globalem Kopf- und Fußbereich und leichtgewichtigen Inhaltsslots.",
+        "badge": "Grundlayout",
+        "markdown_link": "../layouts/relevant/header-footer.md",
+        "styles": """
+    #preview.layout-hf {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    #preview.layout-hf .slot {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-hf\" aria-labelledby=\"hf-heading\">
+      <div class=\"slot\">
+        <h2 id=\"hf-heading\">Header</h2>
+      </div>
+      <div class=\"slot\">
+        <h3>Content Slot</h3>
+        <p>Beliebig kombinierbare Komponenten.</p>
+      </div>
+      <div class=\"slot\">
+        <h3>Footer</h3>
+      </div>
+    </section>
+        """,
+    },
+    "header-sticky-navigation": {
+        "title": "Header Sticky Navigation",
+        "description": "Sticky Navigation mit Scrollspy und sekundären Aktionen.",
+        "badge": "Navigation",
+        "markdown_link": "../layouts/relevant/header-sticky-navigation.md",
+        "styles": """
+    #preview.layout-sticky-nav {
+      position: relative;
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-sticky-nav nav {
+      position: sticky;
+      top: 1.5rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem 1.5rem;
+    }
+
+    #preview.layout-sticky-nav nav a[aria-current="true"] {
+      color: var(--color-primary);
+      font-weight: 600;
+    }
+
+    #preview.layout-sticky-nav section {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      min-height: 16rem;
+    }
+        """,
+        "main": """
+    <div id=\"preview\" class=\"layout-sticky-nav\" data-scrollspy aria-labelledby=\"sticky-heading\">
+      <nav aria-label=\"Abschnittsnavigation\">
+        <a href=\"#section-1\">Überblick</a>
+        <a href=\"#section-2\">Design Tokens</a>
+        <a href=\"#section-3\">Komponenten</a>
+      </nav>
+      <section id=\"section-1\">
+        <h2 id=\"sticky-heading\">Sticky Navigation</h2>
+        <p>Behält Kontext und ermöglicht schnellen Sprung zu Sektionen.</p>
+      </section>
+      <section id=\"section-2\">
+        <h3>Design Tokens</h3>
+        <p>Farbpaletten, Typografie und Spacing im Überblick.</p>
+      </section>
+      <section id=\"section-3\">
+        <h3>Komponenten</h3>
+        <p>Tabellen, Formulare und Overlays.</p>
+      </section>
+    </div>
+        """,
+    },
+    "landing-page": {
+        "title": "Landing Page",
+        "description": "Conversions-getriebene Landingpage mit Hero, Social Proof und Feature-Highlights.",
+        "badge": "Marketing Layout",
+        "markdown_link": "../layouts/relevant/landing-page.md",
+        "styles": """
+    #preview.layout-landing {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-landing .social-proof {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: center;
+      color: var(--color-muted);
+    }
+
+    #preview.layout-landing .features {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    }
+
+    #preview.layout-landing .feature-card {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-landing\" aria-labelledby=\"landing-heading\">
+      <header>
+        <h2 id=\"landing-heading\">Launch schneller validieren</h2>
+        <p>Von der Hypothese bis zum Beta-Feedback – alles in einem Toolkit.</p>
+        <div class=\"social-proof\">
+          <span class=\"badge\">Vertraut von 2.400 Teams</span>
+          <span>★ ★ ★ ★ ★ 4.8 (G2)</span>
+        </div>
+      </header>
+      <div class=\"features\">
+        <article class=\"feature-card\">
+          <h3>Geführte Sprints</h3>
+          <p>Templates für Discovery, Delivery und Measurement.</p>
+        </article>
+        <article class=\"feature-card\">
+          <h3>Automatisierte Reports</h3>
+          <p>Stakeholder-Updates werden automatisch generiert.</p>
+        </article>
+        <article class=\"feature-card\">
+          <h3>Integrationen</h3>
+          <p>Verbinden Sie Jira, Figma und Slack ohne Reibungsverlust.</p>
+        </article>
+      </div>
+    </section>
+        """,
+    },
+    "magazine-layout": {
+        "title": "Magazin Layout",
+        "description": "Editorial Layout mit Multi-Spalten, Highlight-Bannern und Story-Kacheln.",
+        "badge": "Editorial",
+        "markdown_link": "../layouts/relevant/magazine-layout.md",
+        "styles": """
+    #preview.layout-magazine {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-magazine .lead {
+      display: grid;
+      gap: 1rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-magazine .grid {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+    }
+
+    @media (min-width: 64rem) {
+      #preview.layout-magazine .grid {
+        grid-template-columns: 2fr 1fr;
+      }
+    }
+
+    #preview.layout-magazine article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-magazine\" aria-labelledby=\"magazine-heading\">
+      <div class=\"lead\">
+        <p class=\"badge\">Titelstory</p>
+        <h2 id=\"magazine-heading\">Die Renaissance des physischen Prototypings</h2>
+        <p>Warum Teams wieder analog testen und wie sie Feedback schneller verarbeiten.</p>
+      </div>
+      <div class=\"grid\">
+        <article>
+          <h3>Interview</h3>
+          <p>Gespräch mit einer Accessibility-Expertin über barrierefreie Messeauftritte.</p>
+        </article>
+        <article>
+          <h3>Kolumne</h3>
+          <p>Wie sich Print-Layouts auf digitale Leseflüsse übertragen lassen.</p>
+        </article>
+      </div>
+    </section>
+        """,
+    },
+    "masonry-layout": {
+        "title": "Masonry Layout",
+        "description": "Kachel-Layout mit unterschiedlichen Höhen und Masonry-Logik.",
+        "badge": "Content Grid",
+        "markdown_link": "../layouts/relevant/masonry-layout.md",
+        "styles": """
+    #preview.layout-masonry {
+      column-count: 1;
+      column-gap: clamp(1rem, 3vw, 1.5rem);
+    }
+
+    @media (min-width: 48rem) {
+      #preview.layout-masonry {
+        column-count: 2;
+      }
+    }
+
+    @media (min-width: 70rem) {
+      #preview.layout-masonry {
+        column-count: 3;
+      }
+    }
+
+    #preview.layout-masonry article {
+      display: grid;
+      gap: 0.75rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      margin-bottom: clamp(1rem, 3vw, 1.5rem);
+      break-inside: avoid;
+    }
+        """,
+        "main": """
+    <div id=\"preview\" class=\"layout-masonry\" aria-labelledby=\"masonry-heading\">
+      <article>
+        <h2 id=\"masonry-heading\">Kuratiertes Wissen</h2>
+        <p>Artikel und Visuals in variabler Höhe.</p>
+      </article>
+      <article>
+        <h3>UX Writing</h3>
+        <p>Guidelines für Microcopy und Fehlermeldungen.</p>
+      </article>
+      <article>
+        <h3>Research Toolkit</h3>
+        <p>Templates, Checklisten und Workshop-Kits.</p>
+      </article>
+      <article>
+        <h3>Design System</h3>
+        <p>Library-Updates, Figma-Komponenten und Token.</p>
+      </article>
+    </div>
+        """,
+    },
+    "navigation-overlay": {
+        "title": "Navigation Overlay",
+        "description": "Vollflächiges Navigations-Overlay mit Fokus auf ruhige Interaktion.",
+        "badge": "Overlay",
+        "markdown_link": "../layouts/relevant/navigation-overlay.md",
+        "styles": """
+    #preview.layout-overlay {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-overlay .trigger {
+      width: fit-content;
+    }
+
+    #preview.layout-overlay .overlay {
+      position: fixed;
+      inset: 0;
+      background: color-mix(in srgb, var(--color-primary) 12%, rgba(15, 23, 42, 0.9));
+      display: grid;
+      place-items: center;
+      backdrop-filter: blur(18px);
+      transition: opacity 0.3s ease;
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    #preview.layout-overlay .overlay[aria-hidden="false"] {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    #preview.layout-overlay nav {
+      display: grid;
+      gap: 1rem;
+      text-align: center;
+      font-size: clamp(1.5rem, 4vw, 2.5rem);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-overlay\" aria-labelledby=\"overlay-heading\">
+      <h2 id=\"overlay-heading\">Navigation Overlay</h2>
+      <button class=\"trigger badge\" type=\"button\" data-overlay-target=\"site-overlay\">Menü öffnen</button>
+      <div id=\"site-overlay\" class=\"overlay\" aria-hidden=\"true\">
+        <nav aria-label=\"Overlay Navigation\">
+          <a href=\"#\">Home</a>
+          <a href=\"#\">Stories</a>
+          <a href=\"#\">Events</a>
+          <a href=\"#\">Kontakt</a>
+        </nav>
+        <button class=\"trigger\" type=\"button\" data-overlay-close>Schließen</button>
+      </div>
+    </section>
+        """,
+    },
+    "one-column": {
+        "title": "One Column",
+        "description": "Einspaltiges Layout mit maximaler Lesbarkeit und ruhigem Rhythmus.",
+        "badge": "Leselayout",
+        "markdown_link": "../layouts/relevant/one-column.md",
+        "styles": """
+    #preview.layout-one-column {
+      max-width: clamp(52ch, 68ch, 76ch);
+      margin-inline: auto;
+      display: grid;
+      gap: clamp(1.25rem, 4vw, 2rem);
+    }
+        """,
+        "main": """
+    <article id=\"preview\" class=\"layout-one-column\" aria-labelledby=\"onecolumn-heading\">
+      <h2 id=\"onecolumn-heading\">Lesefreundliche Seite</h2>
+      <p>Großzügige Weißräume, klare Typografie und strukturierte Zwischenüberschriften.</p>
+      <h3>Abschnitt</h3>
+      <p>Kurze Absätze halten die Lesbarkeit hoch und unterstützen Fokus.</p>
+    </article>
+        """,
+    },
+    "portfolio-layout": {
+        "title": "Portfolio Layout",
+        "description": "Projekt-Showcase mit Grid, Case-Study-Vorschau und Filtertags.",
+        "badge": "Showcase",
+        "markdown_link": "../layouts/relevant/portfolio-layout.md",
+        "styles": """
+    #preview.layout-portfolio {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-portfolio .projects {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    }
+
+    #preview.layout-portfolio article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-portfolio .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-portfolio\" aria-labelledby=\"portfolio-heading\">
+      <header>
+        <h2 id=\"portfolio-heading\">Ausgewählte Projekte</h2>
+        <p class=\"tags\">
+          <span class=\"badge\">Product Design</span>
+          <span class=\"badge\">Research</span>
+          <span class=\"badge\">Strategy</span>
+        </p>
+      </header>
+      <div class=\"projects\">
+        <article>
+          <h3>Marketplace Redesign</h3>
+          <p>Verbesserte Information Architecture und Filterlogik.</p>
+        </article>
+        <article>
+          <h3>Health App</h3>
+          <p>End-to-End Journey Mapping und Prototypen-Tests.</p>
+        </article>
+        <article>
+          <h3>Analytics Hub</h3>
+          <p>Self-Service Dashboards für Growth-Teams.</p>
+        </article>
+      </div>
+    </section>
+        """,
+    },
+    "responsive-flexbox": {
+        "title": "Responsive Flexbox",
+        "description": "Flexbox-basierte Sektionen, die Reihenfolge und Ausrichtung dynamisch anpassen.",
+        "badge": "Flex Layout",
+        "markdown_link": "../layouts/relevant/responsive-flexbox.md",
+        "styles": """
+    #preview.layout-flex {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(1.25rem, 4vw, 2rem);
+    }
+
+    #preview.layout-flex .row {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    @media (min-width: 60rem) {
+      #preview.layout-flex .row {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-flex\" aria-labelledby=\"flex-heading\">
+      <div class=\"row\">
+        <h2 id=\"flex-heading\">Flexibles Layout</h2>
+        <p>Elemente reihen sich mobil untereinander und orientieren sich am Viewport.</p>
+      </div>
+      <div class=\"row\">
+        <p>Links Inhalt</p>
+        <p>Rechts Aktionen</p>
+      </div>
+    </section>
+        """,
+    },
+    "sidebar-dropdown-menu": {
+        "title": "Sidebar Dropdown Menü",
+        "description": "Seitliche Navigation mit Dropdown-Unterpunkten und Tastaturnavigation.",
+        "badge": "Navigation",
+        "markdown_link": "../layouts/relevant/sidebar-dropdown-menu.md",
+        "styles": """
+    #preview.layout-sidebar-dropdown {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-sidebar-dropdown .layout {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+    }
+
+    @media (min-width: 62rem) {
+      #preview.layout-sidebar-dropdown .layout {
+        grid-template-columns: minmax(14rem, 18rem) 1fr;
+        align-items: start;
+      }
+    }
+
+    #preview.layout-sidebar-dropdown nav {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    #preview.layout-sidebar-dropdown nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    #preview.layout-sidebar-dropdown nav button {
+      border: 0;
+      background: color-mix(in srgb, var(--color-primary) 6%, transparent);
+      border-radius: var(--radius-sm);
+      padding: 0.5rem 0.75rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+    }
+
+    #preview.layout-sidebar-dropdown nav button[aria-expanded="true"] {
+      background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+    }
+
+    #preview.layout-sidebar-dropdown nav .submenu {
+      display: grid;
+      gap: 0.35rem;
+      padding-left: 1rem;
+      margin: 0.25rem 0 0;
+    }
+
+    #preview.layout-sidebar-dropdown main {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-sidebar-dropdown\" aria-labelledby=\"sidebar-heading\">
+      <div class=\"layout\">
+        <nav aria-labelledby=\"sidebar-heading\">
+          <h2 id=\"sidebar-heading\">Navigation</h2>
+          <ul>
+            <li><a href=\"#\">Dashboard</a></li>
+            <li>
+              <button type=\"button\" data-dropdown-button aria-controls=\"projects-menu\" aria-expanded=\"false\">
+                <span>Projekte</span>
+                <span aria-hidden=\"true\">▾</span>
+              </button>
+              <div id=\"projects-menu\" class=\"submenu\" hidden>
+                <a href=\"#\">Aktive</a>
+                <a href=\"#\">Archiv</a>
+              </div>
+            </li>
+            <li><a href=\"#\">Einstellungen</a></li>
+          </ul>
+        </nav>
+        <main>
+          <h3>Projektübersicht</h3>
+          <p>Details zu ausgewählten Projekten erscheinen hier.</p>
+        </main>
+      </div>
+    </section>
+        """,
+    },
+    "spa-layout": {
+        "title": "SPA Layout",
+        "description": "Single-Page-Layout mit App-Shell, Tabs und Content-Routing.",
+        "badge": "App Layout",
+        "markdown_link": "../layouts/relevant/spa-layout.md",
+        "styles": """
+    #preview.layout-spa {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2.25rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-spa .tablist {
+      display: inline-flex;
+      gap: 0.5rem;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+      padding: 0.35rem;
+    }
+
+    #preview.layout-spa [role="tab"] {
+      border: 0;
+      background: transparent;
+      padding: 0.6rem 1.25rem;
+      border-radius: 999px;
+    }
+
+    #preview.layout-spa [role="tab"][aria-selected="true"] {
+      background: var(--color-primary);
+      color: var(--color-primary-contrast);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-spa\" aria-labelledby=\"spa-heading\">
+      <header>
+        <h2 id=\"spa-heading\">Analytics App</h2>
+        <div class=\"tablist\" role=\"tablist\" aria-label=\"Bereiche\">
+          <button role=\"tab\" aria-controls=\"spa-overview\" aria-selected=\"true\">Überblick</button>
+          <button role=\"tab\" aria-controls=\"spa-reports\" aria-selected=\"false\">Reports</button>
+          <button role=\"tab\" aria-controls=\"spa-settings\" aria-selected=\"false\">Einstellungen</button>
+        </div>
+      </header>
+      <article id=\"spa-overview\" role=\"tabpanel\">
+        <p>Key Metrics, Alerts und zuletzt gesehene Dashboards.</p>
+      </article>
+      <article id=\"spa-reports\" role=\"tabpanel\" hidden>
+        <p>Report Builder mit drag &amp; drop.</p>
+      </article>
+      <article id=\"spa-settings\" role=\"tabpanel\" hidden>
+        <p>App Einstellungen und Berechtigungen.</p>
+      </article>
+    </section>
+        """,
+    },
+    "split-screen": {
+        "title": "Split Screen",
+        "description": "Geteiltes Layout mit gleichwertigen Paneelen und kontrastierenden Inhalten.",
+        "badge": "Split Layout",
+        "markdown_link": "../layouts/relevant/split-screen.md",
+        "styles": """
+    #preview.layout-split {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 60rem) {
+      #preview.layout-split {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-split article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2.25rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-split\" aria-labelledby=\"split-heading\">
+      <article>
+        <h2 id=\"split-heading\">Produkt</h2>
+        <p>Leistungsmerkmale, USPs und Differenzierung.</p>
+      </article>
+      <article>
+        <h2>Service</h2>
+        <p>Implementierung, Training und Erfolgsmessung.</p>
+      </article>
+    </section>
+        """,
+    },
+    "sticky-sidebar": {
+        "title": "Sticky Sidebar",
+        "description": "Hauptinhalt mit fixierter Sidebar für Kontextinfos oder TOC.",
+        "badge": "Leselayout",
+        "markdown_link": "../layouts/relevant/sticky-sidebar.md",
+        "styles": """
+    #preview.layout-sticky-sidebar {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 64rem) {
+      #preview.layout-sticky-sidebar {
+        grid-template-columns: minmax(12rem, 18rem) 1fr;
+        align-items: start;
+      }
+    }
+
+    #preview.layout-sticky-sidebar aside {
+      position: sticky;
+      top: 1.5rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-sticky-sidebar main {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-sticky-sidebar\" aria-labelledby=\"sticky-sidebar-heading\">
+      <aside aria-labelledby=\"sticky-sidebar-heading\">
+        <h2 id=\"sticky-sidebar-heading\">Inhaltsverzeichnis</h2>
+        <ol>
+          <li>Einführung</li>
+          <li>Leitlinien</li>
+          <li>Checkliste</li>
+        </ol>
+      </aside>
+      <main>
+        <h3>Artikel</h3>
+        <p>Langform-Inhalte profitieren von einer fixierten Sidebar zur schnellen Navigation.</p>
+      </main>
+    </section>
+        """,
+    },
+    "tabbed-interface": {
+        "title": "Tabbed Interface",
+        "description": "Registerkarten-Layout für strukturierte Informationsarchitektur.",
+        "badge": "Interaktiv",
+        "markdown_link": "../layouts/relevant/tabbed-interface.md",
+        "styles": """
+    #preview.layout-tabs {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-tabs [role="tablist"] {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    #preview.layout-tabs [role="tab"] {
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      border-radius: 999px;
+      padding: 0.5rem 1.25rem;
+      background: transparent;
+    }
+
+    #preview.layout-tabs [role="tab"][aria-selected="true"] {
+      background: var(--color-primary);
+      color: var(--color-primary-contrast);
+      border-color: transparent;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-tabs\" aria-labelledby=\"tabs-heading\">
+      <h2 id=\"tabs-heading\">Produktbereiche</h2>
+      <div role=\"tablist\" aria-label=\"Tabs\">
+        <button role=\"tab\" aria-controls=\"tab-one\" aria-selected=\"true\">Übersicht</button>
+        <button role=\"tab\" aria-controls=\"tab-two\" aria-selected=\"false\">Roadmap</button>
+        <button role=\"tab\" aria-controls=\"tab-three\" aria-selected=\"false\">Support</button>
+      </div>
+      <article id=\"tab-one\" role=\"tabpanel\">
+        <p>Key Metrics und Statusupdates.</p>
+      </article>
+      <article id=\"tab-two\" role=\"tabpanel\" hidden>
+        <p>Nächste Meilensteine und Releases.</p>
+      </article>
+      <article id=\"tab-three\" role=\"tabpanel\" hidden>
+        <p>Support-Artikel, Kontaktoptionen.</p>
+      </article>
+    </section>
+        """,
+    },
+    "timeline-layout": {
+        "title": "Timeline Layout",
+        "description": "Chronologische Darstellung von Meilensteinen mit visueller Achse.",
+        "badge": "Storytelling",
+        "markdown_link": "../layouts/relevant/timeline-layout.md",
+        "styles": """
+    #preview.layout-timeline {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-timeline ol {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      position: relative;
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+    }
+
+    #preview.layout-timeline ol::before {
+      content: "";
+      position: absolute;
+      inset: 0 auto 0 calc(0.75rem);
+      width: 2px;
+      background: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
+    }
+
+    #preview.layout-timeline li {
+      padding-left: 2.5rem;
+      position: relative;
+    }
+
+    #preview.layout-timeline li::before {
+      content: "";
+      position: absolute;
+      left: 0.5rem;
+      top: 0.2rem;
+      width: 0.85rem;
+      height: 0.85rem;
+      border-radius: 50%;
+      background: var(--color-primary);
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 20%, transparent);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-timeline\" aria-labelledby=\"timeline-heading\">
+      <h2 id=\"timeline-heading\">Projektverlauf</h2>
+      <ol>
+        <li>
+          <h3>Q1: Discovery</h3>
+          <p>Research, Hypothesen und Opportunity Solution Trees.</p>
+        </li>
+        <li>
+          <h3>Q2: Beta</h3>
+          <p>Prototyping, Tests und erste Rollouts.</p>
+        </li>
+        <li>
+          <h3>Q3: Scale</h3>
+          <p>Rollout an alle Kunden, Messung der KPIs.</p>
+        </li>
+      </ol>
+    </section>
+        """,
+    },
+    "two-column-equal-width": {
+        "title": "Zweispaltig (gleich breit)",
+        "description": "Zweispaltiges Layout mit gleich breiten Spalten und responsive Stack.",
+        "badge": "Grid",
+        "markdown_link": "../layouts/relevant/two-column-equal-width.md",
+        "styles": """
+    #preview.layout-two-col {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 56rem) {
+      #preview.layout-two-col {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-two-col article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-two-col\" aria-labelledby=\"two-col-heading\">
+      <article>
+        <h2 id=\"two-col-heading\">Inhalt A</h2>
+        <p>Beschreibung für linke Spalte.</p>
+      </article>
+      <article>
+        <h2>Inhalt B</h2>
+        <p>Beschreibung für rechte Spalte.</p>
+      </article>
+    </section>
+        """,
+    },
+    "two-column-left-sidebar": {
+        "title": "Zweispaltig mit linker Sidebar",
+        "description": "Layout mit schmaler Sidebar links und Content rechts.",
+        "badge": "Layout",
+        "markdown_link": "../layouts/relevant/two-column-left-sidebar.md",
+        "styles": """
+    #preview.layout-left-sidebar {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 64rem) {
+      #preview.layout-left-sidebar {
+        grid-template-columns: minmax(12rem, 16rem) 1fr;
+        align-items: start;
+      }
+    }
+
+    #preview.layout-left-sidebar aside,
+    #preview.layout-left-sidebar main {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-left-sidebar\" aria-labelledby=\"left-sidebar-heading\">
+      <aside>
+        <h2 id=\"left-sidebar-heading\">Sidebar</h2>
+        <p>Navigation oder Zusatzinfos.</p>
+      </aside>
+      <main>
+        <h3>Inhaltsbereich</h3>
+        <p>Großzügige Breite für Artikel oder Formulare.</p>
+      </main>
+    </section>
+        """,
+    },
+    "two-column-right-sidebar": {
+        "title": "Zweispaltig mit rechter Sidebar",
+        "description": "Layout mit Hauptinhalt links und sekundärer Spalte rechts.",
+        "badge": "Layout",
+        "markdown_link": "../layouts/relevant/two-column-right-sidebar.md",
+        "styles": """
+    #preview.layout-right-sidebar {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 64rem) {
+      #preview.layout-right-sidebar {
+        grid-template-columns: 1fr minmax(12rem, 16rem);
+        align-items: start;
+      }
+    }
+
+    #preview.layout-right-sidebar aside,
+    #preview.layout-right-sidebar main {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-right-sidebar\" aria-labelledby=\"right-sidebar-heading\">
+      <main>
+        <h2 id=\"right-sidebar-heading\">Content</h2>
+        <p>Primärer Inhalt links.</p>
+      </main>
+      <aside>
+        <h3>Sidebar</h3>
+        <p>CTA, Werbung oder Support-Infos.</p>
+      </aside>
+    </section>
+        """,
+    },
+    "fixed-footer": {
+        "title": "Fixed Footer",
+        "description": "Layout mit fixiertem Footer für permanente Aktionen.",
+        "badge": "Deprecated",
+        "markdown_link": "../layouts/deprecated/fixed-footer.md",
+        "styles": """
+    #preview.layout-fixed-footer {
+      min-height: 18rem;
+      padding-bottom: 4rem;
+      position: relative;
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-fixed-footer footer {
+      position: sticky;
+      bottom: 0;
+      border-radius: var(--radius-lg);
+      background: var(--color-card);
+      padding: 1rem 1.5rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-hard);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-fixed-footer\" aria-labelledby=\"fixed-footer-heading\">
+      <h2 id=\"fixed-footer-heading\">Fixierter Footer</h2>
+      <p>Wird auf kleinen Screens oft als störend wahrgenommen, daher obsolet.</p>
+      <footer>
+        <button type=\"button\">Jetzt kaufen</button>
+      </footer>
+    </section>
+        """,
+    },
+    "horizontal-scrolling": {
+        "title": "Horizontal Scrolling",
+        "description": "Horizontale Scrollbereiche für Navigationsleisten.",
+        "badge": "Deprecated",
+        "markdown_link": "../layouts/deprecated/horizontal-scrolling.md",
+        "styles": """
+    #preview.layout-horizontal {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-horizontal .scroller {
+      display: flex;
+      gap: 1rem;
+      overflow-x: auto;
+      padding: 1rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-horizontal\" aria-labelledby=\"horizontal-heading\">
+      <h2 id=\"horizontal-heading\">Horizontales Scrollen</h2>
+      <div class=\"scroller\">
+        <a href=\"#\">Link 1</a>
+        <a href=\"#\">Link 2</a>
+        <a href=\"#\">Link 3</a>
+        <a href=\"#\">Link 4</a>
+      </div>
+    </section>
+        """,
+    },
+    "nested-columns": {
+        "title": "Nested Columns",
+        "description": "Mehrfach verschachtelte Spaltenstrukturen.",
+        "badge": "Deprecated",
+        "markdown_link": "../layouts/deprecated/nested-columns.md",
+        "styles": """
+    #preview.layout-nested {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-nested .outer {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 60rem) {
+      #preview.layout-nested .outer {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-nested .inner {
+      display: grid;
+      gap: 0.75rem;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-nested\" aria-labelledby=\"nested-heading\">
+      <h2 id=\"nested-heading\">Verschachtelte Spalten</h2>
+      <div class=\"outer\">
+        <div class=\"inner\">
+          <p>Inner Column 1</p>
+          <p>Inner Column 1b</p>
+        </div>
+        <div class=\"inner\">
+          <p>Inner Column 2</p>
+        </div>
+        <div class=\"inner\">
+          <p>Inner Column 3</p>
+          <p>Inner Column 3b</p>
+        </div>
+      </div>
+    </section>
+        """,
+    },
+    "sidebar-navigation": {
+        "title": "Sidebar Navigation",
+        "description": "Fixierte Sidebar ohne mobile Optimierung.",
+        "badge": "Deprecated",
+        "markdown_link": "../layouts/deprecated/sidebar-navigation.md",
+        "styles": """
+    #preview.layout-sidebar-nav {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    #preview.layout-sidebar-nav .layout {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 70rem) {
+      #preview.layout-sidebar-nav .layout {
+        grid-template-columns: 16rem 1fr;
+      }
+    }
+
+    #preview.layout-sidebar-nav nav {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: 1.25rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      height: 100vh;
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-sidebar-nav\" aria-labelledby=\"sidebar-nav-heading\">
+      <h2 id=\"sidebar-nav-heading\">Starre Sidebar</h2>
+      <div class=\"layout\">
+        <nav>
+          <ul>
+            <li><a href=\"#\">Home</a></li>
+            <li><a href=\"#\">Projekte</a></li>
+            <li><a href=\"#\">Kontakt</a></li>
+          </ul>
+        </nav>
+        <article>
+          <p>Keine mobile Adaption – deshalb deprecated.</p>
+        </article>
+      </div>
+    </section>
+        """,
+    },
+    "split-header": {
+        "title": "Split Header",
+        "description": "Geteilter Header mit zwei Ebenen, schwer zugänglich auf mobilen Geräten.",
+        "badge": "Deprecated",
+        "markdown_link": "../layouts/deprecated/split-header.md",
+        "styles": """
+    #preview.layout-split-header {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-split-header header {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 1rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: 1rem 1.5rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-split-header\" aria-labelledby=\"split-header-heading\">
+      <h2 id=\"split-header-heading\">Split Header</h2>
+      <header>
+        <div>Logo + Suche</div>
+        <nav><a href=\"#\">Link A</a> · <a href=\"#\">Link B</a></nav>
+      </header>
+      <p>Auf mobilen Geräten schwer skalierbar.</p>
+    </section>
+        """,
+    },
+    "three-columns": {
+        "title": "Three Columns",
+        "description": "Dreispaltiges Layout ohne mobile Strategie.",
+        "badge": "Deprecated",
+        "markdown_link": "../layouts/deprecated/three-columns.md",
+        "styles": """
+    #preview.layout-three-columns {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 70rem) {
+      #preview.layout-three-columns {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-three-columns article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: 1.25rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+        """,
+        "main": """
+    <section id=\"preview\" class=\"layout-three-columns\" aria-labelledby=\"three-columns-heading\">
+      <h2 id=\"three-columns-heading\">Drei Spalten</h2>
+      <article>Spalte 1</article>
+      <article>Spalte 2</article>
+      <article>Spalte 3</article>
+    </section>
+        """,
+    },
+}
+
+
+def generate_page(slug: str, config: dict[str, str]) -> str:
+  """Return rendered HTML for given layout."""
+  style_block = STYLE_TEMPLATE.format(styles=config.get("styles", "").strip()) if config.get("styles") else ""
+  script_block = SCRIPT_TEMPLATE.format(script=config.get("script", "").strip()) if config.get("script") else ""
+  main = config.get("main", "").rstrip()
+  return BASE_TEMPLATE.format(
+      title=config["title"],
+      description=config["description"],
+      badge=config.get("badge", "Layout Beispiel"),
+      intro=config.get("intro", config["description"]),
+      main=main,
+      style_block=style_block,
+      script_block=script_block,
+      markdown_link=config["markdown_link"],
+  )
+
+
+def build_index(layouts: dict[str, dict[str, str]]) -> str:
+  """Return HTML index page for all layout demos."""
+  items: list[str] = []
+  for slug, config in sorted(layouts.items(), key=lambda entry: entry[1]["title"].lower()):
+    category = "Deprecated" if "/deprecated/" in config["markdown_link"] else "Relevant"
+    items.append(
+        f"        <li><a href=\"{slug}.html\">{config['title']}</a> "
+        f"<span class=\"badge\">{category}</span></li>"
+    )
+
+  items_markup = "\n".join(items)
+  template = """<!DOCTYPE html>
+<html lang=\"de\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>Layout Beispiele Index</title>
+  <meta name=\"description\" content=\"Übersicht über alle Layout-Demos aus den Randnotizen." />
+  <link rel=\"preconnect\" href=\"https://fonts.googleapis.com\" />
+  <link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin />
+  <link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap\" rel=\"stylesheet\" />
+  <link rel=\"stylesheet\" href=\"assets/base.css\" />
+  <style>
+    main {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+      padding-block: clamp(2.5rem, 6vw, 5rem);
+    }
+
+    ul.layout-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    ul.layout-list li {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: 1rem 1.5rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <a class=\"skip-link\" href=\"#main\">Zum Inhalt springen</a>
+  <header class=\"site-header\" role=\"banner\">
+    <nav class=\"site-nav\" aria-label=\"Navigation\">
+      <a class=\"site-header__brand\" href=\"#\">
+        <span class=\"site-header__logo\" aria-hidden=\"true\">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+    </nav>
+  </header>
+  <main id=\"main\" class=\"content-width\" tabindex=\"-1\">
+    <section class=\"layout-intro\">
+      <p class=\"badge\">Übersicht</p>
+      <h1 class=\"section-title\">Layout Demos</h1>
+      <p class=\"prose\">Alle Layout-Beispiele aus den Markdown-Beschreibungen – mobil optimiert und vanilla HTML/CSS/JS.</p>
+    </section>
+    <ul class=\"layout-list\">
+{items}
+    </ul>
+  </main>
+  <footer class=\"site-footer site-header\" role=\"contentinfo\">
+    <div class=\"site-nav\">
+      <p>&copy; <span id=\"year\">2025</span> Randnotizen Layouts</p>
+    </div>
+  </footer>
+  <script src=\"assets/base.js\"></script>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>
+"""
+  return template.replace("{items}", items_markup)
+
+
+def main() -> None:
+  target_dir = REPO_ROOT / "layout-examples"
+  for slug, config in LAYOUTS.items():
+    html = generate_page(slug, config)
+    file_path = target_dir / f"{slug}.html"
+    file_path.write_text(html, encoding="utf-8")
+    print(f"Generated {file_path.relative_to(REPO_ROOT)}")
+  index_html = build_index(LAYOUTS)
+  (target_dir / "index.html").write_text(index_html, encoding="utf-8")
+  print("Generated layout-examples/index.html")
+
+
+if __name__ == "__main__":
+  main()

--- a/layout-examples/grid-layout.html
+++ b/layout-examples/grid-layout.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Grid Layout</title>
+  <meta name="description" content="Flexible CSS-Grid-Startseite mit modularem Aufbau über mehrere Zeilen und Spalten." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-grid {
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+      grid-auto-rows: minmax(12rem, auto);
+    }
+
+    #preview.layout-grid article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-grid .wide {
+      grid-column: span 2;
+    }
+
+    @media (max-width: 60rem) {
+      #preview.layout-grid .wide {
+        grid-column: span 1;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/grid-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Struktur Layout</p>
+      <h1 class="section-title">Grid Layout</h1>
+      <p class="prose">Flexible CSS-Grid-Startseite mit modularem Aufbau über mehrere Zeilen und Spalten.</p>
+    </section>
+
+    <section id="preview" class="layout-grid" aria-labelledby="grid-heading">
+      <article class="wide">
+        <h2 id="grid-heading">Hero Update</h2>
+        <p>Highlights, Teaser oder Releases erhalten eine doppelte Spaltenbreite.</p>
+      </article>
+      <article>
+        <h3>Community</h3>
+        <p>Beiträge, Events und Diskussionen.</p>
+      </article>
+      <article>
+        <h3>Guides</h3>
+        <p>Schritt-für-Schritt Anleitungen für neue Features.</p>
+      </article>
+      <article class="wide">
+        <h3>Case Study</h3>
+        <p>Vertiefende Insights oder Success Stories mit mehr Fläche.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Grid Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/header-content-footer.html
+++ b/layout-examples/header-content-footer.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Header Content Footer</title>
+  <meta name="description" content="Klassisches Dreiteiler-Layout mit Header, flexiblem Content und Footer." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-hcf {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-hcf header,
+    #preview.layout-hcf main,
+    #preview.layout-hcf footer {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-hcf main {
+      min-height: 12rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/header-content-footer.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Standard Layout</p>
+      <h1 class="section-title">Header Content Footer</h1>
+      <p class="prose">Klassisches Dreiteiler-Layout mit Header, flexiblem Content und Footer.</p>
+    </section>
+
+    <section id="preview" class="layout-hcf" aria-labelledby="hcf-heading">
+      <header>
+        <h2 id="hcf-heading">Header</h2>
+        <p>Logo, Navigation, Utility-Links.</p>
+      </header>
+      <main>
+        <h3>Hauptbereich</h3>
+        <p>Semantisch korrekt mit <code>&lt;main&gt;</code> ausgezeichnet.</p>
+      </main>
+      <footer>
+        <h3>Footer</h3>
+        <p>Kontakt, rechtliche Hinweise und sekundäre Navigation.</p>
+      </footer>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Header Content Footer</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/header-footer.html
+++ b/layout-examples/header-footer.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Header Footer</title>
+  <meta name="description" content="Layout mit globalem Kopf- und Fußbereich und leichtgewichtigen Inhaltsslots." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-hf {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    #preview.layout-hf .slot {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/header-footer.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Grundlayout</p>
+      <h1 class="section-title">Header Footer</h1>
+      <p class="prose">Layout mit globalem Kopf- und Fußbereich und leichtgewichtigen Inhaltsslots.</p>
+    </section>
+
+    <section id="preview" class="layout-hf" aria-labelledby="hf-heading">
+      <div class="slot">
+        <h2 id="hf-heading">Header</h2>
+      </div>
+      <div class="slot">
+        <h3>Content Slot</h3>
+        <p>Beliebig kombinierbare Komponenten.</p>
+      </div>
+      <div class="slot">
+        <h3>Footer</h3>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Header Footer</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/header-sticky-navigation.html
+++ b/layout-examples/header-sticky-navigation.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Header Sticky Navigation</title>
+  <meta name="description" content="Sticky Navigation mit Scrollspy und sekundären Aktionen." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-sticky-nav {
+      position: relative;
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-sticky-nav nav {
+      position: sticky;
+      top: 1.5rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem 1.5rem;
+    }
+
+    #preview.layout-sticky-nav nav a[aria-current="true"] {
+      color: var(--color-primary);
+      font-weight: 600;
+    }
+
+    #preview.layout-sticky-nav section {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      min-height: 16rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/header-sticky-navigation.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Navigation</p>
+      <h1 class="section-title">Header Sticky Navigation</h1>
+      <p class="prose">Sticky Navigation mit Scrollspy und sekundären Aktionen.</p>
+    </section>
+
+    <div id="preview" class="layout-sticky-nav" data-scrollspy aria-labelledby="sticky-heading">
+      <nav aria-label="Abschnittsnavigation">
+        <a href="#section-1">Überblick</a>
+        <a href="#section-2">Design Tokens</a>
+        <a href="#section-3">Komponenten</a>
+      </nav>
+      <section id="section-1">
+        <h2 id="sticky-heading">Sticky Navigation</h2>
+        <p>Behält Kontext und ermöglicht schnellen Sprung zu Sektionen.</p>
+      </section>
+      <section id="section-2">
+        <h3>Design Tokens</h3>
+        <p>Farbpaletten, Typografie und Spacing im Überblick.</p>
+      </section>
+      <section id="section-3">
+        <h3>Komponenten</h3>
+        <p>Tabellen, Formulare und Overlays.</p>
+      </section>
+    </div>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Header Sticky Navigation</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/horizontal-scrolling.html
+++ b/layout-examples/horizontal-scrolling.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Horizontal Scrolling</title>
+  <meta name="description" content="Horizontale Scrollbereiche für Navigationsleisten." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-horizontal {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-horizontal .scroller {
+      display: flex;
+      gap: 1rem;
+      overflow-x: auto;
+      padding: 1rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/deprecated/horizontal-scrolling.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Deprecated</p>
+      <h1 class="section-title">Horizontal Scrolling</h1>
+      <p class="prose">Horizontale Scrollbereiche für Navigationsleisten.</p>
+    </section>
+
+    <section id="preview" class="layout-horizontal" aria-labelledby="horizontal-heading">
+      <h2 id="horizontal-heading">Horizontales Scrollen</h2>
+      <div class="scroller">
+        <a href="#">Link 1</a>
+        <a href="#">Link 2</a>
+        <a href="#">Link 3</a>
+        <a href="#">Link 4</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Horizontal Scrolling</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/index.html
+++ b/layout-examples/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiele Index</title>
+  <meta name="description" content="Übersicht über alle Layout-Demos aus den Randnotizen." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+    main {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+      padding-block: clamp(2.5rem, 6vw, 5rem);
+    }
+
+    ul.layout-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    ul.layout-list li {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: 1rem 1.5rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Navigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+    </nav>
+  </header>
+  <main id="main" class="content-width" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Übersicht</p>
+      <h1 class="section-title">Layout Demos</h1>
+      <p class="prose">Alle Layout-Beispiele aus den Markdown-Beschreibungen – mobil optimiert und vanilla HTML/CSS/JS.</p>
+    </section>
+    <ul class="layout-list">
+        <li><a href="accordion-layout.html">Accordion Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="asymmetric-layout.html">Asymmetrisches Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="blog-layout.html">Blog Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="card-layout.html">Card Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="centered-content.html">Centered Content</a> <span class="badge">Relevant</span></li>
+        <li><a href="chat-interface.html">Chat Interface</a> <span class="badge">Relevant</span></li>
+        <li><a href="cover-page.html">Cover Page</a> <span class="badge">Relevant</span></li>
+        <li><a href="dashboard-layout.html">Dashboard Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="ecommerce-product-grid.html">E-Commerce Produktgrid</a> <span class="badge">Relevant</span></li>
+        <li><a href="fixed-footer.html">Fixed Footer</a> <span class="badge">Deprecated</span></li>
+        <li><a href="full-height-layout.html">Full Height Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="full-width-hero.html">Full Width Hero</a> <span class="badge">Relevant</span></li>
+        <li><a href="fullscreen-layout.html">Fullscreen Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="gallery-layout.html">Gallery Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="grid-layout.html">Grid Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="header-content-footer.html">Header Content Footer</a> <span class="badge">Relevant</span></li>
+        <li><a href="header-footer.html">Header Footer</a> <span class="badge">Relevant</span></li>
+        <li><a href="header-sticky-navigation.html">Header Sticky Navigation</a> <span class="badge">Relevant</span></li>
+        <li><a href="horizontal-scrolling.html">Horizontal Scrolling</a> <span class="badge">Deprecated</span></li>
+        <li><a href="landing-page.html">Landing Page</a> <span class="badge">Relevant</span></li>
+        <li><a href="magazine-layout.html">Magazin Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="masonry-layout.html">Masonry Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="navigation-overlay.html">Navigation Overlay</a> <span class="badge">Relevant</span></li>
+        <li><a href="nested-columns.html">Nested Columns</a> <span class="badge">Deprecated</span></li>
+        <li><a href="one-column.html">One Column</a> <span class="badge">Relevant</span></li>
+        <li><a href="portfolio-layout.html">Portfolio Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="responsive-flexbox.html">Responsive Flexbox</a> <span class="badge">Relevant</span></li>
+        <li><a href="sidebar-dropdown-menu.html">Sidebar Dropdown Menü</a> <span class="badge">Relevant</span></li>
+        <li><a href="sidebar-navigation.html">Sidebar Navigation</a> <span class="badge">Deprecated</span></li>
+        <li><a href="spa-layout.html">SPA Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="split-header.html">Split Header</a> <span class="badge">Deprecated</span></li>
+        <li><a href="split-screen.html">Split Screen</a> <span class="badge">Relevant</span></li>
+        <li><a href="sticky-sidebar.html">Sticky Sidebar</a> <span class="badge">Relevant</span></li>
+        <li><a href="tabbed-interface.html">Tabbed Interface</a> <span class="badge">Relevant</span></li>
+        <li><a href="three-columns.html">Three Columns</a> <span class="badge">Deprecated</span></li>
+        <li><a href="timeline-layout.html">Timeline Layout</a> <span class="badge">Relevant</span></li>
+        <li><a href="two-column-equal-width.html">Zweispaltig (gleich breit)</a> <span class="badge">Relevant</span></li>
+        <li><a href="two-column-left-sidebar.html">Zweispaltig mit linker Sidebar</a> <span class="badge">Relevant</span></li>
+        <li><a href="two-column-right-sidebar.html">Zweispaltig mit rechter Sidebar</a> <span class="badge">Relevant</span></li>
+    </ul>
+  </main>
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen Layouts</p>
+    </div>
+  </footer>
+  <script src="assets/base.js"></script>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>

--- a/layout-examples/landing-page.html
+++ b/layout-examples/landing-page.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Landing Page</title>
+  <meta name="description" content="Conversions-getriebene Landingpage mit Hero, Social Proof und Feature-Highlights." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-landing {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-landing .social-proof {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: center;
+      color: var(--color-muted);
+    }
+
+    #preview.layout-landing .features {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    }
+
+    #preview.layout-landing .feature-card {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/landing-page.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Marketing Layout</p>
+      <h1 class="section-title">Landing Page</h1>
+      <p class="prose">Conversions-getriebene Landingpage mit Hero, Social Proof und Feature-Highlights.</p>
+    </section>
+
+    <section id="preview" class="layout-landing" aria-labelledby="landing-heading">
+      <header>
+        <h2 id="landing-heading">Launch schneller validieren</h2>
+        <p>Von der Hypothese bis zum Beta-Feedback – alles in einem Toolkit.</p>
+        <div class="social-proof">
+          <span class="badge">Vertraut von 2.400 Teams</span>
+          <span>★ ★ ★ ★ ★ 4.8 (G2)</span>
+        </div>
+      </header>
+      <div class="features">
+        <article class="feature-card">
+          <h3>Geführte Sprints</h3>
+          <p>Templates für Discovery, Delivery und Measurement.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Automatisierte Reports</h3>
+          <p>Stakeholder-Updates werden automatisch generiert.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Integrationen</h3>
+          <p>Verbinden Sie Jira, Figma und Slack ohne Reibungsverlust.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Landing Page</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/magazine-layout.html
+++ b/layout-examples/magazine-layout.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Magazin Layout</title>
+  <meta name="description" content="Editorial Layout mit Multi-Spalten, Highlight-Bannern und Story-Kacheln." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-magazine {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-magazine .lead {
+      display: grid;
+      gap: 1rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-magazine .grid {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+    }
+
+    @media (min-width: 64rem) {
+      #preview.layout-magazine .grid {
+        grid-template-columns: 2fr 1fr;
+      }
+    }
+
+    #preview.layout-magazine article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/magazine-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Editorial</p>
+      <h1 class="section-title">Magazin Layout</h1>
+      <p class="prose">Editorial Layout mit Multi-Spalten, Highlight-Bannern und Story-Kacheln.</p>
+    </section>
+
+    <section id="preview" class="layout-magazine" aria-labelledby="magazine-heading">
+      <div class="lead">
+        <p class="badge">Titelstory</p>
+        <h2 id="magazine-heading">Die Renaissance des physischen Prototypings</h2>
+        <p>Warum Teams wieder analog testen und wie sie Feedback schneller verarbeiten.</p>
+      </div>
+      <div class="grid">
+        <article>
+          <h3>Interview</h3>
+          <p>Gespräch mit einer Accessibility-Expertin über barrierefreie Messeauftritte.</p>
+        </article>
+        <article>
+          <h3>Kolumne</h3>
+          <p>Wie sich Print-Layouts auf digitale Leseflüsse übertragen lassen.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Magazin Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/masonry-layout.html
+++ b/layout-examples/masonry-layout.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Masonry Layout</title>
+  <meta name="description" content="Kachel-Layout mit unterschiedlichen Höhen und Masonry-Logik." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-masonry {
+      column-count: 1;
+      column-gap: clamp(1rem, 3vw, 1.5rem);
+    }
+
+    @media (min-width: 48rem) {
+      #preview.layout-masonry {
+        column-count: 2;
+      }
+    }
+
+    @media (min-width: 70rem) {
+      #preview.layout-masonry {
+        column-count: 3;
+      }
+    }
+
+    #preview.layout-masonry article {
+      display: grid;
+      gap: 0.75rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      margin-bottom: clamp(1rem, 3vw, 1.5rem);
+      break-inside: avoid;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/masonry-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Content Grid</p>
+      <h1 class="section-title">Masonry Layout</h1>
+      <p class="prose">Kachel-Layout mit unterschiedlichen Höhen und Masonry-Logik.</p>
+    </section>
+
+    <div id="preview" class="layout-masonry" aria-labelledby="masonry-heading">
+      <article>
+        <h2 id="masonry-heading">Kuratiertes Wissen</h2>
+        <p>Artikel und Visuals in variabler Höhe.</p>
+      </article>
+      <article>
+        <h3>UX Writing</h3>
+        <p>Guidelines für Microcopy und Fehlermeldungen.</p>
+      </article>
+      <article>
+        <h3>Research Toolkit</h3>
+        <p>Templates, Checklisten und Workshop-Kits.</p>
+      </article>
+      <article>
+        <h3>Design System</h3>
+        <p>Library-Updates, Figma-Komponenten und Token.</p>
+      </article>
+    </div>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Masonry Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/navigation-overlay.html
+++ b/layout-examples/navigation-overlay.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Navigation Overlay</title>
+  <meta name="description" content="Vollflächiges Navigations-Overlay mit Fokus auf ruhige Interaktion." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-overlay {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-overlay .trigger {
+      width: fit-content;
+    }
+
+    #preview.layout-overlay .overlay {
+      position: fixed;
+      inset: 0;
+      background: color-mix(in srgb, var(--color-primary) 12%, rgba(15, 23, 42, 0.9));
+      display: grid;
+      place-items: center;
+      backdrop-filter: blur(18px);
+      transition: opacity 0.3s ease;
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    #preview.layout-overlay .overlay[aria-hidden="false"] {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    #preview.layout-overlay nav {
+      display: grid;
+      gap: 1rem;
+      text-align: center;
+      font-size: clamp(1.5rem, 4vw, 2.5rem);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/navigation-overlay.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Overlay</p>
+      <h1 class="section-title">Navigation Overlay</h1>
+      <p class="prose">Vollflächiges Navigations-Overlay mit Fokus auf ruhige Interaktion.</p>
+    </section>
+
+    <section id="preview" class="layout-overlay" aria-labelledby="overlay-heading">
+      <h2 id="overlay-heading">Navigation Overlay</h2>
+      <button class="trigger badge" type="button" data-overlay-target="site-overlay">Menü öffnen</button>
+      <div id="site-overlay" class="overlay" aria-hidden="true">
+        <nav aria-label="Overlay Navigation">
+          <a href="#">Home</a>
+          <a href="#">Stories</a>
+          <a href="#">Events</a>
+          <a href="#">Kontakt</a>
+        </nav>
+        <button class="trigger" type="button" data-overlay-close>Schließen</button>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Navigation Overlay</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/nested-columns.html
+++ b/layout-examples/nested-columns.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Nested Columns</title>
+  <meta name="description" content="Mehrfach verschachtelte Spaltenstrukturen." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-nested {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-nested .outer {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 60rem) {
+      #preview.layout-nested .outer {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-nested .inner {
+      display: grid;
+      gap: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/deprecated/nested-columns.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Deprecated</p>
+      <h1 class="section-title">Nested Columns</h1>
+      <p class="prose">Mehrfach verschachtelte Spaltenstrukturen.</p>
+    </section>
+
+    <section id="preview" class="layout-nested" aria-labelledby="nested-heading">
+      <h2 id="nested-heading">Verschachtelte Spalten</h2>
+      <div class="outer">
+        <div class="inner">
+          <p>Inner Column 1</p>
+          <p>Inner Column 1b</p>
+        </div>
+        <div class="inner">
+          <p>Inner Column 2</p>
+        </div>
+        <div class="inner">
+          <p>Inner Column 3</p>
+          <p>Inner Column 3b</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Nested Columns</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/one-column.html
+++ b/layout-examples/one-column.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – One Column</title>
+  <meta name="description" content="Einspaltiges Layout mit maximaler Lesbarkeit und ruhigem Rhythmus." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-one-column {
+      max-width: clamp(52ch, 68ch, 76ch);
+      margin-inline: auto;
+      display: grid;
+      gap: clamp(1.25rem, 4vw, 2rem);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/one-column.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Leselayout</p>
+      <h1 class="section-title">One Column</h1>
+      <p class="prose">Einspaltiges Layout mit maximaler Lesbarkeit und ruhigem Rhythmus.</p>
+    </section>
+
+    <article id="preview" class="layout-one-column" aria-labelledby="onecolumn-heading">
+      <h2 id="onecolumn-heading">Lesefreundliche Seite</h2>
+      <p>Großzügige Weißräume, klare Typografie und strukturierte Zwischenüberschriften.</p>
+      <h3>Abschnitt</h3>
+      <p>Kurze Absätze halten die Lesbarkeit hoch und unterstützen Fokus.</p>
+    </article>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · One Column</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/portfolio-layout.html
+++ b/layout-examples/portfolio-layout.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Portfolio Layout</title>
+  <meta name="description" content="Projekt-Showcase mit Grid, Case-Study-Vorschau und Filtertags." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-portfolio {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-portfolio .projects {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    }
+
+    #preview.layout-portfolio article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    #preview.layout-portfolio .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/portfolio-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Showcase</p>
+      <h1 class="section-title">Portfolio Layout</h1>
+      <p class="prose">Projekt-Showcase mit Grid, Case-Study-Vorschau und Filtertags.</p>
+    </section>
+
+    <section id="preview" class="layout-portfolio" aria-labelledby="portfolio-heading">
+      <header>
+        <h2 id="portfolio-heading">Ausgewählte Projekte</h2>
+        <p class="tags">
+          <span class="badge">Product Design</span>
+          <span class="badge">Research</span>
+          <span class="badge">Strategy</span>
+        </p>
+      </header>
+      <div class="projects">
+        <article>
+          <h3>Marketplace Redesign</h3>
+          <p>Verbesserte Information Architecture und Filterlogik.</p>
+        </article>
+        <article>
+          <h3>Health App</h3>
+          <p>End-to-End Journey Mapping und Prototypen-Tests.</p>
+        </article>
+        <article>
+          <h3>Analytics Hub</h3>
+          <p>Self-Service Dashboards für Growth-Teams.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Portfolio Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/responsive-flexbox.html
+++ b/layout-examples/responsive-flexbox.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Responsive Flexbox</title>
+  <meta name="description" content="Flexbox-basierte Sektionen, die Reihenfolge und Ausrichtung dynamisch anpassen." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-flex {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(1.25rem, 4vw, 2rem);
+    }
+
+    #preview.layout-flex .row {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    @media (min-width: 60rem) {
+      #preview.layout-flex .row {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/responsive-flexbox.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Flex Layout</p>
+      <h1 class="section-title">Responsive Flexbox</h1>
+      <p class="prose">Flexbox-basierte Sektionen, die Reihenfolge und Ausrichtung dynamisch anpassen.</p>
+    </section>
+
+    <section id="preview" class="layout-flex" aria-labelledby="flex-heading">
+      <div class="row">
+        <h2 id="flex-heading">Flexibles Layout</h2>
+        <p>Elemente reihen sich mobil untereinander und orientieren sich am Viewport.</p>
+      </div>
+      <div class="row">
+        <p>Links Inhalt</p>
+        <p>Rechts Aktionen</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Responsive Flexbox</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/sidebar-dropdown-menu.html
+++ b/layout-examples/sidebar-dropdown-menu.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Sidebar Dropdown Menü</title>
+  <meta name="description" content="Seitliche Navigation mit Dropdown-Unterpunkten und Tastaturnavigation." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-sidebar-dropdown {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-sidebar-dropdown .layout {
+      display: grid;
+      gap: clamp(1.25rem, 3vw, 2rem);
+    }
+
+    @media (min-width: 62rem) {
+      #preview.layout-sidebar-dropdown .layout {
+        grid-template-columns: minmax(14rem, 18rem) 1fr;
+        align-items: start;
+      }
+    }
+
+    #preview.layout-sidebar-dropdown nav {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    #preview.layout-sidebar-dropdown nav ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    #preview.layout-sidebar-dropdown nav button {
+      border: 0;
+      background: color-mix(in srgb, var(--color-primary) 6%, transparent);
+      border-radius: var(--radius-sm);
+      padding: 0.5rem 0.75rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+    }
+
+    #preview.layout-sidebar-dropdown nav button[aria-expanded="true"] {
+      background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+    }
+
+    #preview.layout-sidebar-dropdown nav .submenu {
+      display: grid;
+      gap: 0.35rem;
+      padding-left: 1rem;
+      margin: 0.25rem 0 0;
+    }
+
+    #preview.layout-sidebar-dropdown main {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/sidebar-dropdown-menu.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Navigation</p>
+      <h1 class="section-title">Sidebar Dropdown Menü</h1>
+      <p class="prose">Seitliche Navigation mit Dropdown-Unterpunkten und Tastaturnavigation.</p>
+    </section>
+
+    <section id="preview" class="layout-sidebar-dropdown" aria-labelledby="sidebar-heading">
+      <div class="layout">
+        <nav aria-labelledby="sidebar-heading">
+          <h2 id="sidebar-heading">Navigation</h2>
+          <ul>
+            <li><a href="#">Dashboard</a></li>
+            <li>
+              <button type="button" data-dropdown-button aria-controls="projects-menu" aria-expanded="false">
+                <span>Projekte</span>
+                <span aria-hidden="true">▾</span>
+              </button>
+              <div id="projects-menu" class="submenu" hidden>
+                <a href="#">Aktive</a>
+                <a href="#">Archiv</a>
+              </div>
+            </li>
+            <li><a href="#">Einstellungen</a></li>
+          </ul>
+        </nav>
+        <main>
+          <h3>Projektübersicht</h3>
+          <p>Details zu ausgewählten Projekten erscheinen hier.</p>
+        </main>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Sidebar Dropdown Menü</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/sidebar-navigation.html
+++ b/layout-examples/sidebar-navigation.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Sidebar Navigation</title>
+  <meta name="description" content="Fixierte Sidebar ohne mobile Optimierung." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-sidebar-nav {
+      display: grid;
+      gap: 1.5rem;
+    }
+
+    #preview.layout-sidebar-nav .layout {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 70rem) {
+      #preview.layout-sidebar-nav .layout {
+        grid-template-columns: 16rem 1fr;
+      }
+    }
+
+    #preview.layout-sidebar-nav nav {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: 1.25rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+      height: 100vh;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/deprecated/sidebar-navigation.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Deprecated</p>
+      <h1 class="section-title">Sidebar Navigation</h1>
+      <p class="prose">Fixierte Sidebar ohne mobile Optimierung.</p>
+    </section>
+
+    <section id="preview" class="layout-sidebar-nav" aria-labelledby="sidebar-nav-heading">
+      <h2 id="sidebar-nav-heading">Starre Sidebar</h2>
+      <div class="layout">
+        <nav>
+          <ul>
+            <li><a href="#">Home</a></li>
+            <li><a href="#">Projekte</a></li>
+            <li><a href="#">Kontakt</a></li>
+          </ul>
+        </nav>
+        <article>
+          <p>Keine mobile Adaption – deshalb deprecated.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Sidebar Navigation</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/spa-layout.html
+++ b/layout-examples/spa-layout.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – SPA Layout</title>
+  <meta name="description" content="Single-Page-Layout mit App-Shell, Tabs und Content-Routing." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-spa {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2.25rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-spa .tablist {
+      display: inline-flex;
+      gap: 0.5rem;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+      padding: 0.35rem;
+    }
+
+    #preview.layout-spa [role="tab"] {
+      border: 0;
+      background: transparent;
+      padding: 0.6rem 1.25rem;
+      border-radius: 999px;
+    }
+
+    #preview.layout-spa [role="tab"][aria-selected="true"] {
+      background: var(--color-primary);
+      color: var(--color-primary-contrast);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/spa-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">App Layout</p>
+      <h1 class="section-title">SPA Layout</h1>
+      <p class="prose">Single-Page-Layout mit App-Shell, Tabs und Content-Routing.</p>
+    </section>
+
+    <section id="preview" class="layout-spa" aria-labelledby="spa-heading">
+      <header>
+        <h2 id="spa-heading">Analytics App</h2>
+        <div class="tablist" role="tablist" aria-label="Bereiche">
+          <button role="tab" aria-controls="spa-overview" aria-selected="true">Überblick</button>
+          <button role="tab" aria-controls="spa-reports" aria-selected="false">Reports</button>
+          <button role="tab" aria-controls="spa-settings" aria-selected="false">Einstellungen</button>
+        </div>
+      </header>
+      <article id="spa-overview" role="tabpanel">
+        <p>Key Metrics, Alerts und zuletzt gesehene Dashboards.</p>
+      </article>
+      <article id="spa-reports" role="tabpanel" hidden>
+        <p>Report Builder mit drag &amp; drop.</p>
+      </article>
+      <article id="spa-settings" role="tabpanel" hidden>
+        <p>App Einstellungen und Berechtigungen.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · SPA Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/split-header.html
+++ b/layout-examples/split-header.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Split Header</title>
+  <meta name="description" content="Geteilter Header mit zwei Ebenen, schwer zugänglich auf mobilen Geräten." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-split-header {
+      display: grid;
+      gap: 1rem;
+    }
+
+    #preview.layout-split-header header {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 1rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: 1rem 1.5rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/deprecated/split-header.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Deprecated</p>
+      <h1 class="section-title">Split Header</h1>
+      <p class="prose">Geteilter Header mit zwei Ebenen, schwer zugänglich auf mobilen Geräten.</p>
+    </section>
+
+    <section id="preview" class="layout-split-header" aria-labelledby="split-header-heading">
+      <h2 id="split-header-heading">Split Header</h2>
+      <header>
+        <div>Logo + Suche</div>
+        <nav><a href="#">Link A</a> · <a href="#">Link B</a></nav>
+      </header>
+      <p>Auf mobilen Geräten schwer skalierbar.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Split Header</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/split-screen.html
+++ b/layout-examples/split-screen.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Split Screen</title>
+  <meta name="description" content="Geteiltes Layout mit gleichwertigen Paneelen und kontrastierenden Inhalten." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-split {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 60rem) {
+      #preview.layout-split {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-split article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2.25rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/split-screen.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Split Layout</p>
+      <h1 class="section-title">Split Screen</h1>
+      <p class="prose">Geteiltes Layout mit gleichwertigen Paneelen und kontrastierenden Inhalten.</p>
+    </section>
+
+    <section id="preview" class="layout-split" aria-labelledby="split-heading">
+      <article>
+        <h2 id="split-heading">Produkt</h2>
+        <p>Leistungsmerkmale, USPs und Differenzierung.</p>
+      </article>
+      <article>
+        <h2>Service</h2>
+        <p>Implementierung, Training und Erfolgsmessung.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Split Screen</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/sticky-sidebar.html
+++ b/layout-examples/sticky-sidebar.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Sticky Sidebar</title>
+  <meta name="description" content="Hauptinhalt mit fixierter Sidebar für Kontextinfos oder TOC." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-sticky-sidebar {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 64rem) {
+      #preview.layout-sticky-sidebar {
+        grid-template-columns: minmax(12rem, 18rem) 1fr;
+        align-items: start;
+      }
+    }
+
+    #preview.layout-sticky-sidebar aside {
+      position: sticky;
+      top: 1.5rem;
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1rem, 3vw, 1.5rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-sticky-sidebar main {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/sticky-sidebar.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Leselayout</p>
+      <h1 class="section-title">Sticky Sidebar</h1>
+      <p class="prose">Hauptinhalt mit fixierter Sidebar für Kontextinfos oder TOC.</p>
+    </section>
+
+    <section id="preview" class="layout-sticky-sidebar" aria-labelledby="sticky-sidebar-heading">
+      <aside aria-labelledby="sticky-sidebar-heading">
+        <h2 id="sticky-sidebar-heading">Inhaltsverzeichnis</h2>
+        <ol>
+          <li>Einführung</li>
+          <li>Leitlinien</li>
+          <li>Checkliste</li>
+        </ol>
+      </aside>
+      <main>
+        <h3>Artikel</h3>
+        <p>Langform-Inhalte profitieren von einer fixierten Sidebar zur schnellen Navigation.</p>
+      </main>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Sticky Sidebar</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/tabbed-interface.html
+++ b/layout-examples/tabbed-interface.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Tabbed Interface</title>
+  <meta name="description" content="Registerkarten-Layout für strukturierte Informationsarchitektur." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-tabs {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.5rem, 4vw, 2rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+
+    #preview.layout-tabs [role="tablist"] {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    #preview.layout-tabs [role="tab"] {
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      border-radius: 999px;
+      padding: 0.5rem 1.25rem;
+      background: transparent;
+    }
+
+    #preview.layout-tabs [role="tab"][aria-selected="true"] {
+      background: var(--color-primary);
+      color: var(--color-primary-contrast);
+      border-color: transparent;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/tabbed-interface.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Interaktiv</p>
+      <h1 class="section-title">Tabbed Interface</h1>
+      <p class="prose">Registerkarten-Layout für strukturierte Informationsarchitektur.</p>
+    </section>
+
+    <section id="preview" class="layout-tabs" aria-labelledby="tabs-heading">
+      <h2 id="tabs-heading">Produktbereiche</h2>
+      <div role="tablist" aria-label="Tabs">
+        <button role="tab" aria-controls="tab-one" aria-selected="true">Übersicht</button>
+        <button role="tab" aria-controls="tab-two" aria-selected="false">Roadmap</button>
+        <button role="tab" aria-controls="tab-three" aria-selected="false">Support</button>
+      </div>
+      <article id="tab-one" role="tabpanel">
+        <p>Key Metrics und Statusupdates.</p>
+      </article>
+      <article id="tab-two" role="tabpanel" hidden>
+        <p>Nächste Meilensteine und Releases.</p>
+      </article>
+      <article id="tab-three" role="tabpanel" hidden>
+        <p>Support-Artikel, Kontaktoptionen.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Tabbed Interface</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/three-columns.html
+++ b/layout-examples/three-columns.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Three Columns</title>
+  <meta name="description" content="Dreispaltiges Layout ohne mobile Strategie." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-three-columns {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 70rem) {
+      #preview.layout-three-columns {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-three-columns article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: 1.25rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/deprecated/three-columns.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Deprecated</p>
+      <h1 class="section-title">Three Columns</h1>
+      <p class="prose">Dreispaltiges Layout ohne mobile Strategie.</p>
+    </section>
+
+    <section id="preview" class="layout-three-columns" aria-labelledby="three-columns-heading">
+      <h2 id="three-columns-heading">Drei Spalten</h2>
+      <article>Spalte 1</article>
+      <article>Spalte 2</article>
+      <article>Spalte 3</article>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Three Columns</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/timeline-layout.html
+++ b/layout-examples/timeline-layout.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Timeline Layout</title>
+  <meta name="description" content="Chronologische Darstellung von Meilensteinen mit visueller Achse." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-timeline {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    #preview.layout-timeline ol {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      position: relative;
+      display: grid;
+      gap: clamp(1rem, 3vw, 1.75rem);
+    }
+
+    #preview.layout-timeline ol::before {
+      content: "";
+      position: absolute;
+      inset: 0 auto 0 calc(0.75rem);
+      width: 2px;
+      background: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
+    }
+
+    #preview.layout-timeline li {
+      padding-left: 2.5rem;
+      position: relative;
+    }
+
+    #preview.layout-timeline li::before {
+      content: "";
+      position: absolute;
+      left: 0.5rem;
+      top: 0.2rem;
+      width: 0.85rem;
+      height: 0.85rem;
+      border-radius: 50%;
+      background: var(--color-primary);
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 20%, transparent);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/timeline-layout.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Storytelling</p>
+      <h1 class="section-title">Timeline Layout</h1>
+      <p class="prose">Chronologische Darstellung von Meilensteinen mit visueller Achse.</p>
+    </section>
+
+    <section id="preview" class="layout-timeline" aria-labelledby="timeline-heading">
+      <h2 id="timeline-heading">Projektverlauf</h2>
+      <ol>
+        <li>
+          <h3>Q1: Discovery</h3>
+          <p>Research, Hypothesen und Opportunity Solution Trees.</p>
+        </li>
+        <li>
+          <h3>Q2: Beta</h3>
+          <p>Prototyping, Tests und erste Rollouts.</p>
+        </li>
+        <li>
+          <h3>Q3: Scale</h3>
+          <p>Rollout an alle Kunden, Messung der KPIs.</p>
+        </li>
+      </ol>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Timeline Layout</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/two-column-equal-width.html
+++ b/layout-examples/two-column-equal-width.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Zweispaltig (gleich breit)</title>
+  <meta name="description" content="Zweispaltiges Layout mit gleich breiten Spalten und responsive Stack." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-two-col {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 56rem) {
+      #preview.layout-two-col {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    #preview.layout-two-col article {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/two-column-equal-width.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Grid</p>
+      <h1 class="section-title">Zweispaltig (gleich breit)</h1>
+      <p class="prose">Zweispaltiges Layout mit gleich breiten Spalten und responsive Stack.</p>
+    </section>
+
+    <section id="preview" class="layout-two-col" aria-labelledby="two-col-heading">
+      <article>
+        <h2 id="two-col-heading">Inhalt A</h2>
+        <p>Beschreibung für linke Spalte.</p>
+      </article>
+      <article>
+        <h2>Inhalt B</h2>
+        <p>Beschreibung für rechte Spalte.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Zweispaltig (gleich breit)</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/two-column-left-sidebar.html
+++ b/layout-examples/two-column-left-sidebar.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Zweispaltig mit linker Sidebar</title>
+  <meta name="description" content="Layout mit schmaler Sidebar links und Content rechts." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-left-sidebar {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 64rem) {
+      #preview.layout-left-sidebar {
+        grid-template-columns: minmax(12rem, 16rem) 1fr;
+        align-items: start;
+      }
+    }
+
+    #preview.layout-left-sidebar aside,
+    #preview.layout-left-sidebar main {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/two-column-left-sidebar.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Layout</p>
+      <h1 class="section-title">Zweispaltig mit linker Sidebar</h1>
+      <p class="prose">Layout mit schmaler Sidebar links und Content rechts.</p>
+    </section>
+
+    <section id="preview" class="layout-left-sidebar" aria-labelledby="left-sidebar-heading">
+      <aside>
+        <h2 id="left-sidebar-heading">Sidebar</h2>
+        <p>Navigation oder Zusatzinfos.</p>
+      </aside>
+      <main>
+        <h3>Inhaltsbereich</h3>
+        <p>Großzügige Breite für Artikel oder Formulare.</p>
+      </main>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Zweispaltig mit linker Sidebar</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/layout-examples/two-column-right-sidebar.html
+++ b/layout-examples/two-column-right-sidebar.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Layout Beispiel – Zweispaltig mit rechter Sidebar</title>
+  <meta name="description" content="Layout mit Hauptinhalt links und sekundärer Spalte rechts." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/base.css" />
+  <style>
+#preview.layout-right-sidebar {
+      display: grid;
+      gap: clamp(1.5rem, 4vw, 2.5rem);
+    }
+
+    @media (min-width: 64rem) {
+      #preview.layout-right-sidebar {
+        grid-template-columns: 1fr minmax(12rem, 16rem);
+        align-items: start;
+      }
+    }
+
+    #preview.layout-right-sidebar aside,
+    #preview.layout-right-sidebar main {
+      background: var(--color-card);
+      border-radius: var(--radius-lg);
+      padding: clamp(1.25rem, 4vw, 1.75rem);
+      border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+      box-shadow: var(--shadow-soft);
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+  <header class="site-header" role="banner">
+    <nav class="site-nav" aria-label="Hauptnavigation">
+      <a class="site-header__brand" href="#">
+        <span class="site-header__logo" aria-hidden="true">UX</span>
+        <span>Randnotizen Layouts</span>
+      </a>
+      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
+          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        Menü
+      </button>
+      <ul class="site-nav__links" data-nav-list aria-expanded="false">
+        <li><a href="../layouts/relevant/two-column-right-sidebar.md">Markdown</a></li>
+        <li><a href="index.html">Übersicht</a></li>
+        <li><a href="#preview">Demo</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main" class="content-width layout-page" tabindex="-1">
+    <section class="layout-intro">
+      <p class="badge">Layout</p>
+      <h1 class="section-title">Zweispaltig mit rechter Sidebar</h1>
+      <p class="prose">Layout mit Hauptinhalt links und sekundärer Spalte rechts.</p>
+    </section>
+
+    <section id="preview" class="layout-right-sidebar" aria-labelledby="right-sidebar-heading">
+      <main>
+        <h2 id="right-sidebar-heading">Content</h2>
+        <p>Primärer Inhalt links.</p>
+      </main>
+      <aside>
+        <h3>Sidebar</h3>
+        <p>CTA, Werbung oder Support-Infos.</p>
+      </aside>
+    </section>
+  </main>
+
+  <footer class="site-footer site-header" role="contentinfo">
+    <div class="site-nav">
+      <p>&copy; <span id="year">2025</span> Randnotizen · Zweispaltig mit rechter Sidebar</p>
+      <a href="#main">Nach oben</a>
+    </div>
+  </footer>
+
+  <script src="assets/base.js"></script>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a mobile-first base stylesheet and progressive enhancement helpers for layout demos
- implement a generator script that builds HTML examples for all layouts, including an index page
- create standalone HTML demos for each layout described in the markdown files

## Testing
- python layout-examples/generate_pages.py

------
https://chatgpt.com/codex/tasks/task_e_68db91d71d9c832990b0552369dce61d