### PR TITLE
Replace agents-and-robots asset references with PNG

### DIFF
--- a/content-elements-examples/audio-embed.html
+++ b/content-elements-examples/audio-embed.html
@@ -26,7 +26,7 @@
           <div class="audio-player" data-audio-player>
             <section class="card" aria-label="Aktuelle Episode">
               <div class="audio-player__meta">
-                <img class="audio-player__cover" src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
+                <img class="audio-player__cover" src="/assets/agents-and-robots.png" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
                 <div>
                   <p class="text-muted">Remote Culture • Episode 12</p>
                   <h3 class="callout__title">Async Workflows, die funktionieren</h3>

--- a/content-elements-examples/component_data.py
+++ b/content-elements-examples/component_data.py
@@ -11,7 +11,7 @@ COMPONENTS: dict[str, dict[str, object]] = {
 <div class="audio-player" data-audio-player>
   <section class="card" aria-label="Aktuelle Episode">
     <div class="audio-player__meta">
-      <img class="audio-player__cover" src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
+      <img class="audio-player__cover" src="/assets/agents-and-robots.png" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
       <div>
         <p class="text-muted">Remote Culture • Episode 12</p>
         <h3 class="callout__title">Async Workflows, die funktionieren</h3>
@@ -300,15 +300,15 @@ COMPONENTS: dict[str, dict[str, object]] = {
 <section class="carousel" data-carousel aria-roledescription="Karussell" aria-label="Produktbilder">
   <div class="carousel__slides" data-carousel-track>
     <figure class="carousel__slide" data-carousel-slide>
-      <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+      <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
       <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
     </figure>
     <figure class="carousel__slide" data-carousel-slide>
-      <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+      <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
       <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
     </figure>
     <figure class="carousel__slide" data-carousel-slide>
-      <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+      <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
       <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
     </figure>
   </div>
@@ -333,8 +333,8 @@ COMPONENTS: dict[str, dict[str, object]] = {
         "example": """
 <figure class="figure">
   <picture>
-    <source srcset="/assets/agents-and-robots.txt" media="(min-width: 800px)">
-    <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter zwischen Neonreklamen in einer futuristischen Stadt" loading="lazy">
+    <source srcset="/assets/agents-and-robots.png" media="(min-width: 800px)">
+    <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter zwischen Neonreklamen in einer futuristischen Stadt" loading="lazy">
   </picture>
   <figcaption>Team Sync im Workspace Berlin – Foto: <a href="https://unsplash.com" rel="noopener">Unsplash</a></figcaption>
 </figure>
@@ -402,7 +402,7 @@ COMPONENTS: dict[str, dict[str, object]] = {
         "example": """
 <section class="mini-cart" data-mini-cart aria-label="Mini Warenkorb">
   <div class="cart-item" data-cart-item>
-    <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
+    <img src="/assets/agents-and-robots.png" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
     <div>
       <p>Kabellose Kopfhörer</p>
       <p class="text-muted">Lieferung in 2-3 Tagen</p>
@@ -412,7 +412,7 @@ COMPONENTS: dict[str, dict[str, object]] = {
     <strong data-item-price="129.90">129,90 €</strong>
   </div>
   <div class="cart-item" data-cart-item>
-    <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
+    <img src="/assets/agents-and-robots.png" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
     <div>
       <p>Leder Desk Pad</p>
       <p class="text-muted">Nachhaltiges Leder</p>
@@ -633,7 +633,7 @@ COMPONENTS: dict[str, dict[str, object]] = {
         "example": """
 <article class="product-card">
   <div class="product-card__image">
-    <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
+    <img src="/assets/agents-and-robots.png" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
   </div>
   <div class="product-card__body">
     <div class="review-stars">

--- a/content-elements-examples/image-carousel.html
+++ b/content-elements-examples/image-carousel.html
@@ -26,15 +26,15 @@
           <section class="carousel" data-carousel aria-roledescription="Karussell" aria-label="Produktbilder">
             <div class="carousel__slides" data-carousel-track>
               <figure class="carousel__slide" data-carousel-slide>
-                <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+                <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
                 <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
               </figure>
               <figure class="carousel__slide" data-carousel-slide>
-                <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+                <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
                 <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
               </figure>
               <figure class="carousel__slide" data-carousel-slide>
-                <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
+                <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in futuristischer Stadt bei Nacht" loading="lazy">
                 <figcaption class="visually-hidden">Futuristische Stadt mit Agentin und Roboter</figcaption>
               </figure>
             </div>

--- a/content-elements-examples/image-with-caption.html
+++ b/content-elements-examples/image-with-caption.html
@@ -25,8 +25,8 @@
         <section class="component-preview__example" aria-label="Beispiel">
           <figure class="figure">
             <picture>
-              <source srcset="/assets/agents-and-robots.txt" media="(min-width: 800px)">
-              <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter zwischen Neonreklamen in einer futuristischen Stadt" loading="lazy">
+              <source srcset="/assets/agents-and-robots.png" media="(min-width: 800px)">
+              <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter zwischen Neonreklamen in einer futuristischen Stadt" loading="lazy">
             </picture>
             <figcaption>Agentin und Roboter in einer futuristischen Stadt bei Nacht.</figcaption>
           </figure>

--- a/content-elements-examples/mini-cart.html
+++ b/content-elements-examples/mini-cart.html
@@ -25,7 +25,7 @@
         <section class="component-preview__example" aria-label="Beispiel">
           <section class="mini-cart" data-mini-cart aria-label="Mini Warenkorb">
             <div class="cart-item" data-cart-item>
-              <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
+              <img src="/assets/agents-and-robots.png" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
               <div>
                 <p>Kabellose Kopfhörer</p>
                 <p class="text-muted">Lieferung in 2-3 Tagen</p>
@@ -35,7 +35,7 @@
               <strong data-item-price="129.90">129,90 €</strong>
             </div>
             <div class="cart-item" data-cart-item>
-              <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
+              <img src="/assets/agents-and-robots.png" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
               <div>
                 <p>Leder Desk Pad</p>
                 <p class="text-muted">Nachhaltiges Leder</p>

--- a/content-elements-examples/product-card.html
+++ b/content-elements-examples/product-card.html
@@ -25,7 +25,7 @@
         <section class="component-preview__example" aria-label="Beispiel">
           <article class="product-card">
             <div class="product-card__image">
-              <img src="/assets/agents-and-robots.txt" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
+              <img src="/assets/agents-and-robots.png" alt="Illustration einer Agentin und eines Roboters in einer futuristischen Stadt" loading="lazy">
             </div>
             <div class="product-card__body">
               <div class="review-stars">

--- a/content-elements/empty-state.md
+++ b/content-elements/empty-state.md
@@ -44,7 +44,7 @@ Darstellung, wenn keine Daten oder Ergebnisse vorliegen.
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <section class="empty-state">
-  <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
+  <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
   <h2>Keine Ergebnisse</h2>
   <p>Passen Sie Ihre Filter an oder starten Sie eine neue Suche.</p>
   <button type="button">Filter zurücksetzen</button>

--- a/content-elements/image-carousel.md
+++ b/content-elements/image-carousel.md
@@ -46,7 +46,7 @@ Slider-Komponente für mehrere Bilder mit optionaler Lightbox.
 <div class="carousel" aria-roledescription="Karussell">
   <button class="carousel__prev" aria-label="Vorheriges Bild">‹</button>
   <ul class="carousel__track">
-    <li class="carousel__slide"><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy"></li>
+    <li class="carousel__slide"><img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy"></li>
   </ul>
   <button class="carousel__next" aria-label="Nächstes Bild">›</button>
 </div>

--- a/content-elements/image-with-caption.md
+++ b/content-elements/image-with-caption.md
@@ -44,7 +44,7 @@ Bilddarstellung mit erläuternder Bildunterschrift.
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <figure class="image">
-  <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
+  <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
   <figcaption>Agentin und Roboter beobachten die Stadtlichter.</figcaption>
 </figure>
 ```

--- a/content-elements/product-card.md
+++ b/content-elements/product-card.md
@@ -45,7 +45,7 @@ Produktkachel mit Bild, Preis, Bewertung und CTA.
 <!-- Minimales, valides HTML-Beispiel -->
 <article class="product-card" itemscope itemtype="https://schema.org/Product">
   <a href="/produkt" class="product-card__link">
-    <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy" itemprop="image">
+    <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy" itemprop="image">
     <h3 itemprop="name">Sneaker X</h3>
     <p class="product-card__price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
       <span itemprop="price">89,90</span> €

--- a/content-elements/trust-badges.md
+++ b/content-elements/trust-badges.md
@@ -44,8 +44,8 @@ Sicherheits- und Vertrauenssiegel wie Zahlungsanbieter oder Zertifikate.
 ```html
 <!-- Minimales, valides HTML-Beispiel -->
 <ul class="trust-badges">
-  <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht"></li>
-  <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht"></li>
+  <li><img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht"></li>
+  <li><img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht"></li>
 </ul>
 ```
 

--- a/generate_content_elements.py
+++ b/generate_content_elements.py
@@ -198,7 +198,7 @@ entries.extend([
             "Caption optional mit Quellenlink versehen."
         ],
         "dependencies": "Bild-CDN, Lightbox (optional)",
-        "example_html": "<figure class=\"image\">\n  <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\">\n  <figcaption>Agentin und Roboter beobachten die Stadtlichter.</figcaption>\n</figure>",
+        "example_html": "<figure class=\"image\">\n  <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\">\n  <figcaption>Agentin und Roboter beobachten die Stadtlichter.</figcaption>\n</figure>",
         "rating": "⭐⭐⭐⭐ Bilder mit Kontext bleiben wichtig für Storytelling und Compliance."
     },
     {
@@ -224,7 +224,7 @@ entries.extend([
             "Bildvorab-Laden für nächstes Slide optimieren."
         ],
         "dependencies": "Slider-Library, Lightbox, Bild-CDN",
-        "example_html": "<div class=\"carousel\" aria-roledescription=\"Karussell\">\n  <button class=\"carousel__prev\" aria-label=\"Vorheriges Bild\">‹</button>\n  <ul class=\"carousel__track\">\n    <li class=\"carousel__slide\"><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\"></li>\n  </ul>\n  <button class=\"carousel__next\" aria-label=\"Nächstes Bild\">›</button>\n</div>",
+        "example_html": "<div class=\"carousel\" aria-roledescription=\"Karussell\">\n  <button class=\"carousel__prev\" aria-label=\"Vorheriges Bild\">‹</button>\n  <ul class=\"carousel__track\">\n    <li class=\"carousel__slide\"><img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\"></li>\n  </ul>\n  <button class=\"carousel__next\" aria-label=\"Nächstes Bild\">›</button>\n</div>",
         "rating": "⭐⭐⭐⭐ Karussells bleiben gängig, müssen jedoch nutzerzentriert optimiert werden."
     },
     {
@@ -722,7 +722,7 @@ entries.extend([
             "CTA mit eindeutiger Aktion beschriften."
         ],
         "dependencies": "Bewertungen, Preis-API, Tracking",
-        "example_html": "<article class=\"product-card\" itemscope itemtype=\"https://schema.org/Product\">\n  <a href=\"/produkt\" class=\"product-card__link\">\n    <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\" itemprop=\"image\">\n    <h3 itemprop=\"name\">Sneaker X</h3>\n    <p class=\"product-card__price\" itemprop=\"offers\" itemscope itemtype=\"https://schema.org/Offer\">\n      <span itemprop=\"price\">89,90</span> €\n    </p>\n  </a>\n  <button type=\"button\">In den Warenkorb</button>\n</article>",
+        "example_html": "<article class=\"product-card\" itemscope itemtype=\"https://schema.org/Product\">\n  <a href=\"/produkt\" class=\"product-card__link\">\n    <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\" itemprop=\"image\">\n    <h3 itemprop=\"name\">Sneaker X</h3>\n    <p class=\"product-card__price\" itemprop=\"offers\" itemscope itemtype=\"https://schema.org/Offer\">\n      <span itemprop=\"price\">89,90</span> €\n    </p>\n  </a>\n  <button type=\"button\">In den Warenkorb</button>\n</article>",
         "rating": "⭐⭐⭐⭐⭐ Produktkacheln sind zentral für E-Commerce und Conversion-relevant."
     },
     {
@@ -852,7 +852,7 @@ entries.extend([
             "Kontrast zum Hintergrund sicherstellen."
         ],
         "dependencies": "Asset-Management, Legal-Team",
-        "example_html": "<ul class=\"trust-badges\">\n  <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\"></li>\n  <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\"></li>\n</ul>",
+        "example_html": "<ul class=\"trust-badges\">\n  <li><img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\"></li>\n  <li><img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\"></li>\n</ul>",
         "rating": "⭐⭐⭐⭐ Vertrauenssiegel beeinflussen weiterhin Conversion und Glaubwürdigkeit."
     }
 ])
@@ -1036,7 +1036,7 @@ entries.extend([
             "Tonfall empathisch wählen."
         ],
         "dependencies": "Illustrationen, CTA-Komponenten",
-        "example_html": "<section class=\"empty-state\">\n  <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\">\n  <h2>Keine Ergebnisse</h2>\n  <p>Passen Sie Ihre Filter an oder starten Sie eine neue Suche.</p>\n  <button type=\"button\">Filter zurücksetzen</button>\n</section>",
+        "example_html": "<section class=\"empty-state\">\n  <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" loading=\"lazy\">\n  <h2>Keine Ergebnisse</h2>\n  <p>Passen Sie Ihre Filter an oder starten Sie eine neue Suche.</p>\n  <button type=\"button\">Filter zurücksetzen</button>\n</section>",
         "rating": "⭐⭐⭐⭐ Gute Empty States steigern Engagement und helfen bei der Orientierung."
     },
     {

--- a/layout-examples/asymmetric-layout.html
+++ b/layout-examples/asymmetric-layout.html
@@ -78,7 +78,7 @@
           breite Spalte mit großzügiger Typografie und Illustrationen.
         </p>
         <figure>
-          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+          <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <figcaption>
             Prototyping Tag 3: Moderierte Remote-Tests, dokumentiert via Live-Notetaking.
           </figcaption>

--- a/layout-examples/blog-layout.html
+++ b/layout-examples/blog-layout.html
@@ -85,7 +85,7 @@
           <span>Produkt &amp; Design</span>
         </div>
         <figure>
-          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+          <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
         </figure>
         <p>
           Wie Design- und Engineering-Teams kollaborative Workflows etablieren, um Komponentenbibliotheken nachhaltig zu pflegen.

--- a/layout-examples/cover-page.html
+++ b/layout-examples/cover-page.html
@@ -25,7 +25,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      background: url('/assets/agents-and-robots.txt') center/cover;
+      background: url('/assets/agents-and-robots.png') center/cover;
       opacity: 0.35;
       mix-blend-mode: screen;
       pointer-events: none;

--- a/layout-examples/ecommerce-product-grid.html
+++ b/layout-examples/ecommerce-product-grid.html
@@ -80,22 +80,22 @@
       </header>
       <div class="products">
         <article>
-          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+          <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <h3>Notizbuch Re:think</h3>
           <p class="price">€ 32</p>
         </article>
         <article>
-          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+          <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <h3>Hydrate Bottle</h3>
           <p class="price">€ 26</p>
         </article>
         <article>
-          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+          <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <h3>Focus Headphones</h3>
           <p class="price">€ 189</p>
         </article>
         <article>
-          <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+          <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
           <h3>Glow Desk Lamp</h3>
           <p class="price">€ 119</p>
         </article>

--- a/layout-examples/full-width-hero.html
+++ b/layout-examples/full-width-hero.html
@@ -76,7 +76,7 @@
         </div>
       </div>
       <figure class="media">
-        <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+        <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
       </figure>
     </section>
   </main>

--- a/layout-examples/gallery-layout.html
+++ b/layout-examples/gallery-layout.html
@@ -55,10 +55,10 @@
     <section id="preview" class="layout-gallery" aria-labelledby="gallery-heading">
       <h2 id="gallery-heading">Moodboard</h2>
       <ul>
-        <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
-        <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
-        <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
-        <li><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
+        <li><img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
+        <li><img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
+        <li><img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
+        <li><img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></li>
       </ul>
     </section>
   </main>

--- a/layout-examples/generate_pages.py
+++ b/layout-examples/generate_pages.py
@@ -217,7 +217,7 @@ LAYOUTS: dict[str, dict[str, str]] = {
           breite Spalte mit großzügiger Typografie und Illustrationen.
         </p>
         <figure>
-          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
+          <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <figcaption>
             Prototyping Tag 3: Moderierte Remote-Tests, dokumentiert via Live-Notetaking.
           </figcaption>
@@ -312,7 +312,7 @@ LAYOUTS: dict[str, dict[str, str]] = {
           <span>Produkt &amp; Design</span>
         </div>
         <figure>
-          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
+          <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
         </figure>
         <p>
           Wie Design- und Engineering-Teams kollaborative Workflows etablieren, um Komponentenbibliotheken nachhaltig zu pflegen.
@@ -567,7 +567,7 @@ LAYOUTS: dict[str, dict[str, str]] = {
       content: "";
       position: absolute;
       inset: 0;
-      background: url('/assets/agents-and-robots.txt') center/cover;
+      background: url('/assets/agents-and-robots.png') center/cover;
       opacity: 0.35;
       mix-blend-mode: screen;
       pointer-events: none;
@@ -751,22 +751,22 @@ LAYOUTS: dict[str, dict[str, str]] = {
       </header>
       <div class=\"products\">
         <article>
-          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
+          <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <h3>Notizbuch Re:think</h3>
           <p class=\"price\">€ 32</p>
         </article>
         <article>
-          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
+          <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <h3>Hydrate Bottle</h3>
           <p class=\"price\">€ 26</p>
         </article>
         <article>
-          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
+          <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <h3>Focus Headphones</h3>
           <p class=\"price\">€ 189</p>
         </article>
         <article>
-          <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
+          <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
           <h3>Glow Desk Lamp</h3>
           <p class=\"price\">€ 119</p>
         </article>
@@ -877,7 +877,7 @@ LAYOUTS: dict[str, dict[str, str]] = {
         </div>
       </div>
       <figure class=\"media\">
-        <img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
+        <img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" />
       </figure>
     </section>
         """,
@@ -955,10 +955,10 @@ LAYOUTS: dict[str, dict[str, str]] = {
     <section id=\"preview\" class=\"layout-gallery\" aria-labelledby=\"gallery-heading\">
       <h2 id=\"gallery-heading\">Moodboard</h2>
       <ul>
-        <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
-        <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
-        <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
-        <li><img src=\"/assets/agents-and-robots.txt\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
+        <li><img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
+        <li><img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
+        <li><img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
+        <li><img src=\"/assets/agents-and-robots.png\" alt=\"Agentin und Roboter in einer futuristischen Stadt bei Nacht\" /></li>
       </ul>
     </section>
         """,

--- a/layouts/relevant/card-layout.md
+++ b/layouts/relevant/card-layout.md
@@ -38,7 +38,7 @@ Karten bündeln Bild, Titel, Teasertext und CTA in wiederverwendbaren Modulen. S
 ## Beispiel / Code
 ```html
 <article class="card">
-  <img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+  <img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
   <h3>…</h3>
   <p>…</p>
 </article>

--- a/layouts/relevant/split-screen.md
+++ b/layouts/relevant/split-screen.md
@@ -39,7 +39,7 @@ Zwei Bereiche teilen sich die Breite, häufig Text und Bild oder ein Formular ne
 ```html
 <section class="grid md:grid-cols-2">
   <div>Text</div>
-  <div><img src="/assets/agents-and-robots.txt" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></div>
+  <div><img src="/assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></div>
 </section>
 ```
 


### PR DESCRIPTION
## Summary
- update all HTML and Markdown references to agents-and-robots asset to use the .png extension

## Testing
- not run