### PR TITLE
Add demo links to content element docs

### DIFF
--- a/content-elements/audio-embed.md
+++ b/content-elements/audio-embed.md
@@ -39,6 +39,8 @@ Einbettung eines Audio- oder Podcast-Players.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/audio-embed.html](../content-elements-examples/audio-embed.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <figure class="audio">

--- a/content-elements/breadcrumbs.md
+++ b/content-elements/breadcrumbs.md
@@ -39,6 +39,8 @@ Hierarchische Navigation zur Orientierung im Seitensystem.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/breadcrumbs.html](../content-elements-examples/breadcrumbs.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <nav aria-label="Breadcrumb">

--- a/content-elements/callout-box.md
+++ b/content-elements/callout-box.md
@@ -39,6 +39,8 @@ Hervorgehobene Boxen für Hinweise, Warnungen oder Erfolgsnachrichten innerhalb 
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/callout-box.html](../content-elements-examples/callout-box.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <aside class="callout callout--info">

--- a/content-elements/code-snippets.md
+++ b/content-elements/code-snippets.md
@@ -39,6 +39,8 @@ Darstellung von Codebeispielen als Inline- oder Block-Elemente inkl. Kopierfunkt
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/code-snippets.html](../content-elements-examples/code-snippets.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <figure class="code-snippet">

--- a/content-elements/contact-form.md
+++ b/content-elements/contact-form.md
@@ -39,6 +39,8 @@ Formular zur Kontaktaufnahme mit Validierung und Spam-Schutz.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/contact-form.html](../content-elements-examples/contact-form.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <form class="contact-form">

--- a/content-elements/cookie-consent.md
+++ b/content-elements/cookie-consent.md
@@ -39,6 +39,8 @@ Consent-Banner oder Layer zur Einholung der DSGVO-konformen Zustimmung für Cook
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/cookie-consent.html](../content-elements-examples/cookie-consent.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <div class="cookie-consent" role="dialog" aria-modal="true" aria-labelledby="cookie-title">

--- a/content-elements/date-picker.md
+++ b/content-elements/date-picker.md
@@ -39,6 +39,8 @@ Komponente zur Auswahl einzelner Daten oder Zeitspannen.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/date-picker.html](../content-elements-examples/date-picker.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <label for="date">Datum</label>

--- a/content-elements/dropdown-select.md
+++ b/content-elements/dropdown-select.md
@@ -39,6 +39,8 @@ Auswahlliste als Native-Select oder erweiterte Combobox.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/dropdown-select.html](../content-elements-examples/dropdown-select.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <label for="country">Land</label>

--- a/content-elements/empty-state.md
+++ b/content-elements/empty-state.md
@@ -39,6 +39,8 @@ Darstellung, wenn keine Daten oder Ergebnisse vorliegen.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/empty-state.html](../content-elements-examples/empty-state.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <section class="empty-state">

--- a/content-elements/file-uploader.md
+++ b/content-elements/file-uploader.md
@@ -39,6 +39,8 @@ Komponente zum Hochladen von Dateien inklusive Fortschritt und Validierung.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/file-uploader.html](../content-elements-examples/file-uploader.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <form class="uploader">

--- a/content-elements/filter-facets.md
+++ b/content-elements/filter-facets.md
@@ -39,6 +39,8 @@ Facettierte Filtersteuerung mit Chips, Listen oder Slidern.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/filter-facets.html](../content-elements-examples/filter-facets.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <section class="filters">

--- a/content-elements/image-carousel.md
+++ b/content-elements/image-carousel.md
@@ -39,6 +39,8 @@ Slider-Komponente für mehrere Bilder mit optionaler Lightbox.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/image-carousel.html](../content-elements-examples/image-carousel.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <div class="carousel" aria-roledescription="Karussell">

--- a/content-elements/image-with-caption.md
+++ b/content-elements/image-with-caption.md
@@ -39,6 +39,8 @@ Bilddarstellung mit erläuternder Bildunterschrift.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/image-with-caption.html](../content-elements-examples/image-with-caption.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <figure class="image">

--- a/content-elements/input-field.md
+++ b/content-elements/input-field.md
@@ -39,6 +39,8 @@ Standardisierte Eingabefelder für Text, E-Mail oder Nummern mit optionalen Mask
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/input-field.html](../content-elements-examples/input-field.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <label for="email">E-Mail</label>

--- a/content-elements/loading-spinner.md
+++ b/content-elements/loading-spinner.md
@@ -39,6 +39,8 @@ Animierter Indikator für laufende Prozesse.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/loading-spinner.html](../content-elements-examples/loading-spinner.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <div class="spinner" role="status" aria-live="polite">

--- a/content-elements/map-embed.md
+++ b/content-elements/map-embed.md
@@ -39,6 +39,8 @@ Interaktive Karte zur Standortanzeige oder Wegbeschreibung.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/map-embed.html](../content-elements-examples/map-embed.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <section class="map">

--- a/content-elements/mini-cart.md
+++ b/content-elements/mini-cart.md
@@ -39,6 +39,8 @@ Warenkorb-Vorschau als Off-Canvas oder Dropdown.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/mini-cart.html](../content-elements-examples/mini-cart.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <button type="button" aria-haspopup="dialog" aria-expanded="false">Warenkorb</button>

--- a/content-elements/modal.md
+++ b/content-elements/modal.md
@@ -39,6 +39,8 @@ Dialog-Overlay, das den restlichen Inhalt überlagert und fokussierte Interaktio
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/modal.html](../content-elements-examples/modal.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <button type="button" data-open="modal">Modal öffnen</button>

--- a/content-elements/multi-step-wizard.md
+++ b/content-elements/multi-step-wizard.md
@@ -39,6 +39,8 @@ Mehrschrittige Benutzerführung für komplexe Prozesse.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/multi-step-wizard.html](../content-elements-examples/multi-step-wizard.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <form class="wizard">

--- a/content-elements/newsletter-optin.md
+++ b/content-elements/newsletter-optin.md
@@ -39,6 +39,8 @@ Formular zum Anmelden für einen Newsletter mit Double-Opt-In.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/newsletter-optin.html](../content-elements-examples/newsletter-optin.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <form class="newsletter">

--- a/content-elements/notification-banner.md
+++ b/content-elements/notification-banner.md
@@ -39,6 +39,8 @@ Seitenweite Hinweise oder Promotions am oberen Rand.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/notification-banner.html](../content-elements-examples/notification-banner.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <div class="notification-banner" role="region" aria-label="Hinweis">

--- a/content-elements/pagination.md
+++ b/content-elements/pagination.md
@@ -39,6 +39,8 @@ Seitenweise Navigation für Listen und Suchergebnisse.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/pagination.html](../content-elements-examples/pagination.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <nav class="pagination" aria-label="Seiten">

--- a/content-elements/popover.md
+++ b/content-elements/popover.md
@@ -39,6 +39,8 @@ Kontextbezogene Overlays mit weiterführenden Inhalten oder Aktionen.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/popover.html](../content-elements-examples/popover.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <button type="button" aria-haspopup="dialog" aria-expanded="false">Details</button>

--- a/content-elements/price-comparison.md
+++ b/content-elements/price-comparison.md
@@ -39,6 +39,8 @@ Kompakte Vergleichstabelle für Tarife oder Pakete.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/price-comparison.html](../content-elements-examples/price-comparison.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <section class="pricing">

--- a/content-elements/product-card.md
+++ b/content-elements/product-card.md
@@ -39,6 +39,8 @@ Produktkachel mit Bild, Preis, Bewertung und CTA.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/product-card.html](../content-elements-examples/product-card.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <article class="product-card" itemscope itemtype="https://schema.org/Product">

--- a/content-elements/progress-stepper.md
+++ b/content-elements/progress-stepper.md
@@ -39,6 +39,8 @@ Visualisierung des Fortschritts in mehreren Schritten oder Phasen.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/progress-stepper.html](../content-elements-examples/progress-stepper.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <ol class="stepper">

--- a/content-elements/radio-checkbox-toggle.md
+++ b/content-elements/radio-checkbox-toggle.md
@@ -39,6 +39,8 @@ Steuerelemente für Einzel- oder Mehrfachauswahl inklusive Switches.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/radio-checkbox-toggle.html](../content-elements-examples/radio-checkbox-toggle.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <fieldset>

--- a/content-elements/review-form.md
+++ b/content-elements/review-form.md
@@ -39,6 +39,8 @@ Formular zum Abgeben von Bewertungen mit Rating und Textfeld.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/review-form.html](../content-elements-examples/review-form.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <form class="review-form">

--- a/content-elements/review-stars.md
+++ b/content-elements/review-stars.md
@@ -39,6 +39,8 @@ Darstellung von Bewertungen mit Sterne-Rating.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/review-stars.html](../content-elements-examples/review-stars.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <div class="rating" aria-label="4,5 von 5 Sternen">

--- a/content-elements/search.md
+++ b/content-elements/search.md
@@ -39,6 +39,8 @@ Suchfeld mit optionaler Autosuggest-Funktion.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/search.html](../content-elements-examples/search.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <form role="search">

--- a/content-elements/share-buttons.md
+++ b/content-elements/share-buttons.md
@@ -39,6 +39,8 @@ Buttons zum Teilen von Inhalten in sozialen Netzwerken oder per Link.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/share-buttons.html](../content-elements-examples/share-buttons.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <div class="share">

--- a/content-elements/skeleton-loader.md
+++ b/content-elements/skeleton-loader.md
@@ -39,6 +39,8 @@ Platzhalter-Layouts, die die spätere Struktur andeuten, während Inhalte laden.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/skeleton-loader.html](../content-elements-examples/skeleton-loader.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <div class="skeleton-card" aria-hidden="true">

--- a/content-elements/table-of-contents.md
+++ b/content-elements/table-of-contents.md
@@ -39,6 +39,8 @@ Strukturierte Liste von Ankern, die durch längere Inhalte navigiert.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/table-of-contents.html](../content-elements-examples/table-of-contents.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <nav class="toc" aria-label="Inhaltsverzeichnis">

--- a/content-elements/table.md
+++ b/content-elements/table.md
@@ -39,6 +39,8 @@ Tabellarische Darstellung von Daten mit Headern, Spalten und optionaler Sortieru
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/table.html](../content-elements-examples/table.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <table class="data-table">

--- a/content-elements/tags-badges.md
+++ b/content-elements/tags-badges.md
@@ -39,6 +39,8 @@ Labels oder Chips zur Kennzeichnung von Kategorien, Status oder Highlights.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/tags-badges.html](../content-elements-examples/tags-badges.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <ul class="tags">

--- a/content-elements/toast.md
+++ b/content-elements/toast.md
@@ -39,6 +39,8 @@ Kurzlebige Benachrichtigungen, die temporär eingeblendet werden.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/toast.html](../content-elements-examples/toast.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <div class="toast toast--success" role="status" aria-live="polite">Erfolg gespeichert.</div>

--- a/content-elements/tooltip.md
+++ b/content-elements/tooltip.md
@@ -39,6 +39,8 @@ Kurze Hilfetexte, die bei Hover oder Fokus zusätzliche Informationen geben.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/tooltip.html](../content-elements-examples/tooltip.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <button type="button" aria-describedby="tip-id">?

--- a/content-elements/trust-badges.md
+++ b/content-elements/trust-badges.md
@@ -39,6 +39,8 @@ Sicherheits- und Vertrauenssiegel wie Zahlungsanbieter oder Zertifikate.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/trust-badges.html](../content-elements-examples/trust-badges.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <ul class="trust-badges">

--- a/content-elements/typography.md
+++ b/content-elements/typography.md
@@ -39,6 +39,8 @@ Basis-Elemente für Textstruktur wie Überschriften, Absätze, Listen und Zitate
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/typography.html](../content-elements-examples/typography.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <article>

--- a/content-elements/video-embed.md
+++ b/content-elements/video-embed.md
@@ -39,6 +39,8 @@ Einbettung von Videos mit Poster, Controls und optionaler Lazyload-Lösung.
 - A11y & rechtliche Vorgaben erfüllt
 
 ## Beispiel / Code
+[content-elements-examples/video-embed.html](../content-elements-examples/video-embed.html)
+
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <figure class="video">


### PR DESCRIPTION
## Summary
- add links in each content element doc pointing to the corresponding HTML demo files under Beispiel / Code

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbee2085e48329840f9403aea3cbc0