### PR TITLE
Adjust layout headers and expand Pages deployment

### DIFF
--- a/.github/workflows/examples-pages.yml
+++ b/.github/workflows/examples-pages.yml
@@ -31,14 +31,13 @@ jobs:
       - name: Prepare dist & convert Markdown
         run: |
           rm -rf dist
-          mkdir -p dist/layout-examples dist/content-elements-examples
+          mkdir -p dist
 
-          # 1) Kopiere alle Quellen
-          rsync -a layout-examples/ dist/layout-examples/ || true
-          rsync -a content-elements-examples/ dist/content-elements-examples/ || true
+          # 1) Kopiere das komplette Repository (ohne Git-Metadaten) nach dist/
+          rsync -a --exclude 'dist/' --exclude '.git/' ./ dist/
 
           # 2) Konvertiere alle .md -> .html (parallel in-place in dist)
-          find dist/layout-examples dist/content-elements-examples -type f -iname "*.md" | while read -r f; do
+          find dist -type f -iname "*.md" | while read -r f; do
             html="${f%.md}.html"
             pandoc "$f" -f markdown -t html5 -s -o "$html"
           done
@@ -46,11 +45,11 @@ jobs:
           # 3) .nojekyll, damit Pages nichts umbaut
           touch dist/.nojekyll
 
-          # 4) index.html mit Linkliste NUR auf HTML/HTM
+          # 4) index.html mit Linkliste aller HTML/HTM-Dateien
           cat > dist/index.html <<'HTML'
           <!doctype html>
           <meta charset="utf-8">
-          <title>Examples</title>
+          <title>Repository Preview</title>
           <meta name="viewport" content="width=device-width,initial-scale=1">
           <style>
             body{font:16px/1.5 system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:2rem;max-width:72ch}
