### PR TITLE
Convert example markdown to HTML in Pages workflow

### DIFF
--- a/.github/workflows/examples-pages.yml
+++ b/.github/workflows/examples-pages.yml
@@ -25,18 +25,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare dist
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
+      - name: Prepare dist & convert Markdown
         run: |
           rm -rf dist
-          mkdir -p dist
-          # 1) Kopiere beide Beispiel-Ordner
+          mkdir -p dist/layout-examples dist/content-elements-examples
+
+          # 1) Kopiere alle Quellen
           rsync -a layout-examples/ dist/layout-examples/ || true
           rsync -a content-elements-examples/ dist/content-elements-examples/ || true
 
-          # 2) GitHub soll keine Jekyll-Transformation versuchen
+          # 2) Konvertiere alle .md -> .html (parallel in-place in dist)
+          find dist/layout-examples dist/content-elements-examples -type f -iname "*.md" | while read -r f; do
+            html="${f%.md}.html"
+            pandoc "$f" -f markdown -t html5 -s -o "$html"
+          done
+
+          # 3) .nojekyll, damit Pages nichts umbaut
           touch dist/.nojekyll
 
-          # 3) Erzeuge index.html mit Linkliste
+          # 4) index.html mit Linkliste NUR auf HTML/HTM
           cat > dist/index.html <<'HTML'
           <!doctype html>
           <meta charset="utf-8">
@@ -50,22 +60,22 @@ jobs:
             code{background:#f6f8fa;padding:.1rem .3rem;border-radius:.25rem}
           </style>
           <h1>Examples</h1>
-          <p>Automatisch deployte Beispiele aus <code>layout-examples/</code> und <code>content-elements-examples/</code>.</p>
+          <p>Gerenderte Beispiele aus <code>layout-examples/</code> und <code>content-elements-examples/</code>. Markdown wurde in HTML konvertiert.</p>
           <ul>
           HTML
-          find layout-examples content-elements-examples -type f \( -iname "*.html" -o -iname "*.htm" -o -iname "*.md" \) | sort | while read -r f; do
+          find dist/layout-examples dist/content-elements-examples -type f \( -iname "*.html" -o -iname "*.htm" \) | sed 's#^dist/##' | sort | while read -r f; do
             esc="$(printf '%s\n' "$f" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')"
             echo "<li><a href=\"${esc}\">${esc}</a></li>" >> dist/index.html
           done
           echo "</ul>" >> dist/index.html
 
-          # 4) Erzeuge 404.html, die auf index.html umleitet
+          # 5) 404 → zurück zur Übersicht
           cat > dist/404.html <<'HTML'
           <!doctype html>
           <meta charset="utf-8">
           <title>Not Found</title>
           <meta http-equiv="refresh" content="0; url=./index.html">
-          <p>Seite nicht gefunden. <a href="./index.html">Zurück zur Übersicht</a>.</p>
+          <p>Seite nicht gefunden. <a href="./index.html">Zur Übersicht</a>.</p>
           HTML
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- install pandoc during the examples deployment workflow
- convert Markdown example files to HTML after copying into the dist directory
- generate the index so it only links to rendered HTML/HTM files while leaving Markdown copies available

## Testing
- not run (workflow change)