### PR TITLE
Add accessible HTML example gallery for content elements

### DIFF
--- a/content-elements-examples/assets/scripts.js
+++ b/content-elements-examples/assets/scripts.js
@@ -1,0 +1,892 @@
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+const focusableSelectors = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+];
+
+function initCopyButtons() {
+  document.querySelectorAll('[data-copy-button]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const targetId = button.getAttribute('data-copy-target');
+      const target = document.getElementById(targetId);
+      if (!target) return;
+      const text = target.textContent || '';
+      try {
+        await navigator.clipboard.writeText(text.trim());
+        const feedback = button.closest('[data-code-snippet], figure')?.querySelector('[data-copy-feedback]');
+        if (feedback) {
+          feedback.textContent = 'Code in Zwischenablage kopiert.';
+        }
+        button.classList.add('is-active');
+        button.setAttribute('aria-live', 'polite');
+        button.textContent = 'Kopiert!';
+        setTimeout(() => {
+          button.textContent = 'Code kopieren';
+          button.classList.remove('is-active');
+        }, 1800);
+      } catch (error) {
+        console.error('Clipboard fehlgeschlagen', error);
+      }
+    });
+  });
+}
+
+function initAudioPlayers() {
+  document.querySelectorAll('[data-audio-player]').forEach((player) => {
+    const audio = player.querySelector('[data-audio-element]');
+    const tracks = Array.from(player.querySelectorAll('[data-audio-track]'));
+    const status = player.querySelector('#audio-status');
+
+    tracks.forEach((track) => {
+      track.addEventListener('click', () => {
+        const src = track.getAttribute('data-src');
+        if (!src || !audio) return;
+        const wasPlaying = !audio.paused;
+        audio.src = src;
+        audio.currentTime = 0;
+        if (wasPlaying) {
+          audio.play().catch(() => undefined);
+        }
+        tracks.forEach((btn) => {
+          btn.classList.toggle('is-current', btn === track);
+          btn.setAttribute('aria-pressed', btn === track ? 'true' : 'false');
+        });
+        if (status) {
+          const title = track.getAttribute('data-title') || 'Episode';
+          status.textContent = `${title} wird abgespielt.`;
+        }
+      });
+    });
+  });
+}
+
+function initContactForm() {
+  document.querySelectorAll('[data-contact-form]').forEach((form) => {
+    const feedback = form.querySelector('[data-form-feedback]');
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const name = (formData.get('name') || '').toString().trim();
+      const email = (formData.get('email') || '').toString().trim();
+      if (name.length < 2) {
+        if (feedback) feedback.textContent = 'Bitte geben Sie einen gültigen Namen ein.';
+        return;
+      }
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        if (feedback) feedback.textContent = 'Bitte geben Sie eine gültige E-Mail-Adresse ein.';
+        return;
+      }
+      if (!form.checkValidity()) {
+        form.reportValidity();
+        return;
+      }
+      if (feedback) {
+        feedback.textContent = 'Vielen Dank! Wir melden uns innerhalb von 24 Stunden.';
+      }
+      form.reset();
+    });
+  });
+}
+
+function initCookieBanner() {
+  const banner = document.querySelector('[data-cookie-banner]');
+  if (!banner) return;
+  const STORAGE_KEY = 'content-elements-consent';
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      banner.hidden = true;
+      return;
+    }
+  } catch (error) {
+    console.warn('Consent konnte nicht gelesen werden', error);
+  }
+
+  banner.querySelectorAll('[data-consent-action]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const action = button.getAttribute('data-consent-action');
+      try {
+        localStorage.setItem(STORAGE_KEY, action || 'unknown');
+      } catch (error) {
+        console.warn('Consent konnte nicht gespeichert werden', error);
+      }
+      banner.hidden = true;
+    });
+  });
+
+  banner.querySelector('[data-consent-open-settings]')?.addEventListener('click', () => {
+    const details = banner.querySelector('details');
+    if (details) {
+      details.open = true;
+      details.focus();
+    }
+  });
+}
+
+function formatDate(date) {
+  return date.toLocaleDateString('de-DE');
+}
+
+function buildCalendarDays(baseDate) {
+  const firstDay = new Date(baseDate.getFullYear(), baseDate.getMonth(), 1);
+  const startDay = (firstDay.getDay() + 6) % 7; // Montag als erster Tag
+  const daysInMonth = new Date(baseDate.getFullYear(), baseDate.getMonth() + 1, 0).getDate();
+  const previousMonthDays = new Date(baseDate.getFullYear(), baseDate.getMonth(), 0).getDate();
+  const cells = [];
+  for (let i = 0; i < 42; i += 1) {
+    const dayNumber = i - startDay + 1;
+    let date;
+    let muted = false;
+    if (dayNumber < 1) {
+      date = new Date(baseDate.getFullYear(), baseDate.getMonth() - 1, previousMonthDays + dayNumber);
+      muted = true;
+    } else if (dayNumber > daysInMonth) {
+      date = new Date(baseDate.getFullYear(), baseDate.getMonth() + 1, dayNumber - daysInMonth);
+      muted = true;
+    } else {
+      date = new Date(baseDate.getFullYear(), baseDate.getMonth(), dayNumber);
+    }
+    cells.push({ date, muted });
+  }
+  return cells;
+}
+
+function initDatePickers() {
+  document.querySelectorAll('[data-date-picker]').forEach((picker) => {
+    const input = picker.querySelector('[data-date-input]');
+    const grid = picker.querySelector('[data-calendar-grid]');
+    const title = picker.querySelector('[data-calendar-title]');
+    if (!grid || !input || !title) return;
+
+    const startMonth = picker.getAttribute('data-start-month');
+    let activeDate = startMonth ? new Date(`${startMonth}-01T00:00:00`) : new Date();
+    let selectedDate = new Date();
+
+    function render(date) {
+      title.textContent = date.toLocaleDateString('de-DE', { month: 'long', year: 'numeric' });
+      grid.innerHTML = '';
+      const cells = buildCalendarDays(date);
+      cells.forEach((cell, index) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = String(cell.date.getDate());
+        button.dataset.timestamp = cell.date.toISOString();
+        button.dataset.index = String(index);
+        button.classList.toggle('is-muted', cell.muted);
+        const isToday = cell.date.toDateString() === new Date().toDateString();
+        button.classList.toggle('is-today', isToday);
+        const isSelected = selectedDate && cell.date.toDateString() === selectedDate.toDateString();
+        button.classList.toggle('is-selected', isSelected);
+        button.setAttribute('role', 'gridcell');
+        button.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+        if (index === 0 || isSelected) {
+          button.tabIndex = 0;
+        } else {
+          button.tabIndex = -1;
+        }
+        button.addEventListener('click', () => {
+          selectedDate = new Date(button.dataset.timestamp || '');
+          input.value = formatDate(selectedDate);
+          render(activeDate);
+        });
+        button.addEventListener('keydown', (event) => {
+          const currentIndex = Number(button.dataset.index);
+          let nextIndex = currentIndex;
+          if (event.key === 'ArrowRight') nextIndex += 1;
+          if (event.key === 'ArrowLeft') nextIndex -= 1;
+          if (event.key === 'ArrowDown') nextIndex += 7;
+          if (event.key === 'ArrowUp') nextIndex -= 7;
+          if (event.key === 'Home') nextIndex -= currentIndex % 7;
+          if (event.key === 'End') nextIndex += 6 - (currentIndex % 7);
+          if (event.key === 'PageDown') {
+            activeDate = new Date(activeDate.getFullYear(), activeDate.getMonth() + 1, 1);
+            render(activeDate);
+            setTimeout(() => {
+              grid.querySelector('button[data-index="0"]')?.focus();
+            }, 0);
+            event.preventDefault();
+            return;
+          }
+          if (event.key === 'PageUp') {
+            activeDate = new Date(activeDate.getFullYear(), activeDate.getMonth() - 1, 1);
+            render(activeDate);
+            setTimeout(() => {
+              grid.querySelector('button[data-index="0"]')?.focus();
+            }, 0);
+            event.preventDefault();
+            return;
+          }
+          const buttons = grid.querySelectorAll('button');
+          if (nextIndex >= 0 && nextIndex < buttons.length) {
+            const nextButton = buttons[nextIndex];
+            nextButton.focus();
+            event.preventDefault();
+          }
+        });
+        grid.appendChild(button);
+      });
+    }
+
+    render(activeDate);
+
+    picker.querySelector('[data-calendar-prev]')?.addEventListener('click', () => {
+      activeDate = new Date(activeDate.getFullYear(), activeDate.getMonth() - 1, 1);
+      render(activeDate);
+    });
+
+    picker.querySelector('[data-calendar-next]')?.addEventListener('click', () => {
+      activeDate = new Date(activeDate.getFullYear(), activeDate.getMonth() + 1, 1);
+      render(activeDate);
+    });
+  });
+}
+
+function initDropdowns() {
+  document.querySelectorAll('[data-dropdown]').forEach((dropdown) => {
+    const toggle = dropdown.querySelector('[data-dropdown-toggle]');
+    const list = dropdown.querySelector('[data-dropdown-list]');
+    const hiddenInput = dropdown.querySelector('[data-dropdown-input]');
+    const label = dropdown.querySelector('[data-dropdown-label]');
+    if (!toggle || !list || !hiddenInput || !label) return;
+
+    let isOpen = false;
+    const options = Array.from(list.querySelectorAll('.dropdown__option'));
+
+    function close() {
+      isOpen = false;
+      dropdown.classList.remove('is-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      list.setAttribute('hidden', 'true');
+    }
+
+    function open() {
+      isOpen = true;
+      dropdown.classList.add('is-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      list.removeAttribute('hidden');
+      options.find((option) => option.getAttribute('aria-selected') === 'true')?.focus();
+    }
+
+    toggle.addEventListener('click', () => {
+      if (isOpen) {
+        close();
+      } else {
+        open();
+      }
+    });
+
+    toggle.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        open();
+      }
+    });
+
+    options.forEach((option) => {
+      option.addEventListener('click', () => {
+        options.forEach((opt) => opt.setAttribute('aria-selected', 'false'));
+        option.setAttribute('aria-selected', 'true');
+        hiddenInput.value = option.dataset.value || option.textContent || '';
+        label.textContent = option.textContent || '';
+        close();
+        toggle.focus();
+      });
+
+      option.addEventListener('keydown', (event) => {
+        const currentIndex = options.indexOf(option);
+        if (event.key === 'ArrowDown') {
+          options[(currentIndex + 1) % options.length].focus();
+          event.preventDefault();
+        }
+        if (event.key === 'ArrowUp') {
+          options[(currentIndex - 1 + options.length) % options.length].focus();
+          event.preventDefault();
+        }
+        if (event.key === 'Escape') {
+          close();
+          toggle.focus();
+        }
+      });
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!dropdown.contains(event.target)) {
+        close();
+      }
+    });
+  });
+}
+
+function initFileUploader() {
+  document.querySelectorAll('[data-file-uploader]').forEach((section) => {
+    const dropzone = section.querySelector('[data-dropzone]');
+    const input = section.querySelector('[data-file-input]');
+    const list = section.querySelector('[data-upload-list]');
+    if (!dropzone || !input || !list) return;
+
+    function handleFiles(files) {
+      Array.from(files).forEach((file) => {
+        const item = document.createElement('div');
+        item.className = 'upload-item';
+        item.innerHTML = `
+          <span>${file.name}</span>
+          <div class="stack-sm" style="min-width:120px;">
+            <div class="progress-bar"><div class="progress-bar__fill"></div></div>
+            <span class="text-muted" data-upload-status>Lädt hoch …</span>
+          </div>
+        `;
+        list.append(item);
+        const bar = item.querySelector('.progress-bar__fill');
+        const status = item.querySelector('[data-upload-status]');
+        let progress = 0;
+        const timer = setInterval(() => {
+          progress += 10;
+          bar.style.width = `${progress}%`;
+          if (progress >= 100) {
+            clearInterval(timer);
+            if (status) status.textContent = 'Fertig';
+          }
+        }, prefersReducedMotion.matches ? 120 : 80);
+      });
+    }
+
+    dropzone.addEventListener('dragover', (event) => {
+      event.preventDefault();
+      dropzone.classList.add('is-dragover');
+    });
+    dropzone.addEventListener('dragleave', () => dropzone.classList.remove('is-dragover'));
+    dropzone.addEventListener('drop', (event) => {
+      event.preventDefault();
+      dropzone.classList.remove('is-dragover');
+      if (event.dataTransfer?.files) {
+        handleFiles(event.dataTransfer.files);
+      }
+    });
+    dropzone.addEventListener('click', () => input.click());
+    input.addEventListener('change', () => {
+      if (input.files) {
+        handleFiles(input.files);
+      }
+    });
+  });
+}
+
+function initCarousel() {
+  document.querySelectorAll('[data-carousel]').forEach((carousel) => {
+    const track = carousel.querySelector('[data-carousel-track]');
+    const slides = track ? Array.from(track.querySelectorAll('[data-carousel-slide]')) : [];
+    const dotsContainer = carousel.nextElementSibling?.matches('[data-carousel-dots]') ? carousel.nextElementSibling : carousel.querySelector('[data-carousel-dots]');
+    const dots = dotsContainer ? Array.from(dotsContainer.querySelectorAll('[role="tab"]')) : [];
+    if (!track || slides.length === 0) return;
+    let index = 0;
+
+    function update(newIndex) {
+      index = (newIndex + slides.length) % slides.length;
+      track.style.transform = `translateX(-${index * 100}%)`;
+      slides.forEach((slide, slideIndex) => {
+        const isActive = slideIndex === index;
+        slide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      });
+      dots.forEach((dot, dotIndex) => {
+        dot.setAttribute('aria-current', dotIndex === index ? 'true' : 'false');
+      });
+    }
+
+    carousel.querySelector('[data-carousel-prev]')?.addEventListener('click', () => update(index - 1));
+    carousel.querySelector('[data-carousel-next]')?.addEventListener('click', () => update(index + 1));
+    dots.forEach((dot, dotIndex) => {
+      dot.addEventListener('click', () => update(dotIndex));
+    });
+
+    let autoSlide;
+    function startAuto() {
+      if (prefersReducedMotion.matches) return;
+      autoSlide = window.setInterval(() => update(index + 1), 6000);
+    }
+    function stopAuto() {
+      if (autoSlide) window.clearInterval(autoSlide);
+    }
+    carousel.addEventListener('mouseenter', stopAuto);
+    carousel.addEventListener('mouseleave', startAuto);
+    startAuto();
+    update(0);
+  });
+}
+
+function initInputHelpers() {
+  document.querySelectorAll('[data-input-with-counter]').forEach((input) => {
+    const wrapper = input.closest('.input-group');
+    const output = wrapper?.querySelector('[data-input-counter]');
+    if (!output) return;
+    const max = Number(input.getAttribute('maxlength')) || 20;
+    input.addEventListener('input', () => {
+      output.textContent = String(input.value.length);
+      if (input.value.length > max) {
+        input.classList.add('input--invalid');
+      } else {
+        input.classList.remove('input--invalid');
+      }
+    });
+  });
+
+  document.querySelectorAll('[data-toggle-password]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const input = button.previousElementSibling;
+      if (!(input instanceof HTMLInputElement)) return;
+      if (input.type === 'password') {
+        input.type = 'text';
+        button.textContent = 'Verbergen';
+      } else {
+        input.type = 'password';
+        button.textContent = 'Anzeigen';
+      }
+      input.focus();
+    });
+  });
+}
+
+function initMiniCart() {
+  document.querySelectorAll('[data-mini-cart]').forEach((cart) => {
+    const totalEl = cart.querySelector('[data-cart-total]');
+    const items = cart.querySelectorAll('[data-cart-item]');
+
+    function formatCurrency(value) {
+      return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(value);
+    }
+
+    function updateTotal() {
+      let total = 0;
+      items.forEach((item) => {
+        const price = Number(item.querySelector('[data-item-price]')?.getAttribute('data-item-price'));
+        const quantity = Number(item.querySelector('[data-item-qty]')?.value || 1);
+        if (!Number.isNaN(price)) {
+          total += price * quantity;
+        }
+      });
+      if (totalEl) totalEl.textContent = formatCurrency(total);
+    }
+
+    items.forEach((item) => {
+      const qty = item.querySelector('[data-item-qty]');
+      qty?.addEventListener('input', updateTotal);
+    });
+
+    updateTotal();
+  });
+}
+
+function getFocusableElements(container) {
+  return Array.from(container.querySelectorAll(focusableSelectors.join(',')));
+}
+
+function trapFocus(dialog) {
+  const focusables = getFocusableElements(dialog);
+  if (focusables.length === 0) return;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  dialog.addEventListener('keydown', (event) => {
+    if (event.key !== 'Tab') return;
+    if (event.shiftKey && document.activeElement === first) {
+      last.focus();
+      event.preventDefault();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      first.focus();
+      event.preventDefault();
+    }
+  });
+}
+
+function initModals() {
+  document.querySelectorAll('[data-open-modal]').forEach((trigger) => {
+    const targetSelector = trigger.getAttribute('data-open-modal');
+    const dialog = targetSelector ? document.querySelector(targetSelector) : null;
+    if (!(dialog instanceof HTMLDialogElement)) return;
+    const closeButtons = dialog.querySelectorAll('[data-close-modal]');
+    trapFocus(dialog);
+
+    function open() {
+      if (typeof dialog.showModal === 'function') {
+        dialog.showModal();
+      } else {
+        dialog.setAttribute('open', 'true');
+      }
+      dialog.addEventListener('cancel', (event) => event.preventDefault());
+      const firstFocusable = getFocusableElements(dialog)[0];
+      firstFocusable?.focus();
+    }
+
+    function close() {
+      if (typeof dialog.close === 'function') {
+        dialog.close();
+      } else {
+        dialog.removeAttribute('open');
+      }
+      trigger.focus();
+    }
+
+    trigger.addEventListener('click', () => open());
+    closeButtons.forEach((btn) => btn.addEventListener('click', () => close()));
+    dialog.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        close();
+      }
+    });
+  });
+}
+
+function initWizard() {
+  document.querySelectorAll('[data-wizard]').forEach((wizard) => {
+    const steps = Array.from(wizard.querySelectorAll('[data-wizard-step]'));
+    const indicators = wizard.querySelectorAll('.wizard__step');
+    let index = 0;
+
+    function update() {
+      steps.forEach((step, stepIndex) => {
+        step.hidden = stepIndex !== index;
+      });
+      indicators.forEach((indicator, indicatorIndex) => {
+        indicator.setAttribute('aria-current', indicatorIndex === index ? 'step' : 'false');
+      });
+    }
+
+    wizard.querySelectorAll('[data-wizard-next]').forEach((button) => {
+      button.addEventListener('click', () => {
+        index = Math.min(index + 1, steps.length - 1);
+        update();
+      });
+    });
+
+    wizard.querySelectorAll('[data-wizard-prev]').forEach((button) => {
+      button.addEventListener('click', () => {
+        index = Math.max(index - 1, 0);
+        update();
+      });
+    });
+
+    steps.forEach((step) => {
+      step.addEventListener('submit', (event) => {
+        event.preventDefault();
+        index = Math.min(index + 1, steps.length - 1);
+        update();
+      });
+    });
+
+    update();
+  });
+}
+
+function initNewsletterForms() {
+  const forms = document.querySelectorAll('[data-newsletter], [data-newsletter-modal]');
+  forms.forEach((form) => {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const emailInput = form.querySelector('input[type="email"]');
+      const feedback = form.closest('form')?.querySelector('[data-newsletter-feedback]') || form.querySelector('[data-newsletter-feedback]');
+      if (emailInput && !emailInput.value.includes('@')) {
+        if (feedback) feedback.textContent = 'Bitte geben Sie eine gültige E-Mail-Adresse ein.';
+        emailInput.focus();
+        return;
+      }
+      if (feedback) feedback.textContent = 'Checken Sie Ihr Postfach für die Bestätigung.';
+      form.reset();
+    });
+  });
+}
+
+function initNotificationBanner() {
+  document.querySelectorAll('[data-notification-banner]').forEach((banner) => {
+    banner.querySelector('[data-dismiss-banner]')?.addEventListener('click', () => {
+      banner.setAttribute('hidden', 'true');
+    });
+  });
+}
+
+function initPopovers() {
+  document.querySelectorAll('[data-popover]').forEach((popover) => {
+    const toggle = popover.querySelector('[data-popover-toggle]');
+    const panel = popover.querySelector('.popover__panel');
+    if (!toggle || !panel) return;
+    let open = false;
+
+    function close() {
+      open = false;
+      popover.classList.remove('is-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      panel.setAttribute('hidden', 'true');
+    }
+
+    function show() {
+      open = true;
+      popover.classList.add('is-open');
+      toggle.setAttribute('aria-expanded', 'true');
+      panel.removeAttribute('hidden');
+      panel.focus?.();
+    }
+
+    toggle.addEventListener('click', () => {
+      if (open) {
+        close();
+      } else {
+        show();
+      }
+    });
+
+    popover.querySelector('[data-popover-close]')?.addEventListener('click', () => close());
+
+    document.addEventListener('click', (event) => {
+      if (!popover.contains(event.target)) {
+        close();
+      }
+    });
+  });
+}
+
+function initReviewForms() {
+  document.querySelectorAll('[data-review-form]').forEach((form) => {
+    const output = form.querySelector('[data-rating-output]');
+    const radios = Array.from(form.querySelectorAll('input[name="rating"]'));
+    radios.forEach((radio) => {
+      radio.addEventListener('change', () => {
+        if (output) output.textContent = radio.value;
+      });
+    });
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const feedback = form.querySelector('[data-review-feedback]');
+      if (feedback) feedback.textContent = 'Danke für Ihr Feedback!';
+      form.reset();
+      if (output) output.textContent = '0';
+    });
+  });
+}
+
+function initSearch() {
+  const data = [
+    'Accessibility',
+    'Design Tokens',
+    'Komponenten Bibliothek',
+    'Content Strategie',
+    'Onboarding Flow',
+    'Team Collaboration'
+  ];
+  document.querySelectorAll('[data-search]').forEach((form) => {
+    const input = form.querySelector('[data-search-input]');
+    const list = form.querySelector('[data-search-suggestions]');
+    if (!input || !list) return;
+
+    input.addEventListener('input', () => {
+      const query = input.value.trim().toLowerCase();
+      list.innerHTML = '';
+      if (query.length < 2) return;
+      const matches = data.filter((item) => item.toLowerCase().includes(query)).slice(0, 5);
+      matches.forEach((match) => {
+        const li = document.createElement('li');
+        li.textContent = match;
+        li.role = 'option';
+        list.append(li);
+      });
+    });
+  });
+}
+
+function initShareButtons() {
+  document.querySelectorAll('[data-share-buttons]').forEach((group) => {
+    const feedback = group.querySelector('[data-share-feedback]');
+    group.querySelectorAll('[data-share-action]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const action = button.getAttribute('data-share-action');
+        if (action === 'native' && navigator.share) {
+          try {
+            await navigator.share({
+              title: document.title,
+              url: window.location.href
+            });
+          } catch (error) {
+            console.warn('Native Share abgebrochen', error);
+          }
+        } else {
+          await navigator.clipboard.writeText(window.location.href);
+          if (feedback) feedback.textContent = 'Link kopiert';
+        }
+      });
+    });
+  });
+}
+
+function initTableOfContents() {
+  document.querySelectorAll('[data-toc]').forEach((toc) => {
+    const toggle = toc.querySelector('[data-toc-toggle]');
+    const list = toc.querySelector('[data-toc-list]');
+    if (!toggle || !list) return;
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      if (expanded) {
+        list.hidden = true;
+      } else {
+        list.hidden = false;
+      }
+    });
+  });
+}
+
+function initToast() {
+  document.querySelectorAll('[data-toast-trigger]').forEach((button) => {
+    const region = button.closest('.stack-md')?.querySelector('[data-toast-region]');
+    if (!region) return;
+    button.addEventListener('click', () => {
+      const toast = document.createElement('div');
+      toast.className = 'toast';
+      toast.innerHTML = '<strong>Gespeichert!</strong><span>Ihre Einstellungen wurden aktualisiert.</span>';
+      region.append(toast);
+      setTimeout(() => {
+        toast.classList.add('is-leaving');
+        toast.style.opacity = '0';
+        setTimeout(() => toast.remove(), 300);
+      }, 4000);
+    });
+  });
+}
+
+function initTooltip() {
+  document.querySelectorAll('[data-tooltip]').forEach((tooltip) => {
+    const trigger = tooltip.querySelector('[data-tooltip-trigger]');
+    if (!trigger) return;
+    const bubble = tooltip.querySelector('.tooltip__bubble');
+    function show() {
+      tooltip.setAttribute('aria-expanded', 'true');
+      bubble?.setAttribute('aria-hidden', 'false');
+    }
+    function hide() {
+      tooltip.setAttribute('aria-expanded', 'false');
+      bubble?.setAttribute('aria-hidden', 'true');
+    }
+    trigger.addEventListener('focus', show);
+    trigger.addEventListener('blur', hide);
+    trigger.addEventListener('mouseenter', show);
+    trigger.addEventListener('mouseleave', hide);
+  });
+}
+
+function initReviewStars() {
+  // No JS required currently but kept for future extension
+}
+
+function initSearchFormSubmission() {
+  document.querySelectorAll('[data-search]').forEach((form) => {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const input = form.querySelector('[data-search-input]');
+      const feedback = form.querySelector('[data-search-feedback]');
+      if (input && feedback) {
+        feedback.textContent = `Suche gestartet für „${input.value.trim()}“`;
+      }
+    });
+  });
+}
+
+function initShareFallbacks() {
+  if (!navigator.share) {
+    document.querySelectorAll('[data-share-action="native"]').forEach((button) => {
+      button.textContent = 'Link teilen';
+    });
+  }
+}
+
+function initSearchSuggestionsRole() {
+  document.querySelectorAll('[data-search-suggestions]').forEach((list) => {
+    list.setAttribute('role', 'listbox');
+  });
+}
+
+function initToastRegion() {
+  document.querySelectorAll('[data-toast-region]').forEach((region) => {
+    region.setAttribute('aria-live', 'polite');
+  });
+}
+
+function initDropdownAccessibility() {
+  document.querySelectorAll('[data-dropdown]').forEach((dropdown) => {
+    const list = dropdown.querySelector('[data-dropdown-list]');
+    if (list) list.hidden = true;
+  });
+}
+
+function initSearchPrefill() {
+  const params = new URLSearchParams(window.location.search);
+  const query = params.get('q');
+  if (query) {
+    const input = document.querySelector('[data-search-input]');
+    if (input) input.value = query;
+  }
+}
+
+function initTooltipAria() {
+  document.querySelectorAll('[data-tooltip]').forEach((tooltip) => {
+    tooltip.querySelector('.tooltip__bubble')?.setAttribute('aria-hidden', 'true');
+  });
+}
+
+function initDropdownEscape() {
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return;
+    document.querySelectorAll('[data-dropdown]').forEach((dropdown) => {
+      dropdown.classList.remove('is-open');
+      dropdown.querySelector('[data-dropdown-toggle]')?.setAttribute('aria-expanded', 'false');
+      dropdown.querySelector('[data-dropdown-list]')?.setAttribute('hidden', 'true');
+    });
+  });
+}
+
+function initSearchSuggestions() {
+  // already handled in initSearch; placeholder for future extension
+}
+
+function initTooltipPointer() {
+  document.querySelectorAll('[data-tooltip]').forEach((tooltip) => {
+    tooltip.addEventListener('pointerdown', () => {
+      tooltip.setAttribute('aria-expanded', 'true');
+    });
+  });
+}
+
+function initPage() {
+  initCopyButtons();
+  initAudioPlayers();
+  initContactForm();
+  initCookieBanner();
+  initDatePickers();
+  initDropdowns();
+  initDropdownAccessibility();
+  initDropdownEscape();
+  initFileUploader();
+  initCarousel();
+  initInputHelpers();
+  initMiniCart();
+  initModals();
+  initWizard();
+  initNewsletterForms();
+  initNotificationBanner();
+  initPopovers();
+  initReviewForms();
+  initReviewStars();
+  initSearch();
+  initSearchFormSubmission();
+  initSearchSuggestionsRole();
+  initSearchPrefill();
+  initShareButtons();
+  initShareFallbacks();
+  initTableOfContents();
+  initToast();
+  initToastRegion();
+  initTooltip();
+  initTooltipAria();
+  initTooltipPointer();
+}
+
+document.addEventListener('DOMContentLoaded', initPage);