@@ -59,11 +58,12 @@ jobs:
             a{word-break:break-word}
             code{background:#f6f8fa;padding:.1rem .3rem;border-radius:.25rem}
           </style>
-          <h1>Examples</h1>
-          <p>Gerenderte Beispiele aus <code>layout-examples/</code> und <code>content-elements-examples/</code>. Markdown wurde in HTML konvertiert.</p>
+          <h1>Randnotizen – Repository Vorschau</h1>
+          <p>Alle Dateien aus dem Repo werden auf GitHub Pages bereitgestellt. Markdown-Dateien liegen zusätzlich als HTML-Versionen vor.</p>
           <ul>
           HTML
-          find dist/layout-examples dist/content-elements-examples -type f \( -iname "*.html" -o -iname "*.htm" \) | sed 's#^dist/##' | sort | while read -r f; do
+          find dist -type f \( -iname "*.html" -o -iname "*.htm" \) \
+            ! -path "dist/index.html" ! -path "dist/404.html" | sed 's#^dist/##' | sort | while read -r f; do
             esc="$(printf '%s\n' "$f" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')"
             echo "<li><a href=\"${esc}\">${esc}</a></li>" >> dist/index.html
           done

--- a/layout-examples/accordion-layout.html
+++ b/layout-examples/accordion-layout.html
@@ -70,23 +70,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/accordion-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Accordion Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -133,15 +119,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Accordion Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/assets/base.css
+++ b/layout-examples/assets/base.css
@@ -93,6 +93,20 @@ a:focus-visible {
   z-index: 500;
 }
 
+.site-header__inner {
+  max-width: var(--container-max);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.site-header__title {
+  font-weight: 600;
+  font-size: clamp(1.25rem, 2vw + 1rem, 1.75rem);
+  margin: 0;
+}
+
 .site-header__brand {
   display: flex;
   gap: 0.75rem;

--- a/layout-examples/asymmetric-layout.html
+++ b/layout-examples/asymmetric-layout.html
@@ -58,23 +58,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/asymmetric-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Asymmetrisches Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -120,15 +106,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Asymmetrisches Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/blog-layout.html
+++ b/layout-examples/blog-layout.html
@@ -63,23 +63,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/blog-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Blog Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -137,15 +123,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Blog Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/card-layout.html
+++ b/layout-examples/card-layout.html
@@ -44,23 +44,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/card-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Card Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -103,15 +89,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Card Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/centered-content.html
+++ b/layout-examples/centered-content.html
@@ -25,23 +25,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/centered-content.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Centered Content</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -67,15 +53,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Centered Content</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/chat-interface.html
+++ b/layout-examples/chat-interface.html
@@ -66,23 +66,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/chat-interface.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Chat Interface</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -116,7 +102,6 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Chat Interface</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
@@ -137,9 +122,6 @@ const form = document.querySelector('.composer');
       bubble.scrollIntoView({ behavior: 'smooth', block: 'end' });
       input.value = '';
     });
-  </script>
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 </body>
 </html>

--- a/layout-examples/cover-page.html
+++ b/layout-examples/cover-page.html
@@ -54,23 +54,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/cover-page.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Cover Page</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -95,15 +81,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Cover Page</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/dashboard-layout.html
+++ b/layout-examples/dashboard-layout.html
@@ -51,23 +51,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/dashboard-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Dashboard Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -118,15 +104,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Dashboard Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/ecommerce-product-grid.html
+++ b/layout-examples/ecommerce-product-grid.html
@@ -56,23 +56,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/ecommerce-product-grid.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">E-Commerce Produktgrid</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -119,15 +105,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · E-Commerce Produktgrid</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/fixed-footer.html
+++ b/layout-examples/fixed-footer.html
@@ -32,23 +32,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/deprecated/fixed-footer.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Fixed Footer</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -69,15 +55,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Fixed Footer</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/full-height-layout.html
+++ b/layout-examples/full-height-layout.html
@@ -39,23 +39,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/full-height-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Full Height Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -81,15 +67,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Full Height Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/full-width-hero.html
+++ b/layout-examples/full-width-hero.html
@@ -52,23 +52,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/full-width-hero.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Full Width Hero</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -97,15 +83,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Full Width Hero</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/fullscreen-layout.html
+++ b/layout-examples/fullscreen-layout.html
@@ -32,23 +32,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/fullscreen-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Fullscreen Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -72,15 +58,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Fullscreen Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/gallery-layout.html
+++ b/layout-examples/gallery-layout.html
@@ -40,23 +40,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/gallery-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Gallery Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -79,15 +65,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Gallery Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/generate_pages.py
+++ b/layout-examples/generate_pages.py
@@ -22,23 +22,9 @@ BASE_TEMPLATE = """<!DOCTYPE html>
 <body>
   <a class=\"skip-link\" href=\"#main\">Zum Inhalt springen</a>
   <header class=\"site-header\" role=\"banner\">
-    <nav class=\"site-nav\" aria-label=\"Hauptnavigation\">
-      <a class=\"site-header__brand\" href=\"#\">
-        <span class=\"site-header__logo\" aria-hidden=\"true\">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class=\"site-nav__toggle\" type=\"button\" data-nav-toggle aria-expanded=\"false\">
-        <svg aria-hidden=\"true\" viewBox=\"0 0 24 24\" fill=\"none\">
-          <path stroke=\"currentColor\" stroke-width=\"1.6\" stroke-linecap=\"round\" d=\"M4 6h16M4 12h16M4 18h16\" />
-        </svg>
-        Menü
-      </button>
-      <ul class=\"site-nav__links\" data-nav-list aria-expanded=\"false\">
-        <li><a href=\"{markdown_link}\">Markdown</a></li>
-        <li><a href=\"index.html\">Übersicht</a></li>
-        <li><a href=\"#preview\">Demo</a></li>
-      </ul>
-    </nav>
+    <div class=\"site-header__inner\">
+      <span class=\"site-header__title\">{title}</span>
+    </div>
   </header>
 
   <main id=\"main\" class=\"content-width layout-page\" tabindex=\"-1\">
@@ -52,16 +38,12 @@ BASE_TEMPLATE = """<!DOCTYPE html>
 
   <footer class=\"site-footer site-header\" role=\"contentinfo\">
     <div class=\"site-nav\">
-      <p>&copy; <span id=\"year\">2025</span> Randnotizen · {title}</p>
       <a href=\"#main\">Nach oben</a>
     </div>
   </footer>
 
   <script src=\"assets/base.js\"></script>
 {script_block}
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>
 """
@@ -2263,7 +2245,6 @@ def generate_page(slug: str, config: dict[str, str]) -> str:
       main=main,
       style_block=style_block,
       script_block=script_block,
-      markdown_link=config["markdown_link"],
   )
 
 
@@ -2319,12 +2300,9 @@ def build_index(layouts: dict[str, dict[str, str]]) -> str:
 <body>
   <a class=\"skip-link\" href=\"#main\">Zum Inhalt springen</a>
   <header class=\"site-header\" role=\"banner\">
-    <nav class=\"site-nav\" aria-label=\"Navigation\">
-      <a class=\"site-header__brand\" href=\"#\">
-        <span class=\"site-header__logo\" aria-hidden=\"true\">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-    </nav>
+    <div class=\"site-header__inner\">
+      <span class=\"site-header__title\">Layout Demos</span>
+    </div>
   </header>
   <main id=\"main\" class=\"content-width\" tabindex=\"-1\">
     <section class=\"layout-intro\">
@@ -2338,11 +2316,10 @@ def build_index(layouts: dict[str, dict[str, str]]) -> str:
   </main>
   <footer class=\"site-footer site-header\" role=\"contentinfo\">
     <div class=\"site-nav\">
-      <p>&copy; <span id=\"year\">2025</span> Randnotizen Layouts</p>
+      <a href=\"#main\">Nach oben</a>
     </div>
   </footer>
   <script src=\"assets/base.js\"></script>
-  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>
 """

--- a/layout-examples/grid-layout.html
+++ b/layout-examples/grid-layout.html
@@ -41,23 +41,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/grid-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Grid Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -89,15 +75,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Grid Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/header-content-footer.html
+++ b/layout-examples/header-content-footer.html
@@ -33,23 +33,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/header-content-footer.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Header Content Footer</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -77,15 +63,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Header Content Footer</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/header-footer.html
+++ b/layout-examples/header-footer.html
@@ -27,23 +27,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/header-footer.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Header Footer</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -69,15 +55,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Header Footer</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/header-sticky-navigation.html
+++ b/layout-examples/header-sticky-navigation.html
@@ -47,23 +47,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/header-sticky-navigation.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Header Sticky Navigation</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -96,15 +82,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Header Sticky Navigation</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/horizontal-scrolling.html
+++ b/layout-examples/horizontal-scrolling.html
@@ -29,23 +29,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/deprecated/horizontal-scrolling.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Horizontal Scrolling</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -68,15 +54,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Horizontal Scrolling</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/index.html
+++ b/layout-examples/index.html
@@ -39,12 +39,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Navigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Layout Demos</span>
+    </div>
   </header>
   <main id="main" class="content-width" tabindex="-1">
     <section class="layout-intro">
@@ -96,10 +93,9 @@
   </main>
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen Layouts</p>
+      <a href="#main">Nach oben</a>
     </div>
   </footer>
   <script src="assets/base.js"></script>
-  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/layout-examples/landing-page.html
+++ b/layout-examples/landing-page.html
@@ -43,23 +43,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/landing-page.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Landing Page</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -97,15 +83,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Landing Page</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/magazine-layout.html
+++ b/layout-examples/magazine-layout.html
@@ -48,23 +48,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/magazine-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Magazin Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -95,15 +81,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Magazin Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/masonry-layout.html
+++ b/layout-examples/masonry-layout.html
@@ -43,23 +43,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/masonry-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Masonry Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -91,15 +77,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Masonry Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/navigation-overlay.html
+++ b/layout-examples/navigation-overlay.html
@@ -47,23 +47,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/navigation-overlay.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Navigation Overlay</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -90,15 +76,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Navigation Overlay</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/nested-columns.html
+++ b/layout-examples/nested-columns.html
@@ -35,23 +35,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/deprecated/nested-columns.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Nested Columns</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -81,15 +67,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Nested Columns</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/one-column.html
+++ b/layout-examples/one-column.html
@@ -21,23 +21,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/one-column.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">One Column</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -57,15 +43,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · One Column</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/portfolio-layout.html
+++ b/layout-examples/portfolio-layout.html
@@ -41,23 +41,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/portfolio-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Portfolio Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -95,15 +81,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Portfolio Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/responsive-flexbox.html
+++ b/layout-examples/responsive-flexbox.html
@@ -39,23 +39,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/responsive-flexbox.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Responsive Flexbox</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -79,15 +65,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Responsive Flexbox</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/sidebar-dropdown-menu.html
+++ b/layout-examples/sidebar-dropdown-menu.html
@@ -79,23 +79,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/sidebar-dropdown-menu.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Sidebar Dropdown Menü</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -134,15 +120,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Sidebar Dropdown Menü</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/sidebar-navigation.html
+++ b/layout-examples/sidebar-navigation.html
@@ -39,23 +39,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/deprecated/sidebar-navigation.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Sidebar Navigation</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -84,15 +70,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Sidebar Navigation</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/spa-layout.html
+++ b/layout-examples/spa-layout.html
@@ -44,23 +44,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/spa-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">SPA Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -93,15 +79,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · SPA Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/split-header.html
+++ b/layout-examples/split-header.html
@@ -31,23 +31,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/deprecated/split-header.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Split Header</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -69,15 +55,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Split Header</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/split-screen.html
+++ b/layout-examples/split-screen.html
@@ -33,23 +33,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/split-screen.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Split Screen</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -73,15 +59,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Split Screen</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/sticky-sidebar.html
+++ b/layout-examples/sticky-sidebar.html
@@ -44,23 +44,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/sticky-sidebar.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Sticky Sidebar</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -88,15 +74,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Sticky Sidebar</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/tabbed-interface.html
+++ b/layout-examples/tabbed-interface.html
@@ -43,23 +43,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/tabbed-interface.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Tabbed Interface</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -90,15 +76,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Tabbed Interface</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/three-columns.html
+++ b/layout-examples/three-columns.html
@@ -33,23 +33,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/deprecated/three-columns.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Three Columns</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -69,15 +55,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Three Columns</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/timeline-layout.html
+++ b/layout-examples/timeline-layout.html
@@ -53,23 +53,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/timeline-layout.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Timeline Layout</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -100,15 +86,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Timeline Layout</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/two-column-equal-width.html
+++ b/layout-examples/two-column-equal-width.html
@@ -33,23 +33,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/two-column-equal-width.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Zweispaltig (gleich breit)</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -73,15 +59,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Zweispaltig (gleich breit)</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/two-column-left-sidebar.html
+++ b/layout-examples/two-column-left-sidebar.html
@@ -35,23 +35,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/two-column-left-sidebar.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Zweispaltig mit linker Sidebar</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -75,15 +61,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Zweispaltig mit linker Sidebar</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/layout-examples/two-column-right-sidebar.html
+++ b/layout-examples/two-column-right-sidebar.html
@@ -35,23 +35,9 @@
 <body>
   <a class="skip-link" href="#main">Zum Inhalt springen</a>
   <header class="site-header" role="banner">
-    <nav class="site-nav" aria-label="Hauptnavigation">
-      <a class="site-header__brand" href="#">
-        <span class="site-header__logo" aria-hidden="true">UX</span>
-        <span>Randnotizen Layouts</span>
-      </a>
-      <button class="site-nav__toggle" type="button" data-nav-toggle aria-expanded="false">
-        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none">
-          <path stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-        Menü
-      </button>
-      <ul class="site-nav__links" data-nav-list aria-expanded="false">
-        <li><a href="../layouts/relevant/two-column-right-sidebar.md">Markdown</a></li>
-        <li><a href="index.html">Übersicht</a></li>
-        <li><a href="#preview">Demo</a></li>
-      </ul>
-    </nav>
+    <div class="site-header__inner">
+      <span class="site-header__title">Zweispaltig mit rechter Sidebar</span>
+    </div>
   </header>
 
   <main id="main" class="content-width layout-page" tabindex="-1">
@@ -75,15 +61,11 @@
 
   <footer class="site-footer site-header" role="contentinfo">
     <div class="site-nav">
-      <p>&copy; <span id="year">2025</span> Randnotizen · Zweispaltig mit rechter Sidebar</p>
       <a href="#main">Nach oben</a>
     </div>
   </footer>
 
   <script src="assets/base.js"></script>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the layout example navigation header with a simple title banner and regenerate all demo pages
- remove the footer copyright text while updating shared styles and the generator template
- deploy the complete repository via Pages and mirror every Markdown file as standalone HTML

## Testing
- python layout-examples/generate_pages.py