### PR TITLE
Replace agents illustration with text placeholder

### DIFF
--- a/assets/agents-and-robots.txt
+++ b/assets/agents-and-robots.txt
@@ -1,0 +1,2 @@
+Dieses Projekt erwartet hier ein Bild mit der Illustration "Agents and Robots".
+Fügen Sie bei Bedarf eine geeignete Bilddatei hinzu und passen Sie die Verweise an.

--- a/content-elements-examples/audio-embed.html
+++ b/content-elements-examples/audio-embed.html
@@ -26,7 +26,7 @@
           <div class="audio-player" data-audio-player>
             <section class="card" aria-label="Aktuelle Episode">
               <div class="audio-player__meta">
-                <img class="audio-player__cover" src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=320&q=80" alt="Podcast Cover: Remote Culture" loading="lazy">
+                <img class="audio-player__cover" src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
                 <div>
                   <p class="text-muted">Remote Culture • Episode 12</p>
                   <h3 class="callout__title">Async Workflows, die funktionieren</h3>

--- a/content-elements-examples/component_data.py
+++ b/content-elements-examples/component_data.py
@@ -11,7 +11,7 @@ COMPONENTS: dict[str, dict[str, object]] = {
 <div class="audio-player" data-audio-player>
   <section class="card" aria-label="Aktuelle Episode">
     <div class="audio-player__meta">
-      <img class="audio-player__cover" src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=320&q=80" alt="Podcast Cover: Remote Culture" loading="lazy">
+      <img class="audio-player__cover" src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
       <div>
         <p class="text-muted">Remote Culture • Episode 12</p>
         <h3 class="callout__title">Async Workflows, die funktionieren</h3>
@@ -300,16 +300,16 @@ COMPONENTS: dict[str, dict[str, object]] = {
 <section class="carousel" data-carousel aria-roledescription="Karussell" aria-label="Produktbilder">
   <div class="carousel__slides" data-carousel-track>
     <figure class="carousel__slide" data-carousel-slide>
-      <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80" alt="Offenes, helles Wohnzimmer" loading="lazy">
-      <figcaption class="visually-hidden">Wohnbereich mit natürlichem Licht</figcaption>
+      <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+      <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
     </figure>
     <figure class="carousel__slide" data-carousel-slide>
-      <img src="https://images.unsplash.com/photo-1586023492125-27b2c045efd7?auto=format&fit=crop&w=900&q=80" alt="Moderne Küche mit Holzdekor" loading="lazy">
-      <figcaption class="visually-hidden">Moderne Küche</figcaption>
+      <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+      <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
     </figure>
     <figure class="carousel__slide" data-carousel-slide>
-      <img src="https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=900&q=80" alt="Gemütliches Schlafzimmer mit Pflanzen" loading="lazy">
-      <figcaption class="visually-hidden">Schlafzimmer mit Pflanzen</figcaption>
+      <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+      <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
     </figure>
   </div>
   <div class="carousel__controls" aria-hidden="true">
@@ -333,8 +333,8 @@ COMPONENTS: dict[str, dict[str, object]] = {
         "example": """
 <figure class="figure">
   <picture>
-    <source srcset="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=900&q=80" media="(min-width: 800px)">
-    <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=600&q=80" alt="Team, das gemeinsam an einem Tisch arbeitet" loading="lazy">
+    <source srcset="/assets/agents-and-robots.txt" media="(min-width: 800px)">
+    <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter zwischen Neonreklamen in einer futuristischen Stadt" loading="lazy">
   </picture>
   <figcaption>Team Sync im Workspace Berlin – Foto: <a href="https://unsplash.com" rel="noopener">Unsplash</a></figcaption>
 </figure>
@@ -402,7 +402,7 @@ COMPONENTS: dict[str, dict[str, object]] = {
         "example": """
 <section class="mini-cart" data-mini-cart aria-label="Mini Warenkorb">
   <div class="cart-item" data-cart-item>
-    <img src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=200&q=80" alt="Kabellose Kopfhörer" loading="lazy">
+    <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
     <div>
       <p>Kabellose Kopfhörer</p>
       <p class="text-muted">Lieferung in 2-3 Tagen</p>
@@ -412,7 +412,7 @@ COMPONENTS: dict[str, dict[str, object]] = {
     <strong data-item-price="129.90">129,90 €</strong>
   </div>
   <div class="cart-item" data-cart-item>
-    <img src="https://images.unsplash.com/photo-1512496015851-a90fb38ba796?auto=format&fit=crop&w=200&q=80" alt="Leder Schreibtischunterlage" loading="lazy">
+    <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
     <div>
       <p>Leder Desk Pad</p>
       <p class="text-muted">Nachhaltiges Leder</p>
@@ -633,7 +633,7 @@ COMPONENTS: dict[str, dict[str, object]] = {
         "example": """
 <article class="product-card">
   <div class="product-card__image">
-    <img src="https://images.unsplash.com/photo-1512499617640-c2f999098c01?auto=format&fit=crop&w=800&q=80" alt="Minimalistischer Bürostuhl in Grau" loading="lazy">
+    <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
   </div>
   <div class="product-card__body">
     <div class="review-stars">

--- a/content-elements-examples/image-carousel.html
+++ b/content-elements-examples/image-carousel.html
@@ -26,16 +26,16 @@
           <section class="carousel" data-carousel aria-roledescription="Karussell" aria-label="Produktbilder">
             <div class="carousel__slides" data-carousel-track>
               <figure class="carousel__slide" data-carousel-slide>
-                <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=900&q=80" alt="Offenes, helles Wohnzimmer" loading="lazy">
-                <figcaption class="visually-hidden">Wohnbereich mit natürlichem Licht</figcaption>
+                <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+                <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
               </figure>
               <figure class="carousel__slide" data-carousel-slide>
-                <img src="https://images.unsplash.com/photo-1586023492125-27b2c045efd7?auto=format&fit=crop&w=900&q=80" alt="Moderne Küche mit Holzdekor" loading="lazy">
-                <figcaption class="visually-hidden">Moderne Küche</figcaption>
+                <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+                <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
               </figure>
               <figure class="carousel__slide" data-carousel-slide>
-                <img src="https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=900&q=80" alt="Gemütliches Schlafzimmer mit Pflanzen" loading="lazy">
-                <figcaption class="visually-hidden">Schlafzimmer mit Pflanzen</figcaption>
+                <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+                <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
               </figure>
             </div>
             <div class="carousel__controls" aria-hidden="true">

--- a/content-elements-examples/image-with-caption.html
+++ b/content-elements-examples/image-with-caption.html
@@ -25,10 +25,10 @@
         <section class="component-preview__example" aria-label="Beispiel">
           <figure class="figure">
             <picture>
-              <source srcset="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=900&q=80" media="(min-width: 800px)">
-              <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=600&q=80" alt="Team, das gemeinsam an einem Tisch arbeitet" loading="lazy">
+              <source srcset="/assets/agents-and-robots.txt" media="(min-width: 800px)">
+              <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter zwischen Neonreklamen in einer futuristischen Stadt" loading="lazy">
             </picture>
-            <figcaption>Team Sync im Workspace Berlin – Foto: <a href="https://unsplash.com" rel="noopener">Unsplash</a></figcaption>
+            <figcaption>Agentin und Roboter in einer futuristischen Stadt bei Nacht.</figcaption>
           </figure>
         </section>
         

--- a/content-elements-examples/mini-cart.html
+++ b/content-elements-examples/mini-cart.html
@@ -25,7 +25,7 @@
         <section class="component-preview__example" aria-label="Beispiel">
           <section class="mini-cart" data-mini-cart aria-label="Mini Warenkorb">
             <div class="cart-item" data-cart-item>
-              <img src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?auto=format&fit=crop&w=200&q=80" alt="Kabellose Kopfhörer" loading="lazy">
+              <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
               <div>
                 <p>Kabellose Kopfhörer</p>
                 <p class="text-muted">Lieferung in 2-3 Tagen</p>
@@ -35,7 +35,7 @@
               <strong data-item-price="129.90">129,90 €</strong>
             </div>
             <div class="cart-item" data-cart-item>
-              <img src="https://images.unsplash.com/photo-1512496015851-a90fb38ba796?auto=format&fit=crop&w=200&q=80" alt="Leder Schreibtischunterlage" loading="lazy">
+              <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
               <div>
                 <p>Leder Desk Pad</p>
                 <p class="text-muted">Nachhaltiges Leder</p>

--- a/content-elements-examples/product-card.html
+++ b/content-elements-examples/product-card.html
@@ -25,7 +25,7 @@
         <section class="component-preview__example" aria-label="Beispiel">
           <article class="product-card">
             <div class="product-card__image">
-              <img src="https://images.unsplash.com/photo-1512499617640-c2f999098c01?auto=format&fit=crop&w=800&q=80" alt="Minimalistischer Bürostuhl in Grau" loading="lazy">
+              <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
             </div>
             <div class="product-card__body">
               <div class="review-stars">

--- a/content-elements/empty-state.md
+++ b/content-elements/empty-state.md
@@ -44,7 +44,7 @@ Darstellung, wenn keine Daten oder Ergebnisse vorliegen.
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <section class="empty-state">
-  <img src="empty.svg" alt="Kein Ergebnis gefunden" loading="lazy">
+  <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
   <h2>Keine Ergebnisse</h2>
   <p>Passen Sie Ihre Filter an oder starten Sie eine neue Suche.</p>
   <button type="button">Filter zurücksetzen</button>

--- a/content-elements/image-carousel.md
+++ b/content-elements/image-carousel.md
@@ -46,7 +46,7 @@ Slider-Komponente für mehrere Bilder mit optionaler Lightbox.
 <div class="carousel" aria-roledescription="Karussell">
   <button class="carousel__prev" aria-label="Vorheriges Bild">‹</button>
   <ul class="carousel__track">
-    <li class="carousel__slide"><img src="bild1.webp" alt="Produkt Vorderansicht" loading="lazy"></li>
+    <li class="carousel__slide"><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy"></li>
   </ul>
   <button class="carousel__next" aria-label="Nächstes Bild">›</button>
 </div>

--- a/content-elements/image-with-caption.md
+++ b/content-elements/image-with-caption.md
@@ -44,8 +44,8 @@ Bilddarstellung mit erläuternder Bildunterschrift.
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <figure class="image">
-  <img src="bild.webp" alt="Team arbeitet gemeinsam" loading="lazy">
-  <figcaption>Unser Team beim Sprint Planning. Foto: ACME.</figcaption>
+  <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
+  <figcaption>Agentin und Roboter beobachten die Stadtlichter.</figcaption>
 </figure>
 ```
 

--- a/content-elements/product-card.md
+++ b/content-elements/product-card.md
@@ -45,7 +45,7 @@ Produktkachel mit Bild, Preis, Bewertung und CTA.
 <!-- Minimales, valides HTML-Beispiel -->
 <article class="product-card" itemscope itemtype="https://schema.org/Product">
   <a href="/produkt" class="product-card__link">
-    <img src="produkt.webp" alt="Sneaker Modell X" loading="lazy" itemprop="image">
+    <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy" itemprop="image">
     <h3 itemprop="name">Sneaker X</h3>
     <p class="product-card__price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
       <span itemprop="price">89,90</span> €

--- a/content-elements/trust-badges.md
+++ b/content-elements/trust-badges.md
@@ -44,8 +44,8 @@ Sicherheits- und Vertrauenssiegel wie Zahlungsanbieter oder Zertifikate.
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <ul class="trust-badges">
-  <li><img src="tuev.svg" alt="TÜV zertifiziert"></li>
-  <li><img src="ssl.svg" alt="SSL verschlüsselt"></li>
+  <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht"></li>
+  <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht"></li>
 </ul>
 ```
 

--- a/generate_content_elements.py
+++ b/generate_content_elements.py
@@ -198,7 +198,7 @@ entries.extend([
             "Caption optional mit Quellenlink versehen."
         ],
         "dependencies": "Bild-CDN, Lightbox (optional)",
-        "example_html": "<figure class=\"image\">\n  <img src=\"bild.webp\" alt=\"Team arbeitet gemeinsam\" loading=\"lazy\">\n  <figcaption>Unser Team beim Sprint Planning. Foto: ACME.</figcaption>\n</figure>",
+        "example_html": "<figure class=\"image\">\n  <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\">\n  <figcaption>Agentin und Roboter beobachten die Stadtlichter.</figcaption>\n</figure>",
         "rating": "⭐⭐⭐⭐ Bilder mit Kontext bleiben wichtig für Storytelling und Compliance."
     },
     {
@@ -224,7 +224,7 @@ entries.extend([
             "Bildvorab-Laden für nächstes Slide optimieren."
         ],
         "dependencies": "Slider-Library, Lightbox, Bild-CDN",
-        "example_html": "<div class=\"carousel\" aria-roledescription=\"Karussell\">\n  <button class=\"carousel__prev\" aria-label=\"Vorheriges Bild\">‹</button>\n  <ul class=\"carousel__track\">\n    <li class=\"carousel__slide\"><img src=\"bild1.webp\" alt=\"Produkt Vorderansicht\" loading=\"lazy\"></li>\n  </ul>\n  <button class=\"carousel__next\" aria-label=\"Nächstes Bild\">›</button>\n</div>",
+        "example_html": "<div class=\"carousel\" aria-roledescription=\"Karussell\">\n  <button class=\"carousel__prev\" aria-label=\"Vorheriges Bild\">‹</button>\n  <ul class=\"carousel__track\">\n    <li class=\"carousel__slide\"><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\"></li>\n  </ul>\n  <button class=\"carousel__next\" aria-label=\"Nächstes Bild\">›</button>\n</div>",
         "rating": "⭐⭐⭐⭐ Karussells bleiben gängig, müssen jedoch nutzerzentriert optimiert werden."
     },
     {
@@ -722,7 +722,7 @@ entries.extend([
             "CTA mit eindeutiger Aktion beschriften."
         ],
         "dependencies": "Bewertungen, Preis-API, Tracking",
-        "example_html": "<article class=\"product-card\" itemscope itemtype=\"https://schema.org/Product\">\n  <a href=\"/produkt\" class=\"product-card__link\">\n    <img src=\"produkt.webp\" alt=\"Sneaker Modell X\" loading=\"lazy\" itemprop=\"image\">\n    <h3 itemprop=\"name\">Sneaker X</h3>\n    <p class=\"product-card__price\" itemprop=\"offers\" itemscope itemtype=\"https://schema.org/Offer\">\n      <span itemprop=\"price\">89,90</span> €\n    </p>\n  </a>\n  <button type=\"button\">In den Warenkorb</button>\n</article>",
+        "example_html": "<article class=\"product-card\" itemscope itemtype=\"https://schema.org/Product\">\n  <a href=\"/produkt\" class=\"product-card__link\">\n    <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\" itemprop=\"image\">\n    <h3 itemprop=\"name\">Sneaker X</h3>\n    <p class=\"product-card__price\" itemprop=\"offers\" itemscope itemtype=\"https://schema.org/Offer\">\n      <span itemprop=\"price\">89,90</span> €\n    </p>\n  </a>\n  <button type=\"button\">In den Warenkorb</button>\n</article>",
         "rating": "⭐⭐⭐⭐⭐ Produktkacheln sind zentral für E-Commerce und Conversion-relevant."
     },
     {
@@ -852,7 +852,7 @@ entries.extend([
             "Kontrast zum Hintergrund sicherstellen."
         ],
         "dependencies": "Asset-Management, Legal-Team",
-        "example_html": "<ul class=\"trust-badges\">\n  <li><img src=\"tuev.svg\" alt=\"TÜV zertifiziert\"></li>\n  <li><img src=\"ssl.svg\" alt=\"SSL verschlüsselt\"></li>\n</ul>",
+        "example_html": "<ul class=\"trust-badges\">\n  <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\"></li>\n  <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\"></li>\n</ul>",
         "rating": "⭐⭐⭐⭐ Vertrauenssiegel beeinflussen weiterhin Conversion und Glaubwürdigkeit."
     }
 ])
@@ -1036,7 +1036,7 @@ entries.extend([
             "Tonfall empathisch wählen."
         ],
         "dependencies": "Illustrationen, CTA-Komponenten",
-        "example_html": "<section class=\"empty-state\">\n  <img src=\"empty.svg\" alt=\"Kein Ergebnis gefunden\" loading=\"lazy\">\n  <h2>Keine Ergebnisse</h2>\n  <p>Passen Sie Ihre Filter an oder starten Sie eine neue Suche.</p>\n  <button type=\"button\">Filter zurücksetzen</button>\n</section>",
+        "example_html": "<section class=\"empty-state\">\n  <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\">\n  <h2>Keine Ergebnisse</h2>\n  <p>Passen Sie Ihre Filter an oder starten Sie eine neue Suche.</p>\n  <button type=\"button\">Filter zurücksetzen</button>\n</section>",
         "rating": "⭐⭐⭐⭐ Gute Empty States steigern Engagement und helfen bei der Orientierung."
     },
     {

--- a/layout-examples/asymmetric-layout.html
+++ b/layout-examples/asymmetric-layout.html
@@ -78,7 +78,7 @@
           breite Spalte mit großzügiger Typografie und Illustrationen.
         </p>
         <figure>
-          <img src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1400&q=80" alt="Designteam arbeitet gemeinsam am Whiteboard" />
+          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <figcaption>
             Prototyping Tag 3: Moderierte Remote-Tests, dokumentiert via Live-Notetaking.
           </figcaption>

--- a/layout-examples/blog-layout.html
+++ b/layout-examples/blog-layout.html
@@ -85,7 +85,7 @@
           <span>Produkt &amp; Design</span>
         </div>
         <figure>
-          <img src="https://images.unsplash.com/photo-1551434678-e076c223a692?auto=format&fit=crop&w=1400&q=80" alt="Laptop mit Interface-Design" />
+          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
         </figure>
         <p>
           Wie Design- und Engineering-Teams kollaborative Workflows etablieren, um Komponentenbibliotheken nachhaltig zu pflegen.

--- a/layout-examples/cover-page.html
+++ b/layout-examples/cover-page.html
@@ -25,7 +25,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1600&q=80') center/cover;
+      background: url('/assets/agents-and-robots.txt') center/cover;
       opacity: 0.35;
       mix-blend-mode: screen;
       pointer-events: none;

--- a/layout-examples/ecommerce-product-grid.html
+++ b/layout-examples/ecommerce-product-grid.html
@@ -80,22 +80,22 @@
       </header>
       <div class="products">
         <article>
-          <img src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=800&q=80" alt="Notizbuch aus recyceltem Papier" />
+          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <h3>Notizbuch Re:think</h3>
           <p class="price">€ 32</p>
         </article>
         <article>
-          <img src="https://images.unsplash.com/photo-1559050019-31e2a4f0b77b?auto=format&fit=crop&w=800&q=80" alt="Minimalistische Trinkflasche" />
+          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <h3>Hydrate Bottle</h3>
           <p class="price">€ 26</p>
         </article>
         <article>
-          <img src="https://images.unsplash.com/photo-1505740420928-5e560c06d30e?auto=format&fit=crop&w=800&q=80" alt="Kabellose Kopfhörer" />
+          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <h3>Focus Headphones</h3>
           <p class="price">€ 189</p>
         </article>
         <article>
-          <img src="https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=800&q=80" alt="Ergonomische Lampe" />
+          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <h3>Glow Desk Lamp</h3>
           <p class="price">€ 119</p>
         </article>

--- a/layout-examples/full-width-hero.html
+++ b/layout-examples/full-width-hero.html
@@ -76,7 +76,7 @@
         </div>
       </div>
       <figure class="media">
-        <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1400&q=80" alt="Team arbeitet gemeinsam am Laptop" />
+        <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
       </figure>
     </section>
   </main>

--- a/layout-examples/gallery-layout.html
+++ b/layout-examples/gallery-layout.html
@@ -55,10 +55,10 @@
     <section id="preview" class="layout-gallery" aria-labelledby="gallery-heading">
       <h2 id="gallery-heading">Moodboard</h2>
       <ul>
-        <li><img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=800&q=80" alt="Lichtdurchflutetes Büro" /></li>
-        <li><img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=800&q=80" alt="Moodboard mit Materialien" /></li>
-        <li><img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80" alt="Workshop Szene" /></li>
-        <li><img src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=800&q=80" alt="Person arbeitet auf Tablet" /></li>
+        <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
+        <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
+        <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
+        <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
       </ul>
     </section>
   </main>

--- a/layout-examples/generate_pages.py
+++ b/layout-examples/generate_pages.py
@@ -217,7 +217,7 @@ LAYOUTS: dict[str, dict[str, str]] = {
           breite Spalte mit großzügiger Typografie und Illustrationen.
         </p>
         <figure>
-          <img src=\"https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1400&q=80\" alt=\"Designteam arbeitet gemeinsam am Whiteboard\" />
+          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <figcaption>
             Prototyping Tag 3: Moderierte Remote-Tests, dokumentiert via Live-Notetaking.
           </figcaption>
@@ -312,7 +312,7 @@ LAYOUTS: dict[str, dict[str, str]] = {
           <span>Produkt &amp; Design</span>
         </div>
         <figure>
-          <img src=\"https://images.unsplash.com/photo-1551434678-e076c223a692?auto=format&fit=crop&w=1400&q=80\" alt=\"Laptop mit Interface-Design\" />
+          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
         </figure>
         <p>
           Wie Design- und Engineering-Teams kollaborative Workflows etablieren, um Komponentenbibliotheken nachhaltig zu pflegen.
@@ -567,7 +567,7 @@ LAYOUTS: dict[str, dict[str, str]] = {
       content: "";
       position: absolute;
       inset: 0;
-      background: url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1600&q=80') center/cover;
+      background: url('/assets/agents-and-robots.txt') center/cover;
       opacity: 0.35;
       mix-blend-mode: screen;
       pointer-events: none;
@@ -751,22 +751,22 @@ LAYOUTS: dict[str, dict[str, str]] = {
       </header>
       <div class=\"products\">
         <article>
-          <img src=\"https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=800&q=80\" alt=\"Notizbuch aus recyceltem Papier\" />
+          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <h3>Notizbuch Re:think</h3>
           <p class=\"price\">€ 32</p>
         </article>
         <article>
-          <img src=\"https://images.unsplash.com/photo-1559050019-31e2a4f0b77b?auto=format&fit=crop&w=800&q=80\" alt=\"Minimalistische Trinkflasche\" />
+          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <h3>Hydrate Bottle</h3>
           <p class=\"price\">€ 26</p>
         </article>
         <article>
-          <img src=\"https://images.unsplash.com/photo-1505740420928-5e560c06d30e?auto=format&fit=crop&w=800&q=80\" alt=\"Kabellose Kopfhörer\" />
+          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <h3>Focus Headphones</h3>
           <p class=\"price\">€ 189</p>
         </article>
         <article>
-          <img src=\"https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=800&q=80\" alt=\"Ergonomische Lampe\" />
+          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <h3>Glow Desk Lamp</h3>
           <p class=\"price\">€ 119</p>
         </article>
@@ -877,7 +877,7 @@ LAYOUTS: dict[str, dict[str, str]] = {
         </div>
       </div>
       <figure class=\"media\">
-        <img src=\"https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1400&q=80\" alt=\"Team arbeitet gemeinsam am Laptop\" />
+        <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
       </figure>
     </section>
         """,
@@ -955,10 +955,10 @@ LAYOUTS: dict[str, dict[str, str]] = {
     <section id=\"preview\" class=\"layout-gallery\" aria-labelledby=\"gallery-heading\">
       <h2 id=\"gallery-heading\">Moodboard</h2>
       <ul>
-        <li><img src=\"https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=800&q=80\" alt=\"Lichtdurchflutetes Büro\" /></li>
-        <li><img src=\"https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=800&q=80\" alt=\"Moodboard mit Materialien\" /></li>
-        <li><img src=\"https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80\" alt=\"Workshop Szene\" /></li>
-        <li><img src=\"https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=800&q=80\" alt=\"Person arbeitet auf Tablet\" /></li>
+        <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
+        <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
+        <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
+        <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
       </ul>
     </section>
         """,

--- a/layouts/relevant/card-layout.md
+++ b/layouts/relevant/card-layout.md
@@ -38,7 +38,7 @@ Karten bündeln Bild, Titel, Teasertext und CTA in wiederverwendbaren Modulen. S
 ## Beispiel / Code
 ```html
 <article class="card">
-  <img alt="" src="" />
+  <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
   <h3>…</h3>
   <p>…</p>
 </article>

--- a/layouts/relevant/split-screen.md
+++ b/layouts/relevant/split-screen.md
@@ -39,7 +39,7 @@ Zwei Bereiche teilen sich die Breite, häufig Text und Bild oder ein Formular ne
 ```html
 <section class="grid md:grid-cols-2">
   <div>Text</div>
-  <div><img alt="" /></div>
+  <div><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></div>
 </section>
 ```
 


### PR DESCRIPTION
## Summary
- remove the bundled agents-and-robots PNG asset and add a placeholder text file in its place
- update all content-element and layout snippets to reference the new placeholder asset path

## Testing
- not run (not requested)