--- a/content-elements-examples/assets/styles.css
+++ b/content-elements-examples/assets/styles.css
@@ -1,0 +1,1345 @@
+:root {
+  color-scheme: light dark;
+  --color-bg: #f4f5f7;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f0f4ff;
+  --color-primary: #2457f5;
+  --color-primary-dark: #173cb8;
+  --color-primary-soft: #e5ecff;
+  --color-success: #1b9c85;
+  --color-warning: #f2994a;
+  --color-danger: #d64550;
+  --color-neutral-900: #111827;
+  --color-neutral-700: #374151;
+  --color-neutral-500: #6b7280;
+  --color-neutral-300: #d1d5db;
+  --color-neutral-100: #f3f4f6;
+  --shadow-md: 0 10px 30px rgba(15, 23, 42, 0.12);
+  --shadow-sm: 0 4px 14px rgba(15, 23, 42, 0.08);
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1.25rem;
+  --font-sans: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --transition: 180ms ease;
+  --container-width: min(720px, 100vw - 2rem);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  background: var(--color-bg);
+  color: var(--color-neutral-900);
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 1rem;
+  background: var(--color-primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  z-index: 1000;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  left: 1rem;
+}
+
+.site-header {
+  padding: 1.5rem 1rem 0.5rem;
+  text-align: center;
+}
+
+.site-header__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2rem);
+}
+
+.component-page {
+  width: var(--container-width);
+  margin: 0 auto 4rem;
+  padding-bottom: 4rem;
+}
+
+.component-page__intro {
+  font-size: 1rem;
+  color: var(--color-neutral-700);
+  margin-bottom: 2rem;
+}
+
+.component-preview {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.25rem, 4vw, 2rem);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.component-preview__title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.component-preview__description {
+  margin: 0;
+  color: var(--color-neutral-700);
+}
+
+.component-preview__example {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.component-meta {
+  font-size: 0.925rem;
+  color: var(--color-neutral-500);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--color-neutral-100);
+}
+
+.meta-pill svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: none;
+  background: var(--color-primary);
+  color: #fff;
+  padding: 0.65rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  background: var(--color-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn[aria-pressed="true"],
+.btn.is-active {
+  background: var(--color-primary-dark);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--color-neutral-900);
+  border: 1px solid var(--color-neutral-300);
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus-visible {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.btn--danger {
+  background: var(--color-danger);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary-dark);
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: clamp(1rem, 2vw, 1.5rem);
+  display: grid;
+  gap: 1rem;
+}
+
+.card--bordered {
+  border: 1px solid var(--color-neutral-300);
+  box-shadow: none;
+}
+
+.input-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.input-group label {
+  font-weight: 600;
+}
+
+.input {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-neutral-300);
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  background: #fff;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.input:focus-visible {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(36, 87, 245, 0.2);
+  outline: none;
+}
+
+.input--invalid {
+  border-color: var(--color-danger);
+}
+
+.form-help {
+  font-size: 0.85rem;
+  color: var(--color-neutral-500);
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  background: var(--color-neutral-100);
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+}
+
+.icon-button {
+  width: 2.75rem;
+  height: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-primary-soft);
+  color: var(--color-primary-dark);
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  background: var(--color-primary);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.icon-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Typography */
+.typography-demo h1 {
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin: 0;
+}
+
+.typography-demo h2 {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  margin-bottom: 0.75rem;
+}
+
+.typography-demo h3 {
+  font-size: clamp(1.25rem, 3vw, 1.7rem);
+}
+
+.typography-demo p {
+  color: var(--color-neutral-700);
+}
+
+.typography-demo blockquote {
+  margin: 0;
+  padding: 1rem 1.5rem;
+  border-left: 4px solid var(--color-primary);
+  background: var(--color-primary-soft);
+  border-radius: var(--radius-sm);
+}
+
+.typography-demo pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+}
+
+/* Audio player */
+.audio-player {
+  display: grid;
+  gap: 1rem;
+}
+
+.audio-player__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.audio-player__cover {
+  width: 80px;
+  aspect-ratio: 1;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+}
+
+.audio-tracklist {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.audio-track {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-neutral-100);
+}
+
+.audio-track.is-current {
+  background: var(--color-primary-soft);
+  color: var(--color-primary-dark);
+}
+
+/* Breadcrumbs */
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.breadcrumbs__item + .breadcrumbs__item::before {
+  content: "›";
+  color: var(--color-neutral-300);
+  margin: 0 0.35rem;
+}
+
+.breadcrumbs a {
+  color: var(--color-primary-dark);
+  text-decoration: none;
+}
+
+.breadcrumbs a:hover,
+.breadcrumbs a:focus {
+  text-decoration: underline;
+}
+
+/* Callout */
+.callout {
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  border: 1px solid transparent;
+}
+
+.callout__title {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.callout__icon {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.callout--info {
+  background: var(--color-primary-soft);
+  border-color: rgba(36, 87, 245, 0.2);
+}
+
+.callout--success {
+  background: rgba(27, 156, 133, 0.12);
+  border-color: rgba(27, 156, 133, 0.25);
+}
+
+.callout--warning {
+  background: rgba(242, 153, 74, 0.12);
+  border-color: rgba(242, 153, 74, 0.25);
+}
+
+/* Code snippets */
+.code-snippet {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.code-snippet__body {
+  position: relative;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  overflow-x: auto;
+}
+
+.copy-button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+}
+
+/* Contact form */
+.contact-form {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.contact-form__grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 600px) {
+  .contact-form__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* Cookie consent */
+.cookie-banner {
+  display: grid;
+  gap: 1rem;
+  background: var(--color-neutral-900);
+  color: #fff;
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+}
+
+.cookie-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cookie-banner__actions .btn--ghost {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+/* Date picker */
+.date-picker {
+  display: grid;
+  gap: 1rem;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.35rem;
+}
+
+.calendar-grid button {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.4rem;
+  background: var(--color-neutral-100);
+  cursor: pointer;
+}
+
+.calendar-grid button.is-muted {
+  color: var(--color-neutral-500);
+}
+
+.calendar-grid button.is-today {
+  border: 2px solid var(--color-primary);
+}
+
+.calendar-grid button.is-selected {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--color-neutral-500);
+}
+
+/* Dropdown */
+.dropdown {
+  position: relative;
+  display: inline-block;
+  width: min(320px, 100%);
+}
+
+.dropdown__button {
+  width: 100%;
+  justify-content: space-between;
+}
+
+.dropdown__panel {
+  position: absolute;
+  inset: auto 0 0;
+  translate: 0 calc(100% + 0.5rem);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 0.5rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--transition), visibility var(--transition);
+  z-index: 10;
+}
+
+.dropdown.is-open .dropdown__panel {
+  opacity: 1;
+  visibility: visible;
+}
+
+.dropdown__option {
+  width: 100%;
+  border: none;
+  background: none;
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-sm);
+}
+
+.dropdown__option[aria-selected="true"] {
+  background: var(--color-primary-soft);
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+  padding: 2rem 1.5rem;
+}
+
+.empty-state svg {
+  width: 80px;
+  margin: 0 auto;
+}
+
+/* File uploader */
+.file-uploader {
+  display: grid;
+  gap: 1rem;
+}
+
+.dropzone {
+  border: 2px dashed var(--color-neutral-300);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  text-align: center;
+  background: var(--color-neutral-100);
+  transition: border-color var(--transition), background var(--transition);
+}
+
+.dropzone.is-dragover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.upload-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.upload-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: var(--color-neutral-100);
+  border-radius: var(--radius-sm);
+}
+
+.progress-bar {
+  height: 0.35rem;
+  background: var(--color-neutral-300);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  background: var(--color-primary);
+  width: 0;
+}
+
+/* Filter facets */
+.facets {
+  display: grid;
+  gap: 1rem;
+}
+
+.facets details {
+  border-radius: var(--radius-md);
+  background: var(--color-neutral-100);
+  padding: 1rem;
+}
+
+.facets summary {
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+.facets summary::marker {
+  display: none;
+}
+
+.facets__options {
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+/* Image carousel */
+.carousel {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+}
+
+.carousel__slides {
+  display: flex;
+  transition: transform 400ms ease;
+}
+
+.carousel__slide {
+  min-width: 100%;
+  height: 220px;
+  position: relative;
+}
+
+.carousel__slide img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.carousel__controls {
+  position: absolute;
+  inset: auto 1rem 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.carousel__dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.carousel__dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.5);
+  border: none;
+}
+
+.carousel__dot[aria-current="true"] {
+  background: var(--color-primary);
+}
+
+/* Image with caption */
+.figure {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.figure figcaption {
+  color: var(--color-neutral-600);
+}
+
+/* Input field */
+.input-field {
+  display: grid;
+  gap: 1rem;
+}
+
+/* Loading spinner */
+.spinner {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 3px solid var(--color-neutral-300);
+  border-top-color: var(--color-primary);
+  animation: spin 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 3s;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Map embed */
+.map-frame {
+  width: 100%;
+  height: 280px;
+  border: 0;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Mini cart */
+.mini-cart {
+  display: grid;
+  gap: 1rem;
+}
+
+.cart-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.cart-item img {
+  width: 64px;
+  border-radius: var(--radius-sm);
+}
+
+.cart-summary {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+/* Modal */
+.modal-demo {
+  display: grid;
+  gap: 1rem;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.65);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--transition);
+}
+
+.modal[open] {
+  opacity: 1;
+  visibility: visible;
+}
+
+.modal__dialog {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  width: min(480px, 100%);
+  box-shadow: var(--shadow-md);
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+/* Multi-step wizard */
+.wizard {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.wizard__steps {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.wizard__step {
+  flex: 1;
+  padding: 0.6rem;
+  background: var(--color-neutral-100);
+  text-align: center;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+}
+
+.wizard__step[aria-current="step"] {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+/* Newsletter */
+.newsletter-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.newsletter-form__fields {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 520px) {
+  .newsletter-form__fields {
+    grid-template-columns: 2fr 1fr;
+    align-items: end;
+  }
+}
+
+/* Notification banner */
+.notification-banner {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-primary);
+  color: #fff;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.pagination__item {
+  display: inline-flex;
+}
+
+.pagination__link {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-neutral-300);
+  color: var(--color-neutral-700);
+  text-decoration: none;
+}
+
+.pagination__link[aria-current] {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+/* Popover */
+.popover {
+  position: relative;
+  display: inline-block;
+}
+
+.popover__panel {
+  position: absolute;
+  inset: auto auto auto 50%;
+  translate: -50% calc(0.5rem + 100%);
+  padding: 0.9rem 1rem;
+  background: var(--color-neutral-900);
+  color: #fff;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+  width: min(280px, 80vw);
+  opacity: 0;
+  visibility: hidden;
+}
+
+.popover.is-open .popover__panel {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Price comparison */
+.price-comparison {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .price-comparison {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.plan-card {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-neutral-300);
+  padding: 1.5rem 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.plan-card--highlight {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-sm);
+  position: relative;
+}
+
+.plan-card__price {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+/* Product card */
+.product-card {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 0;
+}
+
+.product-card__image {
+  position: relative;
+  aspect-ratio: 4 / 3;
+}
+
+.product-card__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.product-card__body {
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.product-card__price {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+/* Progress stepper */
+.stepper {
+  display: flex;
+  gap: 0.75rem;
+  overflow-x: auto;
+}
+
+.stepper__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--color-neutral-100);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+}
+
+.stepper__item[aria-current="step"] {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+/* Radio/checkbox toggle */
+.toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.toggle {
+  position: relative;
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+}
+
+.toggle label {
+  padding: 0.6rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-neutral-300);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.toggle input:checked + label {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+/* Review form */
+.review-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.rating-inputs {
+  display: inline-flex;
+  flex-direction: row-reverse;
+  gap: 0.35rem;
+}
+
+.rating-inputs input {
+  position: absolute;
+  opacity: 0;
+}
+
+.rating-inputs label {
+  font-size: 1.75rem;
+  color: var(--color-neutral-300);
+  cursor: pointer;
+}
+
+.rating-inputs input:checked ~ label,
+.rating-inputs label:hover,
+.rating-inputs label:hover ~ label {
+  color: #f7b500;
+}
+
+/* Review stars */
+.review-stars {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.review-stars__stars {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.review-stars__star {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+/* Search */
+.search-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.search-form__field {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+}
+
+/* Share buttons */
+.share-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+/* Skeleton loader */
+.skeleton-card {
+  display: grid;
+  gap: 0.75rem;
+  background: var(--color-neutral-100);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+.skeleton {
+  height: 0.8rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(203, 213, 225, 0.35), rgba(148, 163, 184, 0.45), rgba(203, 213, 225, 0.35));
+  background-size: 200% 100%;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Table */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.data-table caption {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-neutral-100);
+  text-align: left;
+}
+
+.data-table th {
+  background: var(--color-neutral-100);
+}
+
+.data-table thead th {
+  position: sticky;
+  top: 0;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+/* Table of contents */
+.toc {
+  border-radius: var(--radius-md);
+  background: var(--color-neutral-100);
+  padding: 1rem;
+}
+
+.toc__toggle {
+  width: 100%;
+  display: inline-flex;
+  justify-content: space-between;
+}
+
+.toc__list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+/* Tags badges */
+.badge-collection {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.badge--success {
+  background: rgba(27, 156, 133, 0.15);
+  color: var(--color-success);
+}
+
+.badge--warning {
+  background: rgba(242, 153, 74, 0.18);
+  color: var(--color-warning);
+}
+
+/* Toast */
+.toast-region {
+  position: fixed;
+  inset: auto 1rem 1rem auto;
+  display: grid;
+  gap: 0.5rem;
+  max-width: min(320px, 90vw);
+  z-index: 2000;
+}
+
+.toast {
+  background: var(--color-neutral-900);
+  color: #fff;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 0.35rem;
+}
+
+/* Tooltip */
+.tooltip {
+  position: relative;
+  display: inline-flex;
+}
+
+.tooltip__bubble {
+  position: absolute;
+  inset: auto 50% calc(100% + 0.75rem) auto;
+  translate: -50%;
+  background: var(--color-neutral-900);
+  color: #fff;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+  opacity: 0;
+  visibility: hidden;
+}
+
+.tooltip[aria-expanded="true"] .tooltip__bubble,
+.tooltip:focus-within .tooltip__bubble,
+.tooltip:hover .tooltip__bubble {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Trust badges */
+.trust-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.trust-badge {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-neutral-200);
+  width: 110px;
+}
+
+.trust-badge svg {
+  width: 32px;
+  height: 32px;
+}
+
+/* Video embed */
+.video-frame {
+  position: relative;
+  padding-top: 56.25%;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+}
+
+.video-frame iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+/* Mini utilities */
+.stack-sm {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.stack-md {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.flex-between {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.text-muted {
+  color: var(--color-neutral-500);
+}
+
+.text-success {
+  color: var(--color-success);
+}
+
+.text-warning {
+  color: var(--color-warning);
+}
+
+.text-danger {
+  color: var(--color-danger);
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+}
+
+@media (min-width: 960px) {
+  body {
+    background: linear-gradient(135deg, #edf2ff 0%, #f8fafc 100%);
+  }
+}

--- a/content-elements-examples/audio-embed.html
+++ b/content-elements-examples/audio-embed.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Audio Embed – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Audio Embed.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Audio Embed</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Einbettung eines Audio- oder Podcast-Players.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Keyboardsteuerung"><span aria-hidden="true">⚙️</span>Keyboardsteuerung</span><span class="meta-pill" role="listitem" aria-label="ARIA Live Feedback"><span aria-hidden="true">⚙️</span>ARIA Live Feedback</span><span class="meta-pill" role="listitem" aria-label="Responsive Layout"><span aria-hidden="true">⚙️</span>Responsive Layout</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="audio-player" data-audio-player>
+            <section class="card" aria-label="Aktuelle Episode">
+              <div class="audio-player__meta">
+                <img class="audio-player__cover" src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=320&q=80" alt="Podcast Cover: Remote Culture" loading="lazy">
+                <div>
+                  <p class="text-muted">Remote Culture • Episode 12</p>
+                  <h3 class="callout__title">Async Workflows, die funktionieren</h3>
+                  <p class="text-muted">Mit Host Mara und Gast Daniel Fuchs</p>
+                </div>
+              </div>
+              <audio controls preload="metadata" data-audio-element aria-describedby="audio-status">
+                <source src="https://upload.wikimedia.org/wikipedia/commons/4/4e/BWV_543-fugue.ogg" type="audio/ogg">
+                <source src="https://upload.wikimedia.org/wikipedia/commons/4/4e/BWV_543-fugue.ogg" type="audio/mpeg">
+                Ihr Browser unterstützt das Audio-Element nicht. <a href="https://upload.wikimedia.org/wikipedia/commons/4/4e/BWV_543-fugue.ogg">Episode herunterladen</a>.
+              </audio>
+              <div id="audio-status" class="visually-hidden" aria-live="polite"></div>
+            </section>
+            <section class="audio-tracklist" role="list" aria-label="Weitere Episoden">
+              <button class="audio-track is-current" type="button" role="listitem" data-audio-track data-src="https://upload.wikimedia.org/wikipedia/commons/4/4e/BWV_543-fugue.ogg" data-title="Async Workflows, die funktionieren" aria-pressed="true">
+                <span>Async Workflows, die funktionieren</span>
+                <span class="text-muted">24:32</span>
+              </button>
+              <button class="audio-track" type="button" role="listitem" data-audio-track data-src="https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg" data-title="Führung auf Distanz" aria-pressed="false">
+                <span>Führung auf Distanz</span>
+                <span class="text-muted">18:05</span>
+              </button>
+              <button class="audio-track" type="button" role="listitem" data-audio-track data-src="https://upload.wikimedia.org/wikipedia/commons/3/32/Example_3.ogg" data-title="Async Feedback Loops" aria-pressed="false">
+                <span>Async Feedback Loops</span>
+                <span class="text-muted">21:11</span>
+              </button>
+            </section>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/breadcrumbs.html
+++ b/content-elements-examples/breadcrumbs.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Breadcrumbs – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Breadcrumbs.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Breadcrumbs</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Hierarchische Navigation zur Orientierung im Seitensystem.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Semantische Navigation"><span aria-hidden="true">⚙️</span>Semantische Navigation</span><span class="meta-pill" role="listitem" aria-label="Touch-Ziele optimiert"><span aria-hidden="true">⚙️</span>Touch-Ziele optimiert</span><span class="meta-pill" role="listitem" aria-label="SR-Label"><span aria-hidden="true">⚙️</span>SR-Label</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <nav class="card" aria-label="Brotkrumen">
+            <ol class="breadcrumbs">
+              <li class="breadcrumbs__item"><a href="#">Startseite</a></li>
+              <li class="breadcrumbs__item"><a href="#">Dokumentation</a></li>
+              <li class="breadcrumbs__item"><a href="#">Designsystem</a></li>
+              <li class="breadcrumbs__item" aria-current="page"><span>Content Elemente</span></li>
+            </ol>
+          </nav>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/callout-box.html
+++ b/content-elements-examples/callout-box.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Callout Box – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Callout Box.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Callout Box</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Hervorgehobene Boxen für Hinweise, Warnungen oder Erfolgsnachrichten innerhalb von Inhalten.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="ARIA Rollen"><span aria-hidden="true">⚙️</span>ARIA Rollen</span><span class="meta-pill" role="listitem" aria-label="Kontrast geprüft"><span aria-hidden="true">⚙️</span>Kontrast geprüft</span><span class="meta-pill" role="listitem" aria-label="Icon dekorativ"><span aria-hidden="true">⚙️</span>Icon dekorativ</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <aside class="callout callout--info" aria-label="Hinweis">
+            <div class="flex-between">
+              <div class="stack-sm">
+                <h3 class="callout__title">Backup nicht vergessen</h3>
+                <p>Planen Sie automatische Sicherungen, um Ihre Inhalte jederzeit wiederherstellen zu können.</p>
+              </div>
+              <svg class="callout__icon" aria-hidden="true" viewBox="0 0 24 24" fill="none">
+                <circle cx="12" cy="12" r="11" stroke="currentColor" stroke-width="2"></circle>
+                <path d="M12 7v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+                <circle cx="12" cy="17" r="1" fill="currentColor"></circle>
+              </svg>
+            </div>
+          </aside>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/code-snippets.html
+++ b/content-elements-examples/code-snippets.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Code Snippets – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Code Snippets.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Code Snippets</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Darstellung von Codebeispielen als Inline- oder Block-Elemente inkl. Kopierfunktion.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Copy to Clipboard"><span aria-hidden="true">⚙️</span>Copy to Clipboard</span><span class="meta-pill" role="listitem" aria-label="ARIA Live Regionen"><span aria-hidden="true">⚙️</span>ARIA Live Regionen</span><span class="meta-pill" role="listitem" aria-label="Syntax freundlich"><span aria-hidden="true">⚙️</span>Syntax freundlich</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <figure class="code-snippet" data-code-snippet>
+            <figcaption>POST-Anfrage gegen die Content API</figcaption>
+            <pre class="code-snippet__body"><code id="snippet-js" data-language="bash">curl --request POST \
+            --url https://api.example.com/v1/entries \
+            --header 'Content-Type: application/json' \
+            --data '{"title": "Accessibility first"}'</code></pre>
+            <button class="btn copy-button" type="button" data-copy-button data-copy-target="snippet-js" aria-live="polite">Code kopieren</button>
+            <output class="visually-hidden" aria-live="polite" data-copy-feedback></output>
+          </figure>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/component_data.py
+++ b/content-elements-examples/component_data.py
@@ -1,0 +1,979 @@
+from __future__ import annotations
+
+COMPONENTS: dict[str, dict[str, object]] = {
+    "audio-embed": {
+        "meta": [
+            "Keyboardsteuerung",
+            "ARIA Live Feedback",
+            "Responsive Layout"
+        ],
+        "example": """
+<div class="audio-player" data-audio-player>
+  <section class="card" aria-label="Aktuelle Episode">
+    <div class="audio-player__meta">
+      <img class="audio-player__cover" src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=320&q=80" alt="Podcast Cover: Remote Culture" loading="lazy">
+      <div>
+        <p class="text-muted">Remote Culture • Episode 12</p>
+        <h3 class="callout__title">Async Workflows, die funktionieren</h3>
+        <p class="text-muted">Mit Host Mara und Gast Daniel Fuchs</p>
+      </div>
+    </div>
+    <audio controls preload="metadata" data-audio-element aria-describedby="audio-status">
+      <source src="https://upload.wikimedia.org/wikipedia/commons/4/4e/BWV_543-fugue.ogg" type="audio/ogg">
+      <source src="https://upload.wikimedia.org/wikipedia/commons/4/4e/BWV_543-fugue.ogg" type="audio/mpeg">
+      Ihr Browser unterstützt das Audio-Element nicht. <a href="https://upload.wikimedia.org/wikipedia/commons/4/4e/BWV_543-fugue.ogg">Episode herunterladen</a>.
+    </audio>
+    <div id="audio-status" class="visually-hidden" aria-live="polite"></div>
+  </section>
+  <section class="audio-tracklist" role="list" aria-label="Weitere Episoden">
+    <button class="audio-track is-current" type="button" role="listitem" data-audio-track data-src="https://upload.wikimedia.org/wikipedia/commons/4/4e/BWV_543-fugue.ogg" data-title="Async Workflows, die funktionieren" aria-pressed="true">
+      <span>Async Workflows, die funktionieren</span>
+      <span class="text-muted">24:32</span>
+    </button>
+    <button class="audio-track" type="button" role="listitem" data-audio-track data-src="https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg" data-title="Führung auf Distanz" aria-pressed="false">
+      <span>Führung auf Distanz</span>
+      <span class="text-muted">18:05</span>
+    </button>
+    <button class="audio-track" type="button" role="listitem" data-audio-track data-src="https://upload.wikimedia.org/wikipedia/commons/3/32/Example_3.ogg" data-title="Async Feedback Loops" aria-pressed="false">
+      <span>Async Feedback Loops</span>
+      <span class="text-muted">21:11</span>
+    </button>
+  </section>
+</div>
+""",
+    },
+    "breadcrumbs": {
+        "meta": [
+            "Semantische Navigation",
+            "Touch-Ziele optimiert",
+            "SR-Label"
+        ],
+        "example": """
+<nav class="card" aria-label="Brotkrumen">
+  <ol class="breadcrumbs">
+    <li class="breadcrumbs__item"><a href="#">Startseite</a></li>
+    <li class="breadcrumbs__item"><a href="#">Dokumentation</a></li>
+    <li class="breadcrumbs__item"><a href="#">Designsystem</a></li>
+    <li class="breadcrumbs__item" aria-current="page"><span>Content Elemente</span></li>
+  </ol>
+</nav>
+""",
+    },
+    "callout-box": {
+        "meta": [
+            "ARIA Rollen",
+            "Kontrast geprüft",
+            "Icon dekorativ"
+        ],
+        "example": """
+<aside class="callout callout--info" aria-label="Hinweis">
+  <div class="flex-between">
+    <div class="stack-sm">
+      <h3 class="callout__title">Backup nicht vergessen</h3>
+      <p>Planen Sie automatische Sicherungen, um Ihre Inhalte jederzeit wiederherstellen zu können.</p>
+    </div>
+    <svg class="callout__icon" aria-hidden="true" viewBox="0 0 24 24" fill="none">
+      <circle cx="12" cy="12" r="11" stroke="currentColor" stroke-width="2"></circle>
+      <path d="M12 7v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+      <circle cx="12" cy="17" r="1" fill="currentColor"></circle>
+    </svg>
+  </div>
+</aside>
+""",
+    },
+    "code-snippets": {
+        "meta": [
+            "Copy to Clipboard",
+            "ARIA Live Regionen",
+            "Syntax freundlich"
+        ],
+        "example": """
+<figure class="code-snippet" data-code-snippet>
+  <figcaption>POST-Anfrage gegen die Content API</figcaption>
+  <pre class="code-snippet__body"><code id="snippet-js" data-language="bash">curl --request POST \\
+  --url https://api.example.com/v1/entries \\
+  --header 'Content-Type: application/json' \\
+  --data '{"title": "Accessibility first"}'</code></pre>
+  <button class="btn copy-button" type="button" data-copy-button data-copy-target="snippet-js" aria-live="polite">Code kopieren</button>
+  <output class="visually-hidden" aria-live="polite" data-copy-feedback></output>
+</figure>
+""",
+    },
+    "contact-form": {
+        "meta": [
+            "Form Validation",
+            "Mobile optimiert",
+            "Fokusführung"
+        ],
+        "example": """
+<form class="contact-form" data-contact-form novalidate>
+  <div class="contact-form__grid">
+    <div class="input-group">
+      <label for="cf-name">Name</label>
+      <input class="input" id="cf-name" name="name" type="text" autocomplete="name" required>
+      <p class="form-help">Pflichtfeld – mindestens 2 Zeichen.</p>
+    </div>
+    <div class="input-group">
+      <label for="cf-email">E-Mail</label>
+      <input class="input" id="cf-email" name="email" type="email" autocomplete="email" inputmode="email" required>
+    </div>
+  </div>
+  <div class="input-group">
+    <label for="cf-topic">Thema</label>
+    <select class="input" id="cf-topic" name="topic">
+      <option value="support">Technischer Support</option>
+      <option value="sales">Beratung &amp; Angebote</option>
+      <option value="feedback">Feedback</option>
+    </select>
+  </div>
+  <div class="input-group">
+    <label for="cf-message">Nachricht</label>
+    <textarea class="input" id="cf-message" name="message" rows="4" maxlength="500" required></textarea>
+    <p class="form-help">Maximal 500 Zeichen.</p>
+  </div>
+  <div class="flex-between">
+    <label class="input-group" style="flex-direction: row; gap: 0.5rem; align-items: center;">
+      <input type="checkbox" name="privacy" required>
+      <span>Ich akzeptiere die <a href="#">Datenschutzerklärung</a>.</span>
+    </label>
+    <button class="btn" type="submit">Absenden</button>
+  </div>
+  <p class="form-help" aria-live="polite" data-form-feedback></p>
+</form>
+""",
+    },
+    "cookie-consent": {
+        "meta": [
+            "Consent Kategorien",
+            "Persistenz Demo",
+            "Barrierefrei"
+        ],
+        "example": """
+<section class="cookie-banner" role="dialog" aria-modal="true" aria-live="assertive" data-cookie-banner>
+  <div class="stack-md">
+    <h2>Wir respektieren Ihre Privatsphäre</h2>
+    <p>Wir verwenden Cookies, um Ihr Erlebnis zu verbessern. Passen Sie Ihre Auswahl jederzeit an.</p>
+    <details>
+      <summary>Details anzeigen</summary>
+      <ul class="stack-sm" style="margin: 0; padding-left: 1rem;">
+        <li><strong>Essentiell:</strong> notwendig für die Seitennutzung.</li>
+        <li><strong>Statistik:</strong> hilft uns, Inhalte zu optimieren.</li>
+        <li><strong>Marketing:</strong> personalisierte Angebote.</li>
+      </ul>
+    </details>
+  </div>
+  <div class="cookie-banner__actions">
+    <button class="btn" type="button" data-consent-action="accept">Alle akzeptieren</button>
+    <button class="btn btn--ghost" type="button" data-consent-action="essentials">Nur essentielle</button>
+    <button class="btn btn--ghost" type="button" data-consent-open-settings>Individuell</button>
+  </div>
+</section>
+""",
+    },
+    "date-picker": {
+        "meta": [
+            "WAI-ARIA Grid",
+            "Tastatur Navigation",
+            "Locale aware"
+        ],
+        "example": """
+<div class="date-picker" data-date-picker data-start-month="2025-05">
+  <div class="input-group">
+    <label for="date-input">Reisedatum</label>
+    <input class="input" id="date-input" name="date" type="text" autocomplete="off" inputmode="numeric" placeholder="TT.MM.JJJJ" data-date-input aria-describedby="date-hint">
+    <p id="date-hint" class="form-help">Mit Pfeiltasten durch den Kalender navigieren. Native Eingabe: <input type="date" aria-label="Datum auswählen" style="display:inline-block; max-width: 150px;"></p>
+  </div>
+  <section class="card card--bordered" aria-labelledby="calendar-title">
+    <div class="flex-between">
+      <button class="icon-button" type="button" data-calendar-prev aria-label="Vorheriger Monat">
+        <span aria-hidden="true">◀</span>
+      </button>
+      <p id="calendar-title" class="text-muted" data-calendar-title>Mai 2025</p>
+      <button class="icon-button" type="button" data-calendar-next aria-label="Nächster Monat">
+        <span aria-hidden="true">▶</span>
+      </button>
+    </div>
+    <div class="calendar-weekdays" aria-hidden="true">
+      <span>Mo</span><span>Di</span><span>Mi</span><span>Do</span><span>Fr</span><span>Sa</span><span>So</span>
+    </div>
+    <div class="calendar-grid" role="grid" aria-labelledby="calendar-title" data-calendar-grid></div>
+  </section>
+</div>
+""",
+    },
+    "dropdown-select": {
+        "meta": [
+            "Roving Tabindex",
+            "Touch friendly",
+            "Hidden Input"
+        ],
+        "example": """
+<div class="dropdown" data-dropdown>
+  <label for="team-size">Teamgröße</label>
+  <button class="btn dropdown__button" type="button" id="team-size" data-dropdown-toggle aria-haspopup="listbox" aria-expanded="false">
+    <span data-dropdown-label>1–10 Personen</span>
+    <span aria-hidden="true">▾</span>
+  </button>
+  <ul class="dropdown__panel" role="listbox" tabindex="-1" aria-labelledby="team-size" data-dropdown-list>
+    <li><button class="dropdown__option" type="button" role="option" aria-selected="true" data-value="small">1–10 Personen</button></li>
+    <li><button class="dropdown__option" type="button" role="option" aria-selected="false" data-value="medium">11–25 Personen</button></li>
+    <li><button class="dropdown__option" type="button" role="option" aria-selected="false" data-value="large">26–50 Personen</button></li>
+    <li><button class="dropdown__option" type="button" role="option" aria-selected="false" data-value="enterprise">Mehr als 50</button></li>
+  </ul>
+  <input type="hidden" name="team-size" value="small" data-dropdown-input>
+</div>
+""",
+    },
+    "empty-state": {
+        "meta": [
+            "Illustration inklusive",
+            "Handlungsaufforderung",
+            "Screenreader Text"
+        ],
+        "example": """
+<section class="empty-state" role="status" aria-live="polite">
+  <svg viewBox="0 0 64 64" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2">
+    <circle cx="32" cy="32" r="30" opacity="0.2"></circle>
+    <path d="M18 38h28" stroke-linecap="round"></path>
+    <path d="M24 30l8-10 8 10" stroke-linecap="round" stroke-linejoin="round"></path>
+  </svg>
+  <h2>Keine Ergebnisse – noch.</h2>
+  <p>Versuchen Sie es mit anderen Filtern oder erstellen Sie einen neuen Eintrag.</p>
+  <div class="share-buttons" role="group">
+    <button class="btn" type="button">Filter zurücksetzen</button>
+    <button class="btn btn--ghost" type="button">Eintrag erstellen</button>
+  </div>
+</section>
+""",
+    },
+    "file-uploader": {
+        "meta": [
+            "Drag & Drop",
+            "Fortschrittsanzeige",
+            "Mehrere Dateien"
+        ],
+        "example": """
+<section class="file-uploader" data-file-uploader>
+  <div class="dropzone" tabindex="0" role="button" aria-label="Dateien hier ablegen oder klicken" data-dropzone>
+    <p><strong>Dateien auswählen</strong></p>
+    <p class="text-muted">Ziehen Sie Dateien hierher oder klicken Sie, um zu wählen. Maximal 10 Dateien.</p>
+    <input class="visually-hidden" type="file" name="documents" id="documents" multiple data-file-input>
+  </div>
+  <div class="upload-list" aria-live="polite" data-upload-list></div>
+</section>
+""",
+    },
+    "filter-facets": {
+        "meta": [
+            "Akkordeon",
+            "Checkbox Gruppen",
+            "Keyboard Fokus"
+        ],
+        "example": """
+<aside class="facets" aria-label="Filter">
+  <details open>
+    <summary>Rollen</summary>
+    <div class="facets__options">
+      <label><input type="checkbox" name="role" value="design" checked> Design</label>
+      <label><input type="checkbox" name="role" value="engineering"> Engineering</label>
+      <label><input type="checkbox" name="role" value="product"> Produkt</label>
+    </div>
+  </details>
+  <details>
+    <summary>Standorte</summary>
+    <div class="facets__options">
+      <label><input type="checkbox" name="location" value="remote"> Remote</label>
+      <label><input type="checkbox" name="location" value="berlin"> Berlin</label>
+      <label><input type="checkbox" name="location" value="muenchen"> München</label>
+    </div>
+  </details>
+</aside>
+""",
+    },
+    "image-carousel": {
+        "meta": [
+            "Swipe-ready",
+            "ARIA Live",
+            "Lazy Loading"
+        ],
+        "example": """
+<section class="carousel" data-carousel aria-roledescription="Karussell" aria-label="Produktbilder">
+  <div class="carousel__slides" data-carousel-track>
+    <figure class="carousel__slide" data-carousel-slide>
+      <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80" alt="Offenes, helles Wohnzimmer" loading="lazy">
+      <figcaption class="visually-hidden">Wohnbereich mit natürlichem Licht</figcaption>
+    </figure>
+    <figure class="carousel__slide" data-carousel-slide>
+      <img src="https://images.unsplash.com/photo-1586023492125-27b2c045efd7?auto=format&fit=crop&w=900&q=80" alt="Moderne Küche mit Holzdekor" loading="lazy">
+      <figcaption class="visually-hidden">Moderne Küche</figcaption>
+    </figure>
+    <figure class="carousel__slide" data-carousel-slide>
+      <img src="https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=900&q=80" alt="Gemütliches Schlafzimmer mit Pflanzen" loading="lazy">
+      <figcaption class="visually-hidden">Schlafzimmer mit Pflanzen</figcaption>
+    </figure>
+  </div>
+  <div class="carousel__controls" aria-hidden="true">
+    <button class="icon-button" type="button" data-carousel-prev aria-label="Vorheriges Bild">◀</button>
+    <button class="icon-button" type="button" data-carousel-next aria-label="Nächstes Bild">▶</button>
+  </div>
+</section>
+<div class="carousel__dots" role="tablist" data-carousel-dots>
+  <button class="carousel__dot" type="button" role="tab" aria-controls="slide-1" aria-current="true"></button>
+  <button class="carousel__dot" type="button" role="tab" aria-controls="slide-2"></button>
+  <button class="carousel__dot" type="button" role="tab" aria-controls="slide-3"></button>
+</div>
+""",
+    },
+    "image-with-caption": {
+        "meta": [
+            "Figure &amp; Figcaption",
+            "Responsive Bilder",
+            "Lazy loading"
+        ],
+        "example": """
+<figure class="figure">
+  <picture>
+    <source srcset="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=900&q=80" media="(min-width: 800px)">
+    <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=600&q=80" alt="Team, das gemeinsam an einem Tisch arbeitet" loading="lazy">
+  </picture>
+  <figcaption>Team Sync im Workspace Berlin – Foto: <a href="https://unsplash.com" rel="noopener">Unsplash</a></figcaption>
+</figure>
+""",
+    },
+    "input-field": {
+        "meta": [
+            "Inline Fehlermeldung",
+            "Charakterbegrenzung",
+            "State Styling"
+        ],
+        "example": """
+<section class="input-field" aria-live="polite">
+  <div class="input-group">
+    <label for="input-username">Benutzername</label>
+    <input class="input" id="input-username" name="username" type="text" placeholder="z. B. ux-nerd" minlength="3" maxlength="20" required data-input-with-counter>
+    <p class="form-help"><span data-input-counter>0</span>/20 Zeichen</p>
+  </div>
+  <div class="input-group">
+    <label for="input-password">Passwort</label>
+    <div style="position: relative;">
+      <input class="input" id="input-password" name="password" type="password" required aria-describedby="password-hint">
+      <button class="btn btn--ghost" type="button" data-toggle-password style="position:absolute; top:50%; right:0.5rem; transform:translateY(-50%);">Anzeigen</button>
+    </div>
+    <p id="password-hint" class="form-help">Mindestens 8 Zeichen, Groß-/Kleinschreibung sowie Zahl.</p>
+  </div>
+</section>
+""",
+    },
+    "loading-spinner": {
+        "meta": [
+            "Reduced Motion",
+            "Role Status",
+            "Contrast optimiert"
+        ],
+        "example": """
+<div class="card" role="status" aria-live="polite">
+  <div class="spinner" aria-hidden="true"></div>
+  <p>Daten werden geladen …</p>
+  <p class="form-help">Sollte der Vorgang länger dauern als 30 Sekunden, aktualisieren Sie die Seite.</p>
+</div>
+""",
+    },
+    "map-embed": {
+        "meta": [
+            "Iframe Titel",
+            "Fallback Link",
+            "Lazy Loading"
+        ],
+        "example": """
+<section class="card">
+  <h2>Büro Berlin</h2>
+  <p class="text-muted">Invalidenstraße 91, 10115 Berlin</p>
+  <iframe class="map-frame" loading="lazy" src="https://www.openstreetmap.org/export/embed.html?bbox=13.3789%2C52.5294%2C13.3839%2C52.5324&amp;layer=mapnik" title="Karte des Büros in Berlin"></iframe>
+  <p><a href="https://www.openstreetmap.org/?mlat=52.531&amp;mlon=13.381#map=18/52.5310/13.3810" target="_blank" rel="noopener">Auf OpenStreetMap öffnen</a></p>
+</section>
+""",
+    },
+    "mini-cart": {
+        "meta": [
+            "Live Aktualisierung",
+            "Accessible Pricing",
+            "Keyboard ready"
+        ],
+        "example": """
+<section class="mini-cart" data-mini-cart aria-label="Mini Warenkorb">
+  <div class="cart-item" data-cart-item>
+    <img src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=200&q=80" alt="Kabellose Kopfhörer" loading="lazy">
+    <div>
+      <p>Kabellose Kopfhörer</p>
+      <p class="text-muted">Lieferung in 2-3 Tagen</p>
+      <label class="visually-hidden" for="item-1">Anzahl</label>
+      <input class="input" id="item-1" type="number" min="1" value="1" data-item-qty>
+    </div>
+    <strong data-item-price="129.90">129,90 €</strong>
+  </div>
+  <div class="cart-item" data-cart-item>
+    <img src="https://images.unsplash.com/photo-1512496015851-a90fb38ba796?auto=format&fit=crop&w=200&q=80" alt="Leder Schreibtischunterlage" loading="lazy">
+    <div>
+      <p>Leder Desk Pad</p>
+      <p class="text-muted">Nachhaltiges Leder</p>
+      <label class="visually-hidden" for="item-2">Anzahl</label>
+      <input class="input" id="item-2" type="number" min="1" value="2" data-item-qty>
+    </div>
+    <strong data-item-price="59.90">59,90 €</strong>
+  </div>
+  <div class="cart-summary">
+    <span>Zwischensumme</span>
+    <span data-cart-total>249,70 €</span>
+  </div>
+  <button class="btn" type="button">Zur Kasse</button>
+</section>
+""",
+    },
+    "modal": {
+        "meta": [
+            "Focus Trap",
+            "Escape schließt",
+            "Aria Beschriftung"
+        ],
+        "example": """
+<section class="modal-demo">
+  <button class="btn" type="button" data-open-modal="#newsletter-modal">Neuigkeiten abonnieren</button>
+  <dialog class="modal" id="newsletter-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal__dialog">
+      <header class="modal__header">
+        <h2 id="modal-title">Wöchentlicher Newsletter</h2>
+        <button class="icon-button" type="button" data-close-modal aria-label="Modal schließen">✕</button>
+      </header>
+      <p>Erhalten Sie Updates zu Produkt-Releases und Best Practices direkt in Ihr Postfach.</p>
+      <form class="newsletter-form" data-newsletter-modal>
+        <label class="visually-hidden" for="modal-email">E-Mail-Adresse</label>
+        <input class="input" id="modal-email" type="email" name="email" placeholder="name@example.com" required>
+        <button class="btn" type="submit">Abonnieren</button>
+      </form>
+    </div>
+  </dialog>
+</section>
+""",
+    },
+    "multi-step-wizard": {
+        "meta": [
+            "ARIA Current",
+            "Progressive Disclosure",
+            "Keyboard Navigation"
+        ],
+        "example": """
+<section class="wizard" data-wizard>
+  <div class="wizard__steps" role="list" aria-label="Setup Schritte">
+    <span class="wizard__step" role="listitem" aria-current="step">Profil</span>
+    <span class="wizard__step" role="listitem">Team</span>
+    <span class="wizard__step" role="listitem">Bestätigung</span>
+  </div>
+  <form class="card" data-wizard-step="0">
+    <div class="input-group">
+      <label for="wizard-name">Name</label>
+      <input class="input" id="wizard-name" required>
+    </div>
+    <div class="input-group">
+      <label for="wizard-role">Rolle</label>
+      <select class="input" id="wizard-role">
+        <option>Produktmanager:in</option>
+        <option>Designer:in</option>
+        <option>Developer:in</option>
+      </select>
+    </div>
+    <div class="flex-between">
+      <span></span>
+      <button class="btn" type="button" data-wizard-next>Weiter</button>
+    </div>
+  </form>
+  <form class="card" hidden data-wizard-step="1">
+    <div class="input-group">
+      <label for="wizard-team-size">Teamgröße</label>
+      <input class="input" id="wizard-team-size" type="number" min="1" value="5">
+    </div>
+    <div class="flex-between">
+      <button class="btn btn--ghost" type="button" data-wizard-prev>Zurück</button>
+      <button class="btn" type="button" data-wizard-next>Weiter</button>
+    </div>
+  </form>
+  <form class="card" hidden data-wizard-step="2">
+    <p>Alles bereit! Wir senden Ihnen einen Bestätigungslink.</p>
+    <div class="flex-between">
+      <button class="btn btn--ghost" type="button" data-wizard-prev>Zurück</button>
+      <button class="btn" type="submit">Setup abschließen</button>
+    </div>
+  </form>
+</section>
+""",
+    },
+    "newsletter-optin": {
+        "meta": [
+            "Double Opt-in Hinweis",
+            "Inline Validierung",
+            "Success Feedback"
+        ],
+        "example": """
+<form class="newsletter-form" data-newsletter>
+  <div class="newsletter-form__fields">
+    <div class="input-group">
+      <label for="newsletter-email">E-Mail-Adresse</label>
+      <input class="input" id="newsletter-email" name="email" type="email" placeholder="you@example.com" required>
+      <p class="form-help">Wir senden einen Double-Opt-in-Link.</p>
+    </div>
+    <button class="btn" type="submit">Anmelden</button>
+  </div>
+  <label class="input-group" style="flex-direction: row; gap: 0.5rem; align-items: center;">
+    <input type="checkbox" name="news-privacy" required>
+    <span>Ich stimme dem Erhalt des Newsletters zu.</span>
+  </label>
+  <p class="form-help" data-newsletter-feedback aria-live="polite"></p>
+</form>
+""",
+    },
+    "notification-banner": {
+        "meta": [
+            "Role Status",
+            "Close Button",
+            "Keyboard Fokus"
+        ],
+        "example": """
+<section class="notification-banner" role="status" data-notification-banner>
+  <div class="flex-between">
+    <div>
+      <strong>Neue Version verfügbar!</strong>
+      <p class="text-muted" style="color: rgba(255,255,255,0.8);">Aktualisieren Sie jetzt, um von Performance-Optimierungen zu profitieren.</p>
+    </div>
+    <button class="icon-button" type="button" aria-label="Benachrichtigung schließen" data-dismiss-banner>✕</button>
+  </div>
+</section>
+""",
+    },
+    "pagination": {
+        "meta": [
+            "ARIA Labels",
+            "Erweiterte Klickflächen",
+            "Responsives Layout"
+        ],
+        "example": """
+<nav aria-label="Seiten Navigation">
+  <ul class="pagination">
+    <li class="pagination__item"><a class="pagination__link" href="#" aria-label="Vorherige Seite">‹</a></li>
+    <li class="pagination__item"><a class="pagination__link" href="#">1</a></li>
+    <li class="pagination__item"><a class="pagination__link" href="#" aria-current="page">2</a></li>
+    <li class="pagination__item"><a class="pagination__link" href="#">3</a></li>
+    <li class="pagination__item"><a class="pagination__link" href="#" aria-label="Nächste Seite">›</a></li>
+  </ul>
+</nav>
+""",
+    },
+    "popover": {
+        "meta": [
+            "Focus Management",
+            "Auto Close",
+            "ARIA Controls"
+        ],
+        "example": """
+<div class="popover" data-popover>
+  <button class="btn btn--ghost" type="button" data-popover-toggle aria-expanded="false" aria-controls="popover-panel">Mehr Infos</button>
+  <div class="popover__panel" id="popover-panel" role="dialog">
+    <p><strong>Warum wir fragen:</strong></p>
+    <p class="text-muted">Wir nutzen Ihre Angaben, um personalisierte Empfehlungen zu erstellen. Ihre Daten bleiben privat.</p>
+    <button class="btn btn--ghost" type="button" data-popover-close>Verstanden</button>
+  </div>
+</div>
+""",
+    },
+    "price-comparison": {
+        "meta": [
+            "Responsive Karten",
+            "Highlight Tarif",
+            "Semantische Listen"
+        ],
+        "example": """
+<section class="price-comparison">
+  <article class="plan-card" aria-label="Starter Tarif">
+    <span class="badge">Starter</span>
+    <p class="plan-card__price">19 €<span class="text-muted" style="font-size:0.9rem;">/Monat</span></p>
+    <ul class="stack-sm" style="padding-left: 1rem; margin: 0;">
+      <li>Bis zu 5 Projekte</li>
+      <li>E-Mail Support</li>
+      <li>Community Zugang</li>
+    </ul>
+    <button class="btn btn--ghost" type="button">Jetzt starten</button>
+  </article>
+  <article class="plan-card plan-card--highlight" aria-label="Professional Tarif">
+    <span class="badge badge--success">Beliebt</span>
+    <p class="plan-card__price">39 €<span class="text-muted" style="font-size:0.9rem;">/Monat</span></p>
+    <ul class="stack-sm" style="padding-left: 1rem; margin: 0;">
+      <li>Unbegrenzte Projekte</li>
+      <li>Fortgeschrittene Automatisierung</li>
+      <li>Priorisierter Support</li>
+    </ul>
+    <button class="btn" type="button">Kostenlos testen</button>
+  </article>
+  <article class="plan-card" aria-label="Enterprise Tarif">
+    <span class="badge badge--warning">Enterprise</span>
+    <p class="plan-card__price">Auf Anfrage</p>
+    <ul class="stack-sm" style="padding-left: 1rem; margin: 0;">
+      <li>Dedizierte Betreuung</li>
+      <li>Single Sign-On</li>
+      <li>Custom SLAs</li>
+    </ul>
+    <button class="btn btn--ghost" type="button">Kontakt aufnehmen</button>
+  </article>
+</section>
+""",
+    },
+    "product-card": {
+        "meta": [
+            "Bildverhältnis",
+            "Preis Hervorhebung",
+            "Bewertung"
+        ],
+        "example": """
+<article class="product-card">
+  <div class="product-card__image">
+    <img src="https://images.unsplash.com/photo-1512499617640-c2f999098c01?auto=format&fit=crop&w=800&q=80" alt="Minimalistischer Bürostuhl in Grau" loading="lazy">
+  </div>
+  <div class="product-card__body">
+    <div class="review-stars">
+      <div class="review-stars__stars" aria-label="4,8 von 5 Sternen">
+        <span aria-hidden="true">★ ★ ★ ★ ☆</span>
+      </div>
+      <span class="text-muted">(128)</span>
+    </div>
+    <h2>Ergonomischer Chair One</h2>
+    <p class="text-muted">Atmungsaktives Mesh, 4D Armlehnen, Sitzhöhenverstellung.</p>
+    <p class="product-card__price">349 €</p>
+    <div class="share-buttons" role="group" aria-label="Produktaktionen">
+      <button class="btn" type="button">In den Warenkorb</button>
+      <button class="btn btn--ghost" type="button">Merken</button>
+    </div>
+  </div>
+</article>
+""",
+    },
+    "progress-stepper": {
+        "meta": [
+            "ARIA Current",
+            "Responsives Scrolling",
+            "Iconische Darstellung"
+        ],
+        "example": """
+<nav class="stepper" aria-label="Bestellfortschritt">
+  <span class="stepper__item" aria-current="step">
+    <span aria-hidden="true">1</span>
+    <span>Adresse</span>
+  </span>
+  <span class="stepper__item">
+    <span aria-hidden="true">2</span>
+    <span>Versand</span>
+  </span>
+  <span class="stepper__item">
+    <span aria-hidden="true">3</span>
+    <span>Zahlung</span>
+  </span>
+</nav>
+""",
+    },
+    "radio-checkbox-toggle": {
+        "meta": [
+            "ARIA Checked",
+            "Benutzerdefinierte Toggle",
+            "Form Integration"
+        ],
+        "example": """
+<fieldset class="toggle-group">
+  <legend>Benachrichtigungen</legend>
+  <div class="toggle">
+    <input type="checkbox" id="toggle-email" name="notifications" value="email" checked>
+    <label for="toggle-email">E-Mail</label>
+  </div>
+  <div class="toggle">
+    <input type="checkbox" id="toggle-push" name="notifications" value="push">
+    <label for="toggle-push">Push</label>
+  </div>
+  <div class="toggle">
+    <input type="radio" id="toggle-daily" name="digest" value="daily" checked>
+    <label for="toggle-daily">Täglich</label>
+  </div>
+  <div class="toggle">
+    <input type="radio" id="toggle-weekly" name="digest" value="weekly">
+    <label for="toggle-weekly">Wöchentlich</label>
+  </div>
+</fieldset>
+""",
+    },
+    "review-form": {
+        "meta": [
+            "Live Rating",
+            "Form Feedback",
+            "Validierung"
+        ],
+        "example": """
+<form class="review-form" data-review-form>
+  <div class="input-group">
+    <label for="review-title">Titel Ihrer Bewertung</label>
+    <input class="input" id="review-title" required maxlength="80">
+  </div>
+  <fieldset class="stack-md" aria-describedby="rating-desc">
+    <legend>Sternebewertung</legend>
+    <p id="rating-desc" class="form-help">Mit Pfeiltasten auswählen. Aktuell: <span data-rating-output>0</span> Sterne.</p>
+    <div class="rating-inputs" role="radiogroup">
+      <input type="radio" id="rating-5" name="rating" value="5">
+      <label for="rating-5" aria-label="5 Sterne">★</label>
+      <input type="radio" id="rating-4" name="rating" value="4">
+      <label for="rating-4" aria-label="4 Sterne">★</label>
+      <input type="radio" id="rating-3" name="rating" value="3">
+      <label for="rating-3" aria-label="3 Sterne">★</label>
+      <input type="radio" id="rating-2" name="rating" value="2">
+      <label for="rating-2" aria-label="2 Sterne">★</label>
+      <input type="radio" id="rating-1" name="rating" value="1">
+      <label for="rating-1" aria-label="1 Stern">★</label>
+    </div>
+  </fieldset>
+  <div class="input-group">
+    <label for="review-comment">Ihre Erfahrung</label>
+    <textarea class="input" id="review-comment" rows="4" required></textarea>
+  </div>
+  <button class="btn" type="submit">Bewertung senden</button>
+  <p class="form-help" aria-live="polite" data-review-feedback></p>
+</form>
+""",
+    },
+    "review-stars": {
+        "meta": [
+            "Visuelle Bewertung",
+            "Accessible Text",
+            "Kontrast"
+        ],
+        "example": """
+<div class="review-stars" aria-label="Durchschnittliche Bewertung 4,6 von 5 Sternen">
+  <div class="review-stars__stars" aria-hidden="true">
+    <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+    <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+    <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+    <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+    <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor" opacity="0.4"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+  </div>
+  <span>4,6/5 (267 Rezensionen)</span>
+</div>
+""",
+    },
+    "search": {
+        "meta": [
+            "Autocomplete ready",
+            "Submit CTA",
+            "ARIA Live"
+        ],
+        "example": """
+<form class="search-form" role="search" data-search>
+  <label class="visually-hidden" for="site-search">Website durchsuchen</label>
+  <div class="search-form__field">
+    <input class="input" id="site-search" name="q" type="search" placeholder="Wonach suchen Sie?" autocomplete="off" data-search-input aria-describedby="search-suggestions">
+    <button class="btn" type="submit">Suchen</button>
+  </div>
+  <ul id="search-suggestions" class="stack-sm" aria-live="polite" data-search-suggestions role="listbox"></ul>
+  <p class="form-help" data-search-feedback aria-live="polite"></p>
+</form>
+""",
+    },
+    "share-buttons": {
+        "meta": [
+            "Web Share API",
+            "Fallback Copy",
+            "SR Feedback"
+        ],
+        "example": """
+<div class="share-buttons" data-share-buttons aria-label="Inhalte teilen">
+  <button class="btn" type="button" data-share-action="native">Teilen</button>
+  <button class="btn btn--ghost" type="button" data-share-action="copy">Link kopieren</button>
+  <output class="visually-hidden" aria-live="polite" data-share-feedback></output>
+</div>
+""",
+    },
+    "skeleton-loader": {
+        "meta": [
+            "Animation steuerbar",
+            "Semantische Rolle",
+            "Design Tokens"
+        ],
+        "example": """
+<section class="skeleton-card" role="status" aria-live="polite">
+  <div class="skeleton" style="height: 160px; border-radius: var(--radius-md);"></div>
+  <div class="skeleton" style="width: 70%;"></div>
+  <div class="skeleton" style="width: 50%;"></div>
+</section>
+""",
+    },
+    "table": {
+        "meta": [
+            "Sticky Header",
+            "Scroll Container",
+            "Caption"
+        ],
+        "example": """
+<div class="table-wrapper">
+  <table class="data-table" role="table">
+    <caption>Performance Kennzahlen Q1</caption>
+    <thead>
+      <tr>
+        <th scope="col">Metrik</th>
+        <th scope="col">Januar</th>
+        <th scope="col">Februar</th>
+        <th scope="col">März</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">Aktive Nutzer</th>
+        <td>12.430</td>
+        <td>13.105</td>
+        <td>14.890</td>
+      </tr>
+      <tr>
+        <th scope="row">Conversion Rate</th>
+        <td>3,2 %</td>
+        <td>3,5 %</td>
+        <td>3,8 %</td>
+      </tr>
+      <tr>
+        <th scope="row">Net Promoter Score</th>
+        <td>41</td>
+        <td>44</td>
+        <td>46</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+""",
+    },
+    "table-of-contents": {
+        "meta": [
+            "Toggle mobil",
+            "Scrollspy ready",
+            "Semantische nav"
+        ],
+        "example": """
+<nav class="toc" data-toc aria-label="Inhaltsverzeichnis">
+  <button class="btn btn--ghost toc__toggle" type="button" data-toc-toggle aria-expanded="false">
+    <span>Inhaltsverzeichnis</span>
+    <span aria-hidden="true">▾</span>
+  </button>
+  <ol class="toc__list" data-toc-list hidden>
+    <li><a href="#abschnitt-1">1. Einleitung</a></li>
+    <li><a href="#abschnitt-2">2. Umsetzung</a></li>
+    <li><a href="#abschnitt-3">3. Ergebnisse</a></li>
+  </ol>
+</nav>
+""",
+    },
+    "tags-badges": {
+        "meta": [
+            "Mehrfarbig",
+            "Responsives Wrapping",
+            "ARIA Gruppe"
+        ],
+        "example": """
+<div class="badge-collection" role="list">
+  <span class="badge" role="listitem">UX Writing</span>
+  <span class="badge badge--success" role="listitem">Accessibility</span>
+  <span class="badge badge--warning" role="listitem">Research</span>
+  <span class="badge" role="listitem">Component Library</span>
+</div>
+""",
+    },
+    "toast": {
+        "meta": [
+            "Aria Live",
+            "Auto Dismiss",
+            "Mehrere Toaster"
+        ],
+        "example": """
+<div class="stack-md">
+  <button class="btn" type="button" data-toast-trigger>Toast anzeigen</button>
+  <div class="toast-region" role="status" aria-live="polite" data-toast-region></div>
+</div>
+""",
+    },
+    "tooltip": {
+        "meta": [
+            "Hover &amp; Focus",
+            "Aria Expanded",
+            "Kurztexte"
+        ],
+        "example": """
+<div class="tooltip" aria-expanded="false" data-tooltip>
+  <button class="icon-button" type="button" aria-describedby="tooltip-1" data-tooltip-trigger>?</button>
+  <span class="tooltip__bubble" role="tooltip" id="tooltip-1">Wir speichern Ihre Einstellungen sicher verschlüsselt.</span>
+</div>
+""",
+    },
+    "trust-badges": {
+        "meta": [
+            "SVG Icons",
+            "Screenreader Text",
+            "Responsives Grid"
+        ],
+        "example": """
+<section class="trust-badges" aria-label="Vertrauenssiegel">
+  <span class="trust-badge">
+    <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M4 6l12-4 12 4v8c0 8-5.3 12.7-12 16-6.7-3.3-12-8-12-16z" fill="currentColor" opacity="0.1"></path><path d="M10 14l4 4 8-8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"></path></svg>
+    <span>Trusted Shop</span>
+  </span>
+  <span class="trust-badge">
+    <svg viewBox="0 0 32 32" aria-hidden="true"><circle cx="16" cy="16" r="14" fill="currentColor" opacity="0.1"></circle><path d="M10 16l4 4 8-8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"></path></svg>
+    <span>SSL Secure</span>
+  </span>
+  <span class="trust-badge">
+    <svg viewBox="0 0 32 32" aria-hidden="true"><rect x="6" y="6" width="20" height="20" rx="6" fill="currentColor" opacity="0.1"></rect><path d="M12 16h8" stroke="currentColor" stroke-width="2"></path><path d="M16 12v8" stroke="currentColor" stroke-width="2"></path></svg>
+    <span>30 Tage Rückgabe</span>
+  </span>
+</section>
+""",
+    },
+    "typography": {
+        "meta": [
+            "Skalierende Fonts",
+            "Lesbare Länge",
+            "Zitate"
+        ],
+        "example": """
+<article class="typography-demo">
+  <header>
+    <h1>Designsystem Playbook 2025</h1>
+    <p>Ein Leitfaden für skalierbare Content- und UI-Strukturen.</p>
+  </header>
+  <h2 id="abschnitt-1">Einleitung</h2>
+  <p>Klare Typografie schafft Orientierung und steigert die Lesbarkeit auf allen Geräten. Unsere Skala folgt einem modularen System.</p>
+  <h3>Listen &amp; Gliederung</h3>
+  <ul>
+    <li>Definierte Hierarchien</li>
+    <li>Kontrastreiche Linkstile</li>
+    <li>Klare Abstände</li>
+  </ul>
+  <blockquote id="abschnitt-2">„Design ist nicht nur wie es aussieht und sich anfühlt. Design ist wie es funktioniert.“ – Steve Jobs</blockquote>
+  <pre><code>npm install @acme/content-kit</code></pre>
+</article>
+""",
+    },
+    "video-embed": {
+        "meta": [
+            "Responsive Wrapper",
+            "Titel &amp; Transcript",
+            "Lazy Loading"
+        ],
+        "example": """
+<section class="card">
+  <h2>Produktdemo</h2>
+  <div class="video-frame">
+    <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Produktdemo Video" loading="lazy" allowfullscreen></iframe>
+  </div>
+  <details>
+    <summary>Transkript anzeigen</summary>
+    <p class="text-muted">In diesem Video erfahren Sie, wie das Onboarding in weniger als fünf Minuten funktioniert.</p>
+  </details>
+</section>
+""",
+    },
+}

--- a/content-elements-examples/contact-form.html
+++ b/content-elements-examples/contact-form.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Contact Form – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Contact Form.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Contact Form</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Formular zur Kontaktaufnahme mit Validierung und Spam-Schutz.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Form Validation"><span aria-hidden="true">⚙️</span>Form Validation</span><span class="meta-pill" role="listitem" aria-label="Mobile optimiert"><span aria-hidden="true">⚙️</span>Mobile optimiert</span><span class="meta-pill" role="listitem" aria-label="Fokusführung"><span aria-hidden="true">⚙️</span>Fokusführung</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <form class="contact-form" data-contact-form novalidate>
+            <div class="contact-form__grid">
+              <div class="input-group">
+                <label for="cf-name">Name</label>
+                <input class="input" id="cf-name" name="name" type="text" autocomplete="name" required>
+                <p class="form-help">Pflichtfeld – mindestens 2 Zeichen.</p>
+              </div>
+              <div class="input-group">
+                <label for="cf-email">E-Mail</label>
+                <input class="input" id="cf-email" name="email" type="email" autocomplete="email" inputmode="email" required>
+              </div>
+            </div>
+            <div class="input-group">
+              <label for="cf-topic">Thema</label>
+              <select class="input" id="cf-topic" name="topic">
+                <option value="support">Technischer Support</option>
+                <option value="sales">Beratung &amp; Angebote</option>
+                <option value="feedback">Feedback</option>
+              </select>
+            </div>
+            <div class="input-group">
+              <label for="cf-message">Nachricht</label>
+              <textarea class="input" id="cf-message" name="message" rows="4" maxlength="500" required></textarea>
+              <p class="form-help">Maximal 500 Zeichen.</p>
+            </div>
+            <div class="flex-between">
+              <label class="input-group" style="flex-direction: row; gap: 0.5rem; align-items: center;">
+                <input type="checkbox" name="privacy" required>
+                <span>Ich akzeptiere die <a href="#">Datenschutzerklärung</a>.</span>
+              </label>
+              <button class="btn" type="submit">Absenden</button>
+            </div>
+            <p class="form-help" aria-live="polite" data-form-feedback></p>
+          </form>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/cookie-consent.html
+++ b/content-elements-examples/cookie-consent.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cookie Consent – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Cookie Consent.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Cookie Consent</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Consent-Banner oder Layer zur Einholung der DSGVO-konformen Zustimmung für Cookies.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Consent Kategorien"><span aria-hidden="true">⚙️</span>Consent Kategorien</span><span class="meta-pill" role="listitem" aria-label="Persistenz Demo"><span aria-hidden="true">⚙️</span>Persistenz Demo</span><span class="meta-pill" role="listitem" aria-label="Barrierefrei"><span aria-hidden="true">⚙️</span>Barrierefrei</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="cookie-banner" role="dialog" aria-modal="true" aria-live="assertive" data-cookie-banner>
+            <div class="stack-md">
+              <h2>Wir respektieren Ihre Privatsphäre</h2>
+              <p>Wir verwenden Cookies, um Ihr Erlebnis zu verbessern. Passen Sie Ihre Auswahl jederzeit an.</p>
+              <details>
+                <summary>Details anzeigen</summary>
+                <ul class="stack-sm" style="margin: 0; padding-left: 1rem;">
+                  <li><strong>Essentiell:</strong> notwendig für die Seitennutzung.</li>
+                  <li><strong>Statistik:</strong> hilft uns, Inhalte zu optimieren.</li>
+                  <li><strong>Marketing:</strong> personalisierte Angebote.</li>
+                </ul>
+              </details>
+            </div>
+            <div class="cookie-banner__actions">
+              <button class="btn" type="button" data-consent-action="accept">Alle akzeptieren</button>
+              <button class="btn btn--ghost" type="button" data-consent-action="essentials">Nur essentielle</button>
+              <button class="btn btn--ghost" type="button" data-consent-open-settings>Individuell</button>
+            </div>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/date-picker.html
+++ b/content-elements-examples/date-picker.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Date Picker – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Date Picker.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Date Picker</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Komponente zur Auswahl einzelner Daten oder Zeitspannen.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="WAI-ARIA Grid"><span aria-hidden="true">⚙️</span>WAI-ARIA Grid</span><span class="meta-pill" role="listitem" aria-label="Tastatur Navigation"><span aria-hidden="true">⚙️</span>Tastatur Navigation</span><span class="meta-pill" role="listitem" aria-label="Locale aware"><span aria-hidden="true">⚙️</span>Locale aware</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="date-picker" data-date-picker data-start-month="2025-05">
+            <div class="input-group">
+              <label for="date-input">Reisedatum</label>
+              <input class="input" id="date-input" name="date" type="text" autocomplete="off" inputmode="numeric" placeholder="TT.MM.JJJJ" data-date-input aria-describedby="date-hint">
+              <p id="date-hint" class="form-help">Mit Pfeiltasten durch den Kalender navigieren. Native Eingabe: <input type="date" aria-label="Datum auswählen" style="display:inline-block; max-width: 150px;"></p>
+            </div>
+            <section class="card card--bordered" aria-labelledby="calendar-title">
+              <div class="flex-between">
+                <button class="icon-button" type="button" data-calendar-prev aria-label="Vorheriger Monat">
+                  <span aria-hidden="true">◀</span>
+                </button>
+                <p id="calendar-title" class="text-muted" data-calendar-title>Mai 2025</p>
+                <button class="icon-button" type="button" data-calendar-next aria-label="Nächster Monat">
+                  <span aria-hidden="true">▶</span>
+                </button>
+              </div>
+              <div class="calendar-weekdays" aria-hidden="true">
+                <span>Mo</span><span>Di</span><span>Mi</span><span>Do</span><span>Fr</span><span>Sa</span><span>So</span>
+              </div>
+              <div class="calendar-grid" role="grid" aria-labelledby="calendar-title" data-calendar-grid></div>
+            </section>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/dropdown-select.html
+++ b/content-elements-examples/dropdown-select.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Dropdown Select – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Dropdown Select.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Dropdown Select</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Auswahlliste als Native-Select oder erweiterte Combobox.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Roving Tabindex"><span aria-hidden="true">⚙️</span>Roving Tabindex</span><span class="meta-pill" role="listitem" aria-label="Touch friendly"><span aria-hidden="true">⚙️</span>Touch friendly</span><span class="meta-pill" role="listitem" aria-label="Hidden Input"><span aria-hidden="true">⚙️</span>Hidden Input</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="dropdown" data-dropdown>
+            <label for="team-size">Teamgröße</label>
+            <button class="btn dropdown__button" type="button" id="team-size" data-dropdown-toggle aria-haspopup="listbox" aria-expanded="false">
+              <span data-dropdown-label>1–10 Personen</span>
+              <span aria-hidden="true">▾</span>
+            </button>
+            <ul class="dropdown__panel" role="listbox" tabindex="-1" aria-labelledby="team-size" data-dropdown-list>
+              <li><button class="dropdown__option" type="button" role="option" aria-selected="true" data-value="small">1–10 Personen</button></li>
+              <li><button class="dropdown__option" type="button" role="option" aria-selected="false" data-value="medium">11–25 Personen</button></li>
+              <li><button class="dropdown__option" type="button" role="option" aria-selected="false" data-value="large">26–50 Personen</button></li>
+              <li><button class="dropdown__option" type="button" role="option" aria-selected="false" data-value="enterprise">Mehr als 50</button></li>
+            </ul>
+            <input type="hidden" name="team-size" value="small" data-dropdown-input>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/empty-state.html
+++ b/content-elements-examples/empty-state.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Empty State – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Empty State.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Empty State</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Darstellung, wenn keine Daten oder Ergebnisse vorliegen.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Illustration inklusive"><span aria-hidden="true">⚙️</span>Illustration inklusive</span><span class="meta-pill" role="listitem" aria-label="Handlungsaufforderung"><span aria-hidden="true">⚙️</span>Handlungsaufforderung</span><span class="meta-pill" role="listitem" aria-label="Screenreader Text"><span aria-hidden="true">⚙️</span>Screenreader Text</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="empty-state" role="status" aria-live="polite">
+            <svg viewBox="0 0 64 64" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="32" cy="32" r="30" opacity="0.2"></circle>
+              <path d="M18 38h28" stroke-linecap="round"></path>
+              <path d="M24 30l8-10 8 10" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+            <h2>Keine Ergebnisse – noch.</h2>
+            <p>Versuchen Sie es mit anderen Filtern oder erstellen Sie einen neuen Eintrag.</p>
+            <div class="share-buttons" role="group">
+              <button class="btn" type="button">Filter zurücksetzen</button>
+              <button class="btn btn--ghost" type="button">Eintrag erstellen</button>
+            </div>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/file-uploader.html
+++ b/content-elements-examples/file-uploader.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>File Uploader – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element File Uploader.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">File Uploader</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Komponente zum Hochladen von Dateien inklusive Fortschritt und Validierung.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Drag & Drop"><span aria-hidden="true">⚙️</span>Drag & Drop</span><span class="meta-pill" role="listitem" aria-label="Fortschrittsanzeige"><span aria-hidden="true">⚙️</span>Fortschrittsanzeige</span><span class="meta-pill" role="listitem" aria-label="Mehrere Dateien"><span aria-hidden="true">⚙️</span>Mehrere Dateien</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="file-uploader" data-file-uploader>
+            <div class="dropzone" tabindex="0" role="button" aria-label="Dateien hier ablegen oder klicken" data-dropzone>
+              <p><strong>Dateien auswählen</strong></p>
+              <p class="text-muted">Ziehen Sie Dateien hierher oder klicken Sie, um zu wählen. Maximal 10 Dateien.</p>
+              <input class="visually-hidden" type="file" name="documents" id="documents" multiple data-file-input>
+            </div>
+            <div class="upload-list" aria-live="polite" data-upload-list></div>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/filter-facets.html
+++ b/content-elements-examples/filter-facets.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Filter Facets – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Filter Facets.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Filter Facets</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Facettierte Filtersteuerung mit Chips, Listen oder Slidern.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Akkordeon"><span aria-hidden="true">⚙️</span>Akkordeon</span><span class="meta-pill" role="listitem" aria-label="Checkbox Gruppen"><span aria-hidden="true">⚙️</span>Checkbox Gruppen</span><span class="meta-pill" role="listitem" aria-label="Keyboard Fokus"><span aria-hidden="true">⚙️</span>Keyboard Fokus</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <aside class="facets" aria-label="Filter">
+            <details open>
+              <summary>Rollen</summary>
+              <div class="facets__options">
+                <label><input type="checkbox" name="role" value="design" checked> Design</label>
+                <label><input type="checkbox" name="role" value="engineering"> Engineering</label>
+                <label><input type="checkbox" name="role" value="product"> Produkt</label>
+              </div>
+            </details>
+            <details>
+              <summary>Standorte</summary>
+              <div class="facets__options">
+                <label><input type="checkbox" name="location" value="remote"> Remote</label>
+                <label><input type="checkbox" name="location" value="berlin"> Berlin</label>
+                <label><input type="checkbox" name="location" value="muenchen"> München</label>
+              </div>
+            </details>
+          </aside>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/generate_examples.py
+++ b/content-elements-examples/generate_examples.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+import textwrap
+
+from component_data import COMPONENTS
+
+CONTENT_DIR = Path("../content-elements").resolve()
+OUTPUT_DIR = Path(".").resolve()
+
+TEMPLATE = """<!doctype html>
+<html lang=\"de\">
+  <head>
+    <meta charset=\"utf-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+    <title>{title} – Content Element Beispiel</title>
+    <meta name=\"description\" content=\"Beispielimplementierung für das Content-Element {title}.\">
+    <link rel=\"stylesheet\" href=\"assets/styles.css\">
+  </head>
+  <body>
+    <a href=\"#main\" class=\"skip-link\">Zum Inhalt springen</a>
+    <header class=\"site-header\">
+      <p class=\"badge\">Content Element Beispiel</p>
+      <h1 class=\"site-header__title\">{title}</h1>
+    </header>
+    <main id=\"main\" class=\"component-page\" tabindex=\"-1\">
+      <article class=\"component-preview\">
+        <header class=\"component-preview__header\">
+          <h2 class=\"component-preview__title\">Live-Demo</h2>
+          <p class=\"component-preview__description\">{description}</p>
+          <div class=\"component-meta\" role=\"list\">
+            {meta}
+          </div>
+        </header>
+        <section class=\"component-preview__example\" aria-label=\"Beispiel\">
+{example}
+        </section>
+        {notes}
+      </article>
+    </main>
+    <script src=\"assets/scripts.js\" defer></script>
+  </body>
+</html>
+"""
+
+
+def read_title(md_path: Path) -> str:
+    for line in md_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("# "):
+            return line.split(":", 1)[-1].strip()
+    raise ValueError(f"Kein Titel in {md_path}")
+
+
+def read_description(md_path: Path) -> str:
+    lines = md_path.read_text(encoding="utf-8").splitlines()
+    try:
+        idx = lines.index("## Beschreibung") + 1
+    except ValueError as exc:
+        raise ValueError(f"Keine Beschreibung in {md_path}") from exc
+    collected: list[str] = []
+    for line in lines[idx:]:
+        if not line.strip():
+            break
+        collected.append(line.strip())
+    return " ".join(collected)
+
+
+def build_meta(meta_items: list[str]) -> str:
+    pills = []
+    for item in meta_items:
+        pills.append(
+            f"<span class=\"meta-pill\" role=\"listitem\" aria-label=\"{item}\">" f"<span aria-hidden=\"true\">⚙️</span>{item}</span>"
+        )
+    return "".join(pills) if pills else "<span class=\"meta-pill\">Standard Best Practices</span>"
+
+
+def indent(text: str, spaces: int = 10) -> str:
+    return textwrap.indent(text.strip(), " " * spaces)
+
+
+def main() -> None:
+    for md_path in sorted(CONTENT_DIR.glob("*.md")):
+        slug = md_path.stem
+        if slug not in COMPONENTS:
+            raise KeyError(f"Für {slug} wurde kein Beispiel definiert")
+        entry = COMPONENTS[slug]
+        title = entry.get("title") or read_title(md_path)
+        description = entry.get("description") or read_description(md_path)
+        meta = build_meta(entry.get("meta", []))
+        example = indent(entry["example"], 10)
+        notes_block = entry.get("notes")
+        notes_html = ""
+        if notes_block:
+            notes_html = "          <footer class=\"component-meta\">" + notes_block + "</footer>"
+        html = TEMPLATE.format(
+            title=title,
+            description=description,
+            meta=meta,
+            example=example,
+            notes=notes_html,
+        )
+        output_path = OUTPUT_DIR / f"{slug}.html"
+        output_path.write_text(html, encoding="utf-8")
+        print(f"geschrieben: {output_path.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/content-elements-examples/image-carousel.html
+++ b/content-elements-examples/image-carousel.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Image Carousel – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Image Carousel.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Image Carousel</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Slider-Komponente für mehrere Bilder mit optionaler Lightbox.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Swipe-ready"><span aria-hidden="true">⚙️</span>Swipe-ready</span><span class="meta-pill" role="listitem" aria-label="ARIA Live"><span aria-hidden="true">⚙️</span>ARIA Live</span><span class="meta-pill" role="listitem" aria-label="Lazy Loading"><span aria-hidden="true">⚙️</span>Lazy Loading</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="carousel" data-carousel aria-roledescription="Karussell" aria-label="Produktbilder">
+            <div class="carousel__slides" data-carousel-track>
+              <figure class="carousel__slide" data-carousel-slide>
+                <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80" alt="Offenes, helles Wohnzimmer" loading="lazy">
+                <figcaption class="visually-hidden">Wohnbereich mit natürlichem Licht</figcaption>
+              </figure>
+              <figure class="carousel__slide" data-carousel-slide>
+                <img src="https://images.unsplash.com/photo-1586023492125-27b2c045efd7?auto=format&fit=crop&w=900&q=80" alt="Moderne Küche mit Holzdekor" loading="lazy">
+                <figcaption class="visually-hidden">Moderne Küche</figcaption>
+              </figure>
+              <figure class="carousel__slide" data-carousel-slide>
+                <img src="https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=900&q=80" alt="Gemütliches Schlafzimmer mit Pflanzen" loading="lazy">
+                <figcaption class="visually-hidden">Schlafzimmer mit Pflanzen</figcaption>
+              </figure>
+            </div>
+            <div class="carousel__controls" aria-hidden="true">
+              <button class="icon-button" type="button" data-carousel-prev aria-label="Vorheriges Bild">◀</button>
+              <button class="icon-button" type="button" data-carousel-next aria-label="Nächstes Bild">▶</button>
+            </div>
+          </section>
+          <div class="carousel__dots" role="tablist" data-carousel-dots>
+            <button class="carousel__dot" type="button" role="tab" aria-controls="slide-1" aria-current="true"></button>
+            <button class="carousel__dot" type="button" role="tab" aria-controls="slide-2"></button>
+            <button class="carousel__dot" type="button" role="tab" aria-controls="slide-3"></button>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/image-with-caption.html
+++ b/content-elements-examples/image-with-caption.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Image with Caption – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Image with Caption.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Image with Caption</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Bilddarstellung mit erläuternder Bildunterschrift.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Figure &amp; Figcaption"><span aria-hidden="true">⚙️</span>Figure &amp; Figcaption</span><span class="meta-pill" role="listitem" aria-label="Responsive Bilder"><span aria-hidden="true">⚙️</span>Responsive Bilder</span><span class="meta-pill" role="listitem" aria-label="Lazy loading"><span aria-hidden="true">⚙️</span>Lazy loading</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <figure class="figure">
+            <picture>
+              <source srcset="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=900&q=80" media="(min-width: 800px)">
+              <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=600&q=80" alt="Team, das gemeinsam an einem Tisch arbeitet" loading="lazy">
+            </picture>
+            <figcaption>Team Sync im Workspace Berlin – Foto: <a href="https://unsplash.com" rel="noopener">Unsplash</a></figcaption>
+          </figure>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/input-field.html
+++ b/content-elements-examples/input-field.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Input Field – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Input Field.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Input Field</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Standardisierte Eingabefelder für Text, E-Mail oder Nummern mit optionalen Masken.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Inline Fehlermeldung"><span aria-hidden="true">⚙️</span>Inline Fehlermeldung</span><span class="meta-pill" role="listitem" aria-label="Charakterbegrenzung"><span aria-hidden="true">⚙️</span>Charakterbegrenzung</span><span class="meta-pill" role="listitem" aria-label="State Styling"><span aria-hidden="true">⚙️</span>State Styling</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="input-field" aria-live="polite">
+            <div class="input-group">
+              <label for="input-username">Benutzername</label>
+              <input class="input" id="input-username" name="username" type="text" placeholder="z. B. ux-nerd" minlength="3" maxlength="20" required data-input-with-counter>
+              <p class="form-help"><span data-input-counter>0</span>/20 Zeichen</p>
+            </div>
+            <div class="input-group">
+              <label for="input-password">Passwort</label>
+              <div style="position: relative;">
+                <input class="input" id="input-password" name="password" type="password" required aria-describedby="password-hint">
+                <button class="btn btn--ghost" type="button" data-toggle-password style="position:absolute; top:50%; right:0.5rem; transform:translateY(-50%);">Anzeigen</button>
+              </div>
+              <p id="password-hint" class="form-help">Mindestens 8 Zeichen, Groß-/Kleinschreibung sowie Zahl.</p>
+            </div>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/loading-spinner.html
+++ b/content-elements-examples/loading-spinner.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Loading Spinner – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Loading Spinner.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Loading Spinner</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Animierter Indikator für laufende Prozesse.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Reduced Motion"><span aria-hidden="true">⚙️</span>Reduced Motion</span><span class="meta-pill" role="listitem" aria-label="Role Status"><span aria-hidden="true">⚙️</span>Role Status</span><span class="meta-pill" role="listitem" aria-label="Contrast optimiert"><span aria-hidden="true">⚙️</span>Contrast optimiert</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="card" role="status" aria-live="polite">
+            <div class="spinner" aria-hidden="true"></div>
+            <p>Daten werden geladen …</p>
+            <p class="form-help">Sollte der Vorgang länger dauern als 30 Sekunden, aktualisieren Sie die Seite.</p>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/map-embed.html
+++ b/content-elements-examples/map-embed.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Map Embed – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Map Embed.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Map Embed</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Interaktive Karte zur Standortanzeige oder Wegbeschreibung.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Iframe Titel"><span aria-hidden="true">⚙️</span>Iframe Titel</span><span class="meta-pill" role="listitem" aria-label="Fallback Link"><span aria-hidden="true">⚙️</span>Fallback Link</span><span class="meta-pill" role="listitem" aria-label="Lazy Loading"><span aria-hidden="true">⚙️</span>Lazy Loading</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="card">
+            <h2>Büro Berlin</h2>
+            <p class="text-muted">Invalidenstraße 91, 10115 Berlin</p>
+            <iframe class="map-frame" loading="lazy" src="https://www.openstreetmap.org/export/embed.html?bbox=13.3789%2C52.5294%2C13.3839%2C52.5324&amp;layer=mapnik" title="Karte des Büros in Berlin"></iframe>
+            <p><a href="https://www.openstreetmap.org/?mlat=52.531&amp;mlon=13.381#map=18/52.5310/13.3810" target="_blank" rel="noopener">Auf OpenStreetMap öffnen</a></p>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/mini-cart.html
+++ b/content-elements-examples/mini-cart.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Mini Cart – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Mini Cart.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Mini Cart</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Warenkorb-Vorschau als Off-Canvas oder Dropdown.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Live Aktualisierung"><span aria-hidden="true">⚙️</span>Live Aktualisierung</span><span class="meta-pill" role="listitem" aria-label="Accessible Pricing"><span aria-hidden="true">⚙️</span>Accessible Pricing</span><span class="meta-pill" role="listitem" aria-label="Keyboard ready"><span aria-hidden="true">⚙️</span>Keyboard ready</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="mini-cart" data-mini-cart aria-label="Mini Warenkorb">
+            <div class="cart-item" data-cart-item>
+              <img src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=200&q=80" alt="Kabellose Kopfhörer" loading="lazy">
+              <div>
+                <p>Kabellose Kopfhörer</p>
+                <p class="text-muted">Lieferung in 2-3 Tagen</p>
+                <label class="visually-hidden" for="item-1">Anzahl</label>
+                <input class="input" id="item-1" type="number" min="1" value="1" data-item-qty>
+              </div>
+              <strong data-item-price="129.90">129,90 €</strong>
+            </div>
+            <div class="cart-item" data-cart-item>
+              <img src="https://images.unsplash.com/photo-1512496015851-a90fb38ba796?auto=format&fit=crop&w=200&q=80" alt="Leder Schreibtischunterlage" loading="lazy">
+              <div>
+                <p>Leder Desk Pad</p>
+                <p class="text-muted">Nachhaltiges Leder</p>
+                <label class="visually-hidden" for="item-2">Anzahl</label>
+                <input class="input" id="item-2" type="number" min="1" value="2" data-item-qty>
+              </div>
+              <strong data-item-price="59.90">59,90 €</strong>
+            </div>
+            <div class="cart-summary">
+              <span>Zwischensumme</span>
+              <span data-cart-total>249,70 €</span>
+            </div>
+            <button class="btn" type="button">Zur Kasse</button>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/modal.html
+++ b/content-elements-examples/modal.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Modal – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Modal.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Modal</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Dialog-Overlay, das den restlichen Inhalt überlagert und fokussierte Interaktion verlangt.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Focus Trap"><span aria-hidden="true">⚙️</span>Focus Trap</span><span class="meta-pill" role="listitem" aria-label="Escape schließt"><span aria-hidden="true">⚙️</span>Escape schließt</span><span class="meta-pill" role="listitem" aria-label="Aria Beschriftung"><span aria-hidden="true">⚙️</span>Aria Beschriftung</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="modal-demo">
+            <button class="btn" type="button" data-open-modal="#newsletter-modal">Neuigkeiten abonnieren</button>
+            <dialog class="modal" id="newsletter-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+              <div class="modal__dialog">
+                <header class="modal__header">
+                  <h2 id="modal-title">Wöchentlicher Newsletter</h2>
+                  <button class="icon-button" type="button" data-close-modal aria-label="Modal schließen">✕</button>
+                </header>
+                <p>Erhalten Sie Updates zu Produkt-Releases und Best Practices direkt in Ihr Postfach.</p>
+                <form class="newsletter-form" data-newsletter-modal>
+                  <label class="visually-hidden" for="modal-email">E-Mail-Adresse</label>
+                  <input class="input" id="modal-email" type="email" name="email" placeholder="name@example.com" required>
+                  <button class="btn" type="submit">Abonnieren</button>
+                </form>
+              </div>
+            </dialog>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/multi-step-wizard.html
+++ b/content-elements-examples/multi-step-wizard.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Multi-Step Wizard – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Multi-Step Wizard.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Multi-Step Wizard</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Mehrschrittige Benutzerführung für komplexe Prozesse.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="ARIA Current"><span aria-hidden="true">⚙️</span>ARIA Current</span><span class="meta-pill" role="listitem" aria-label="Progressive Disclosure"><span aria-hidden="true">⚙️</span>Progressive Disclosure</span><span class="meta-pill" role="listitem" aria-label="Keyboard Navigation"><span aria-hidden="true">⚙️</span>Keyboard Navigation</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="wizard" data-wizard>
+            <div class="wizard__steps" role="list" aria-label="Setup Schritte">
+              <span class="wizard__step" role="listitem" aria-current="step">Profil</span>
+              <span class="wizard__step" role="listitem">Team</span>
+              <span class="wizard__step" role="listitem">Bestätigung</span>
+            </div>
+            <form class="card" data-wizard-step="0">
+              <div class="input-group">
+                <label for="wizard-name">Name</label>
+                <input class="input" id="wizard-name" required>
+              </div>
+              <div class="input-group">
+                <label for="wizard-role">Rolle</label>
+                <select class="input" id="wizard-role">
+                  <option>Produktmanager:in</option>
+                  <option>Designer:in</option>
+                  <option>Developer:in</option>
+                </select>
+              </div>
+              <div class="flex-between">
+                <span></span>
+                <button class="btn" type="button" data-wizard-next>Weiter</button>
+              </div>
+            </form>
+            <form class="card" hidden data-wizard-step="1">
+              <div class="input-group">
+                <label for="wizard-team-size">Teamgröße</label>
+                <input class="input" id="wizard-team-size" type="number" min="1" value="5">
+              </div>
+              <div class="flex-between">
+                <button class="btn btn--ghost" type="button" data-wizard-prev>Zurück</button>
+                <button class="btn" type="button" data-wizard-next>Weiter</button>
+              </div>
+            </form>
+            <form class="card" hidden data-wizard-step="2">
+              <p>Alles bereit! Wir senden Ihnen einen Bestätigungslink.</p>
+              <div class="flex-between">
+                <button class="btn btn--ghost" type="button" data-wizard-prev>Zurück</button>
+                <button class="btn" type="submit">Setup abschließen</button>
+              </div>
+            </form>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/newsletter-optin.html
+++ b/content-elements-examples/newsletter-optin.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Newsletter Opt-in – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Newsletter Opt-in.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Newsletter Opt-in</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Formular zum Anmelden für einen Newsletter mit Double-Opt-In.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Double Opt-in Hinweis"><span aria-hidden="true">⚙️</span>Double Opt-in Hinweis</span><span class="meta-pill" role="listitem" aria-label="Inline Validierung"><span aria-hidden="true">⚙️</span>Inline Validierung</span><span class="meta-pill" role="listitem" aria-label="Success Feedback"><span aria-hidden="true">⚙️</span>Success Feedback</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <form class="newsletter-form" data-newsletter>
+            <div class="newsletter-form__fields">
+              <div class="input-group">
+                <label for="newsletter-email">E-Mail-Adresse</label>
+                <input class="input" id="newsletter-email" name="email" type="email" placeholder="you@example.com" required>
+                <p class="form-help">Wir senden einen Double-Opt-in-Link.</p>
+              </div>
+              <button class="btn" type="submit">Anmelden</button>
+            </div>
+            <label class="input-group" style="flex-direction: row; gap: 0.5rem; align-items: center;">
+              <input type="checkbox" name="news-privacy" required>
+              <span>Ich stimme dem Erhalt des Newsletters zu.</span>
+            </label>
+            <p class="form-help" data-newsletter-feedback aria-live="polite"></p>
+          </form>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/notification-banner.html
+++ b/content-elements-examples/notification-banner.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Notification Banner – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Notification Banner.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Notification Banner</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Seitenweite Hinweise oder Promotions am oberen Rand.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Role Status"><span aria-hidden="true">⚙️</span>Role Status</span><span class="meta-pill" role="listitem" aria-label="Close Button"><span aria-hidden="true">⚙️</span>Close Button</span><span class="meta-pill" role="listitem" aria-label="Keyboard Fokus"><span aria-hidden="true">⚙️</span>Keyboard Fokus</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="notification-banner" role="status" data-notification-banner>
+            <div class="flex-between">
+              <div>
+                <strong>Neue Version verfügbar!</strong>
+                <p class="text-muted" style="color: rgba(255,255,255,0.8);">Aktualisieren Sie jetzt, um von Performance-Optimierungen zu profitieren.</p>
+              </div>
+              <button class="icon-button" type="button" aria-label="Benachrichtigung schließen" data-dismiss-banner>✕</button>
+            </div>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/pagination.html
+++ b/content-elements-examples/pagination.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Pagination – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Pagination.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Pagination</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Seitenweise Navigation für Listen und Suchergebnisse.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="ARIA Labels"><span aria-hidden="true">⚙️</span>ARIA Labels</span><span class="meta-pill" role="listitem" aria-label="Erweiterte Klickflächen"><span aria-hidden="true">⚙️</span>Erweiterte Klickflächen</span><span class="meta-pill" role="listitem" aria-label="Responsives Layout"><span aria-hidden="true">⚙️</span>Responsives Layout</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <nav aria-label="Seiten Navigation">
+            <ul class="pagination">
+              <li class="pagination__item"><a class="pagination__link" href="#" aria-label="Vorherige Seite">‹</a></li>
+              <li class="pagination__item"><a class="pagination__link" href="#">1</a></li>
+              <li class="pagination__item"><a class="pagination__link" href="#" aria-current="page">2</a></li>
+              <li class="pagination__item"><a class="pagination__link" href="#">3</a></li>
+              <li class="pagination__item"><a class="pagination__link" href="#" aria-label="Nächste Seite">›</a></li>
+            </ul>
+          </nav>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/popover.html
+++ b/content-elements-examples/popover.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Popover – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Popover.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Popover</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Kontextbezogene Overlays mit weiterführenden Inhalten oder Aktionen.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Focus Management"><span aria-hidden="true">⚙️</span>Focus Management</span><span class="meta-pill" role="listitem" aria-label="Auto Close"><span aria-hidden="true">⚙️</span>Auto Close</span><span class="meta-pill" role="listitem" aria-label="ARIA Controls"><span aria-hidden="true">⚙️</span>ARIA Controls</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="popover" data-popover>
+            <button class="btn btn--ghost" type="button" data-popover-toggle aria-expanded="false" aria-controls="popover-panel">Mehr Infos</button>
+            <div class="popover__panel" id="popover-panel" role="dialog">
+              <p><strong>Warum wir fragen:</strong></p>
+              <p class="text-muted">Wir nutzen Ihre Angaben, um personalisierte Empfehlungen zu erstellen. Ihre Daten bleiben privat.</p>
+              <button class="btn btn--ghost" type="button" data-popover-close>Verstanden</button>
+            </div>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/price-comparison.html
+++ b/content-elements-examples/price-comparison.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Price Comparison – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Price Comparison.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Price Comparison</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Kompakte Vergleichstabelle für Tarife oder Pakete.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Responsive Karten"><span aria-hidden="true">⚙️</span>Responsive Karten</span><span class="meta-pill" role="listitem" aria-label="Highlight Tarif"><span aria-hidden="true">⚙️</span>Highlight Tarif</span><span class="meta-pill" role="listitem" aria-label="Semantische Listen"><span aria-hidden="true">⚙️</span>Semantische Listen</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="price-comparison">
+            <article class="plan-card" aria-label="Starter Tarif">
+              <span class="badge">Starter</span>
+              <p class="plan-card__price">19 €<span class="text-muted" style="font-size:0.9rem;">/Monat</span></p>
+              <ul class="stack-sm" style="padding-left: 1rem; margin: 0;">
+                <li>Bis zu 5 Projekte</li>
+                <li>E-Mail Support</li>
+                <li>Community Zugang</li>
+              </ul>
+              <button class="btn btn--ghost" type="button">Jetzt starten</button>
+            </article>
+            <article class="plan-card plan-card--highlight" aria-label="Professional Tarif">
+              <span class="badge badge--success">Beliebt</span>
+              <p class="plan-card__price">39 €<span class="text-muted" style="font-size:0.9rem;">/Monat</span></p>
+              <ul class="stack-sm" style="padding-left: 1rem; margin: 0;">
+                <li>Unbegrenzte Projekte</li>
+                <li>Fortgeschrittene Automatisierung</li>
+                <li>Priorisierter Support</li>
+              </ul>
+              <button class="btn" type="button">Kostenlos testen</button>
+            </article>
+            <article class="plan-card" aria-label="Enterprise Tarif">
+              <span class="badge badge--warning">Enterprise</span>
+              <p class="plan-card__price">Auf Anfrage</p>
+              <ul class="stack-sm" style="padding-left: 1rem; margin: 0;">
+                <li>Dedizierte Betreuung</li>
+                <li>Single Sign-On</li>
+                <li>Custom SLAs</li>
+              </ul>
+              <button class="btn btn--ghost" type="button">Kontakt aufnehmen</button>
+            </article>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/product-card.html
+++ b/content-elements-examples/product-card.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Product Card – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Product Card.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Product Card</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Produktkachel mit Bild, Preis, Bewertung und CTA.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Bildverhältnis"><span aria-hidden="true">⚙️</span>Bildverhältnis</span><span class="meta-pill" role="listitem" aria-label="Preis Hervorhebung"><span aria-hidden="true">⚙️</span>Preis Hervorhebung</span><span class="meta-pill" role="listitem" aria-label="Bewertung"><span aria-hidden="true">⚙️</span>Bewertung</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <article class="product-card">
+            <div class="product-card__image">
+              <img src="https://images.unsplash.com/photo-1512499617640-c2f999098c01?auto=format&fit=crop&w=800&q=80" alt="Minimalistischer Bürostuhl in Grau" loading="lazy">
+            </div>
+            <div class="product-card__body">
+              <div class="review-stars">
+                <div class="review-stars__stars" aria-label="4,8 von 5 Sternen">
+                  <span aria-hidden="true">★ ★ ★ ★ ☆</span>
+                </div>
+                <span class="text-muted">(128)</span>
+              </div>
+              <h2>Ergonomischer Chair One</h2>
+              <p class="text-muted">Atmungsaktives Mesh, 4D Armlehnen, Sitzhöhenverstellung.</p>
+              <p class="product-card__price">349 €</p>
+              <div class="share-buttons" role="group" aria-label="Produktaktionen">
+                <button class="btn" type="button">In den Warenkorb</button>
+                <button class="btn btn--ghost" type="button">Merken</button>
+              </div>
+            </div>
+          </article>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/progress-stepper.html
+++ b/content-elements-examples/progress-stepper.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Progress Stepper – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Progress Stepper.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Progress Stepper</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Visualisierung des Fortschritts in mehreren Schritten oder Phasen.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="ARIA Current"><span aria-hidden="true">⚙️</span>ARIA Current</span><span class="meta-pill" role="listitem" aria-label="Responsives Scrolling"><span aria-hidden="true">⚙️</span>Responsives Scrolling</span><span class="meta-pill" role="listitem" aria-label="Iconische Darstellung"><span aria-hidden="true">⚙️</span>Iconische Darstellung</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <nav class="stepper" aria-label="Bestellfortschritt">
+            <span class="stepper__item" aria-current="step">
+              <span aria-hidden="true">1</span>
+              <span>Adresse</span>
+            </span>
+            <span class="stepper__item">
+              <span aria-hidden="true">2</span>
+              <span>Versand</span>
+            </span>
+            <span class="stepper__item">
+              <span aria-hidden="true">3</span>
+              <span>Zahlung</span>
+            </span>
+          </nav>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/radio-checkbox-toggle.html
+++ b/content-elements-examples/radio-checkbox-toggle.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Radio / Checkbox / Toggle – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Radio / Checkbox / Toggle.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Radio / Checkbox / Toggle</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Steuerelemente für Einzel- oder Mehrfachauswahl inklusive Switches.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="ARIA Checked"><span aria-hidden="true">⚙️</span>ARIA Checked</span><span class="meta-pill" role="listitem" aria-label="Benutzerdefinierte Toggle"><span aria-hidden="true">⚙️</span>Benutzerdefinierte Toggle</span><span class="meta-pill" role="listitem" aria-label="Form Integration"><span aria-hidden="true">⚙️</span>Form Integration</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <fieldset class="toggle-group">
+            <legend>Benachrichtigungen</legend>
+            <div class="toggle">
+              <input type="checkbox" id="toggle-email" name="notifications" value="email" checked>
+              <label for="toggle-email">E-Mail</label>
+            </div>
+            <div class="toggle">
+              <input type="checkbox" id="toggle-push" name="notifications" value="push">
+              <label for="toggle-push">Push</label>
+            </div>
+            <div class="toggle">
+              <input type="radio" id="toggle-daily" name="digest" value="daily" checked>
+              <label for="toggle-daily">Täglich</label>
+            </div>
+            <div class="toggle">
+              <input type="radio" id="toggle-weekly" name="digest" value="weekly">
+              <label for="toggle-weekly">Wöchentlich</label>
+            </div>
+          </fieldset>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/review-form.html
+++ b/content-elements-examples/review-form.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Review Form – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Review Form.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Review Form</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Formular zum Abgeben von Bewertungen mit Rating und Textfeld.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Live Rating"><span aria-hidden="true">⚙️</span>Live Rating</span><span class="meta-pill" role="listitem" aria-label="Form Feedback"><span aria-hidden="true">⚙️</span>Form Feedback</span><span class="meta-pill" role="listitem" aria-label="Validierung"><span aria-hidden="true">⚙️</span>Validierung</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <form class="review-form" data-review-form>
+            <div class="input-group">
+              <label for="review-title">Titel Ihrer Bewertung</label>
+              <input class="input" id="review-title" required maxlength="80">
+            </div>
+            <fieldset class="stack-md" aria-describedby="rating-desc">
+              <legend>Sternebewertung</legend>
+              <p id="rating-desc" class="form-help">Mit Pfeiltasten auswählen. Aktuell: <span data-rating-output>0</span> Sterne.</p>
+              <div class="rating-inputs" role="radiogroup">
+                <input type="radio" id="rating-5" name="rating" value="5">
+                <label for="rating-5" aria-label="5 Sterne">★</label>
+                <input type="radio" id="rating-4" name="rating" value="4">
+                <label for="rating-4" aria-label="4 Sterne">★</label>
+                <input type="radio" id="rating-3" name="rating" value="3">
+                <label for="rating-3" aria-label="3 Sterne">★</label>
+                <input type="radio" id="rating-2" name="rating" value="2">
+                <label for="rating-2" aria-label="2 Sterne">★</label>
+                <input type="radio" id="rating-1" name="rating" value="1">
+                <label for="rating-1" aria-label="1 Stern">★</label>
+              </div>
+            </fieldset>
+            <div class="input-group">
+              <label for="review-comment">Ihre Erfahrung</label>
+              <textarea class="input" id="review-comment" rows="4" required></textarea>
+            </div>
+            <button class="btn" type="submit">Bewertung senden</button>
+            <p class="form-help" aria-live="polite" data-review-feedback></p>
+          </form>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/review-stars.html
+++ b/content-elements-examples/review-stars.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Review Stars – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Review Stars.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Review Stars</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Darstellung von Bewertungen mit Sterne-Rating.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Visuelle Bewertung"><span aria-hidden="true">⚙️</span>Visuelle Bewertung</span><span class="meta-pill" role="listitem" aria-label="Accessible Text"><span aria-hidden="true">⚙️</span>Accessible Text</span><span class="meta-pill" role="listitem" aria-label="Kontrast"><span aria-hidden="true">⚙️</span>Kontrast</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="review-stars" aria-label="Durchschnittliche Bewertung 4,6 von 5 Sternen">
+            <div class="review-stars__stars" aria-hidden="true">
+              <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+              <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+              <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+              <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+              <svg class="review-stars__star" viewBox="0 0 20 20" fill="currentColor" opacity="0.4"><polygon points="10 1 12.6 7.1 19.2 7.3 14 11.6 15.8 18 10 14.3 4.2 18 6 11.6 0.8 7.3 7.4 7.1"></polygon></svg>
+            </div>
+            <span>4,6/5 (267 Rezensionen)</span>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/search.html
+++ b/content-elements-examples/search.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Search – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Search.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Search</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Suchfeld mit optionaler Autosuggest-Funktion.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Autocomplete ready"><span aria-hidden="true">⚙️</span>Autocomplete ready</span><span class="meta-pill" role="listitem" aria-label="Submit CTA"><span aria-hidden="true">⚙️</span>Submit CTA</span><span class="meta-pill" role="listitem" aria-label="ARIA Live"><span aria-hidden="true">⚙️</span>ARIA Live</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <form class="search-form" role="search" data-search>
+            <label class="visually-hidden" for="site-search">Website durchsuchen</label>
+            <div class="search-form__field">
+              <input class="input" id="site-search" name="q" type="search" placeholder="Wonach suchen Sie?" autocomplete="off" data-search-input aria-describedby="search-suggestions">
+              <button class="btn" type="submit">Suchen</button>
+            </div>
+            <ul id="search-suggestions" class="stack-sm" aria-live="polite" data-search-suggestions role="listbox"></ul>
+            <p class="form-help" data-search-feedback aria-live="polite"></p>
+          </form>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/share-buttons.html
+++ b/content-elements-examples/share-buttons.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Share Buttons – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Share Buttons.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Share Buttons</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Buttons zum Teilen von Inhalten in sozialen Netzwerken oder per Link.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Web Share API"><span aria-hidden="true">⚙️</span>Web Share API</span><span class="meta-pill" role="listitem" aria-label="Fallback Copy"><span aria-hidden="true">⚙️</span>Fallback Copy</span><span class="meta-pill" role="listitem" aria-label="SR Feedback"><span aria-hidden="true">⚙️</span>SR Feedback</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="share-buttons" data-share-buttons aria-label="Inhalte teilen">
+            <button class="btn" type="button" data-share-action="native">Teilen</button>
+            <button class="btn btn--ghost" type="button" data-share-action="copy">Link kopieren</button>
+            <output class="visually-hidden" aria-live="polite" data-share-feedback></output>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/skeleton-loader.html
+++ b/content-elements-examples/skeleton-loader.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Skeleton Loader – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Skeleton Loader.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Skeleton Loader</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Platzhalter-Layouts, die die spätere Struktur andeuten, während Inhalte laden.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Animation steuerbar"><span aria-hidden="true">⚙️</span>Animation steuerbar</span><span class="meta-pill" role="listitem" aria-label="Semantische Rolle"><span aria-hidden="true">⚙️</span>Semantische Rolle</span><span class="meta-pill" role="listitem" aria-label="Design Tokens"><span aria-hidden="true">⚙️</span>Design Tokens</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="skeleton-card" role="status" aria-live="polite">
+            <div class="skeleton" style="height: 160px; border-radius: var(--radius-md);"></div>
+            <div class="skeleton" style="width: 70%;"></div>
+            <div class="skeleton" style="width: 50%;"></div>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/table-of-contents.html
+++ b/content-elements-examples/table-of-contents.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Table of Contents – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Table of Contents.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Table of Contents</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Strukturierte Liste von Ankern, die durch längere Inhalte navigiert.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Toggle mobil"><span aria-hidden="true">⚙️</span>Toggle mobil</span><span class="meta-pill" role="listitem" aria-label="Scrollspy ready"><span aria-hidden="true">⚙️</span>Scrollspy ready</span><span class="meta-pill" role="listitem" aria-label="Semantische nav"><span aria-hidden="true">⚙️</span>Semantische nav</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <nav class="toc" data-toc aria-label="Inhaltsverzeichnis">
+            <button class="btn btn--ghost toc__toggle" type="button" data-toc-toggle aria-expanded="false">
+              <span>Inhaltsverzeichnis</span>
+              <span aria-hidden="true">▾</span>
+            </button>
+            <ol class="toc__list" data-toc-list hidden>
+              <li><a href="#abschnitt-1">1. Einleitung</a></li>
+              <li><a href="#abschnitt-2">2. Umsetzung</a></li>
+              <li><a href="#abschnitt-3">3. Ergebnisse</a></li>
+            </ol>
+          </nav>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/table.html
+++ b/content-elements-examples/table.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Table – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Table.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Table</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Tabellarische Darstellung von Daten mit Headern, Spalten und optionaler Sortierung.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Sticky Header"><span aria-hidden="true">⚙️</span>Sticky Header</span><span class="meta-pill" role="listitem" aria-label="Scroll Container"><span aria-hidden="true">⚙️</span>Scroll Container</span><span class="meta-pill" role="listitem" aria-label="Caption"><span aria-hidden="true">⚙️</span>Caption</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="table-wrapper">
+            <table class="data-table" role="table">
+              <caption>Performance Kennzahlen Q1</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Metrik</th>
+                  <th scope="col">Januar</th>
+                  <th scope="col">Februar</th>
+                  <th scope="col">März</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">Aktive Nutzer</th>
+                  <td>12.430</td>
+                  <td>13.105</td>
+                  <td>14.890</td>
+                </tr>
+                <tr>
+                  <th scope="row">Conversion Rate</th>
+                  <td>3,2 %</td>
+                  <td>3,5 %</td>
+                  <td>3,8 %</td>
+                </tr>
+                <tr>
+                  <th scope="row">Net Promoter Score</th>
+                  <td>41</td>
+                  <td>44</td>
+                  <td>46</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/tags-badges.html
+++ b/content-elements-examples/tags-badges.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Tags & Badges – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Tags & Badges.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Tags & Badges</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Labels oder Chips zur Kennzeichnung von Kategorien, Status oder Highlights.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Mehrfarbig"><span aria-hidden="true">⚙️</span>Mehrfarbig</span><span class="meta-pill" role="listitem" aria-label="Responsives Wrapping"><span aria-hidden="true">⚙️</span>Responsives Wrapping</span><span class="meta-pill" role="listitem" aria-label="ARIA Gruppe"><span aria-hidden="true">⚙️</span>ARIA Gruppe</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="badge-collection" role="list">
+            <span class="badge" role="listitem">UX Writing</span>
+            <span class="badge badge--success" role="listitem">Accessibility</span>
+            <span class="badge badge--warning" role="listitem">Research</span>
+            <span class="badge" role="listitem">Component Library</span>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/toast.html
+++ b/content-elements-examples/toast.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Toast – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Toast.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Toast</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Kurzlebige Benachrichtigungen, die temporär eingeblendet werden.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Aria Live"><span aria-hidden="true">⚙️</span>Aria Live</span><span class="meta-pill" role="listitem" aria-label="Auto Dismiss"><span aria-hidden="true">⚙️</span>Auto Dismiss</span><span class="meta-pill" role="listitem" aria-label="Mehrere Toaster"><span aria-hidden="true">⚙️</span>Mehrere Toaster</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="stack-md">
+            <button class="btn" type="button" data-toast-trigger>Toast anzeigen</button>
+            <div class="toast-region" role="status" aria-live="polite" data-toast-region></div>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/tooltip.html
+++ b/content-elements-examples/tooltip.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Tooltip – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Tooltip.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Tooltip</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Kurze Hilfetexte, die bei Hover oder Fokus zusätzliche Informationen geben.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Hover &amp; Focus"><span aria-hidden="true">⚙️</span>Hover &amp; Focus</span><span class="meta-pill" role="listitem" aria-label="Aria Expanded"><span aria-hidden="true">⚙️</span>Aria Expanded</span><span class="meta-pill" role="listitem" aria-label="Kurztexte"><span aria-hidden="true">⚙️</span>Kurztexte</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <div class="tooltip" aria-expanded="false" data-tooltip>
+            <button class="icon-button" type="button" aria-describedby="tooltip-1" data-tooltip-trigger>?</button>
+            <span class="tooltip__bubble" role="tooltip" id="tooltip-1">Wir speichern Ihre Einstellungen sicher verschlüsselt.</span>
+          </div>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/trust-badges.html
+++ b/content-elements-examples/trust-badges.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Trust Badges – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Trust Badges.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Trust Badges</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Sicherheits- und Vertrauenssiegel wie Zahlungsanbieter oder Zertifikate.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="SVG Icons"><span aria-hidden="true">⚙️</span>SVG Icons</span><span class="meta-pill" role="listitem" aria-label="Screenreader Text"><span aria-hidden="true">⚙️</span>Screenreader Text</span><span class="meta-pill" role="listitem" aria-label="Responsives Grid"><span aria-hidden="true">⚙️</span>Responsives Grid</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="trust-badges" aria-label="Vertrauenssiegel">
+            <span class="trust-badge">
+              <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M4 6l12-4 12 4v8c0 8-5.3 12.7-12 16-6.7-3.3-12-8-12-16z" fill="currentColor" opacity="0.1"></path><path d="M10 14l4 4 8-8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"></path></svg>
+              <span>Trusted Shop</span>
+            </span>
+            <span class="trust-badge">
+              <svg viewBox="0 0 32 32" aria-hidden="true"><circle cx="16" cy="16" r="14" fill="currentColor" opacity="0.1"></circle><path d="M10 16l4 4 8-8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"></path></svg>
+              <span>SSL Secure</span>
+            </span>
+            <span class="trust-badge">
+              <svg viewBox="0 0 32 32" aria-hidden="true"><rect x="6" y="6" width="20" height="20" rx="6" fill="currentColor" opacity="0.1"></rect><path d="M12 16h8" stroke="currentColor" stroke-width="2"></path><path d="M16 12v8" stroke="currentColor" stroke-width="2"></path></svg>
+              <span>30 Tage Rückgabe</span>
+            </span>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/typography.html
+++ b/content-elements-examples/typography.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Typography – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Typography.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Typography</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Basis-Elemente für Textstruktur wie Überschriften, Absätze, Listen und Zitate, die Inhalte lesbar und hierarchisch gliedern.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Skalierende Fonts"><span aria-hidden="true">⚙️</span>Skalierende Fonts</span><span class="meta-pill" role="listitem" aria-label="Lesbare Länge"><span aria-hidden="true">⚙️</span>Lesbare Länge</span><span class="meta-pill" role="listitem" aria-label="Zitate"><span aria-hidden="true">⚙️</span>Zitate</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <article class="typography-demo">
+            <header>
+              <h1>Designsystem Playbook 2025</h1>
+              <p>Ein Leitfaden für skalierbare Content- und UI-Strukturen.</p>
+            </header>
+            <h2 id="abschnitt-1">Einleitung</h2>
+            <p>Klare Typografie schafft Orientierung und steigert die Lesbarkeit auf allen Geräten. Unsere Skala folgt einem modularen System.</p>
+            <h3>Listen &amp; Gliederung</h3>
+            <ul>
+              <li>Definierte Hierarchien</li>
+              <li>Kontrastreiche Linkstile</li>
+              <li>Klare Abstände</li>
+            </ul>
+            <blockquote id="abschnitt-2">„Design ist nicht nur wie es aussieht und sich anfühlt. Design ist wie es funktioniert.“ – Steve Jobs</blockquote>
+            <pre><code>npm install @acme/content-kit</code></pre>
+          </article>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>

--- a/content-elements-examples/video-embed.html
+++ b/content-elements-examples/video-embed.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Video Embed – Content Element Beispiel</title>
+    <meta name="description" content="Beispielimplementierung für das Content-Element Video Embed.">
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Zum Inhalt springen</a>
+    <header class="site-header">
+      <p class="badge">Content Element Beispiel</p>
+      <h1 class="site-header__title">Video Embed</h1>
+    </header>
+    <main id="main" class="component-page" tabindex="-1">
+      <article class="component-preview">
+        <header class="component-preview__header">
+          <h2 class="component-preview__title">Live-Demo</h2>
+          <p class="component-preview__description">Einbettung von Videos mit Poster, Controls und optionaler Lazyload-Lösung.</p>
+          <div class="component-meta" role="list">
+            <span class="meta-pill" role="listitem" aria-label="Responsive Wrapper"><span aria-hidden="true">⚙️</span>Responsive Wrapper</span><span class="meta-pill" role="listitem" aria-label="Titel &amp; Transcript"><span aria-hidden="true">⚙️</span>Titel &amp; Transcript</span><span class="meta-pill" role="listitem" aria-label="Lazy Loading"><span aria-hidden="true">⚙️</span>Lazy Loading</span>
+          </div>
+        </header>
+        <section class="component-preview__example" aria-label="Beispiel">
+          <section class="card">
+            <h2>Produktdemo</h2>
+            <div class="video-frame">
+              <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Produktdemo Video" loading="lazy" allowfullscreen></iframe>
+            </div>
+            <details>
+              <summary>Transkript anzeigen</summary>
+              <p class="text-muted">In diesem Video erfahren Sie, wie das Onboarding in weniger als fünf Minuten funktioniert.</p>
+            </details>
+          </section>
+        </section>
+        
+      </article>
+    </main>
+    <script src="assets/scripts.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a reusable generator that builds example pages for every content element markdown entry
- introduce shared mobile-first CSS and vanilla JS that implement accessible interactions for the gallery
- generate dedicated HTML demos for all documented content elements using the shared assets

## Testing
- python content-elements-examples/generate_examples.py