### PR TITLE
Set up Jekyll blog deployment

### DIFF
--- a/.github/workflows/examples-pages.yml
+++ b/.github/workflows/examples-pages.yml
@@ -28,61 +28,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install pandoc
-        run: sudo apt-get update && sudo apt-get install -y pandoc
-
-      - name: Prepare dist & convert Markdown
+      - name: Prepare dist
         run: |
           rm -rf dist
           mkdir -p dist
-
-          # 1) Kopiere das komplette Repository (ohne Git-Metadaten) nach dist/
           rsync -a --exclude 'dist/' --exclude '.git/' ./ dist/
-
-          # 2) Konvertiere alle .md -> .html (parallel in-place in dist)
-          find dist -type f -iname "*.md" | while read -r f; do
-            html="${f%.md}.html"
-            pandoc "$f" -f markdown -t html5 -s -o "$html"
-          done
-
-          # 3) .nojekyll, damit Pages nichts umbaut
           touch dist/.nojekyll
-
-          # 4) index.html mit Linkliste aller HTML/HTM-Dateien
-          cat > dist/index.html <<'HTML'
-          <!doctype html>
-          <meta charset="utf-8">
-          <title>Repository Preview</title>
-          <meta name="viewport" content="width=device-width,initial-scale=1">
-          <style>
-            body{font:16px/1.5 system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:2rem;max-width:72ch}
-            h1{margin:0 0 1rem}
-            ul{padding-left:1.2rem}
-            a{word-break:break-word}
-            code{background:#f6f8fa;padding:.1rem .3rem;border-radius:.25rem}
-          </style>
-          <h1>Randnotizen – Repository Vorschau</h1>
-          <p>Alle Dateien aus dem Repo werden auf GitHub Pages bereitgestellt. Markdown-Dateien liegen zusätzlich als HTML-Versionen vor.</p>
-          <ul>
-          HTML
-          find dist -type f \( -iname "*.html" -o -iname "*.htm" \) \
-            ! -path "dist/index.html" ! -path "dist/404.html" | sed 's#^dist/##' | sort | while read -r f; do
-            esc="$(printf '%s\n' "$f" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')"
-            echo "<li><a href=\"${esc}\">${esc}</a></li>" >> dist/index.html
-          done
-          echo "</ul>" >> dist/index.html
-
-          # 4b) Fehlende index.html-Dateien in Unterordnern erzeugen
-          python3 .github/scripts/generate_folder_indexes.py dist
-
-          # 5) 404 → zurück zur Übersicht
-          cat > dist/404.html <<'HTML'
-          <!doctype html>
-          <meta charset="utf-8">
-          <title>Not Found</title>
-          <meta http-equiv="refresh" content="0; url=./index.html">
-          <p>Seite nicht gefunden. <a href="./index.html">Zur Übersicht</a>.</p>
-          HTML
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,80 @@
+name: Build & Deploy Jekyll Blog
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '_posts/**'
+      - 'content-elements/**/*.md'
+      - 'layouts/**/*.md'
+      - 'frontend/**/*.md'
+      - '_config.yml'
+      - 'blog/**'
+      - '_includes/**'
+      - '_layouts/**'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '.github/workflows/jekyll.yml'
+  workflow_dispatch:
+
+env:
+  JEKYLL_BASEURL: /randnotizen
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: jekyll-blog
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Build Jekyll site
+        run: bundle exec jekyll build --baseurl "${{ env.JEKYLL_BASEURL || '/randnotizen' }}" --destination dist
+
+      - name: Copy static files
+        run: |
+          set -euo pipefail
+          for dir in assets layout-examples content-elements-examples; do
+            if [ -d "$dir" ]; then
+              rsync -a "$dir/" "dist/$dir/"
+            fi
+          done
+          for file in index.html README.md generate_content_elements.py; do
+            if [ -f "$file" ]; then
+              mkdir -p "dist/$(dirname "$file")"
+              cp "$file" "dist/$file"
+            fi
+          done
+          touch dist/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "jekyll-feed", "~> 0.16"

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,39 @@
+baseurl: "/randnotizen"
+permalink: /blog/:categories/:year/:month/:day/:title/
+markdown: kramdown
+plugins:
+  - jekyll-feed
+include:
+  - content-elements
+  - layouts
+  - frontend
+collections:
+  posts:
+    output: true
+
+defaults:
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: post
+  - scope:
+      path: "content-elements"
+      type: pages
+    values:
+      layout: post
+      categories: [content-elements]
+  - scope:
+      path: "layouts"
+      type: pages
+    values:
+      layout: post
+      categories: [layouts]
+  - scope:
+      path: "frontend"
+      type: pages
+    values:
+      layout: post
+      categories: [frontend]
+feed:
+  path: feed.xml

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,7 @@
+<header class="site-header">
+  <div class="site-header__inner">
+    <p class="site-header__claim">we’re not behaving like insects</p>
+    <h1 class="site-header__title"><a href="{{ '/' | relative_url }}">Randnotizen</a></h1>
+  </div>
+  {% include nav.html %}
+</header>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,7 @@
+<nav class="site-nav" aria-label="Blog-Navigation">
+  <ul class="site-nav__list">
+    <li class="site-nav__item"><a href="{{ '/blog/' | relative_url }}">Blog</a></li>
+    <li class="site-nav__item"><a href="{{ '/blog/categories/' | relative_url }}">Kategorien</a></li>
+    <li class="site-nav__item"><a href="{{ '/index.html' | relative_url }}">Startseite</a></li>
+  </ul>
+</nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% if page.title %}{{ page.title }} · {% endif %}Randnotizen</title>
+    {%- feed_meta -%}
+    <link rel="stylesheet" href="{{ '/assets/styles.css' | relative_url }}" />
+  </head>
+  <body>
+    {% include header.html %}
+    <main class="site-main" id="main">
+      {{ content }}
+    </main>
+    <footer class="site-footer">
+      <p>&copy; {{ site.time | date: '%Y' }} Randnotizen. Mit Liebe für Details gebaut.</p>
+    </footer>
+  </body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,26 @@
+---
+layout: default
+---
+<article class="post">
+  <header class="post__header">
+    <h1 class="post__title">{{ page.title }}</h1>
+    <p class="post__meta">
+      <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: '%d.%m.%Y' }}</time>
+      {%- if page.categories and page.categories != empty -%}
+        · Kategorien:
+        {%- for category in page.categories -%}
+          <a href="{{ '/blog/categories/#' | append: category | relative_url }}" class="post__category">{{ category }}</a>{% unless forloop.last %}, {% endunless %}
+        {%- endfor -%}
+      {%- endif -%}
+      {%- if page.tags and page.tags != empty -%}
+        · Tags:
+        {%- for tag in page.tags -%}
+          <span class="post__tag">#{{ tag }}</span>{% unless forloop.last %} {% endunless %}
+        {%- endfor -%}
+      {%- endif -%}
+    </p>
+  </header>
+  <div class="post__content">
+    {{ content }}
+  </div>
+</article>

--- a/_posts/2025-09-30-content-elements-audio-embed.md
+++ b/_posts/2025-09-30-content-elements-audio-embed.md
@@ -1,0 +1,86 @@
+---
+title: "Audio Embed: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Audio Embed unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-audio-embed
+original_path: content-elements/audio-embed.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Audio Embed** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Audio Embed nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Audio Embed
+
+## Beschreibung
+Einbettung eines Audio- oder Podcast-Players.
+
+## Warum dieses Element?
+- Podcastepisoden im Blog bereitstellen.
+- Audio-Zitate oder Interviews ergänzend zum Text anbieten.
+- Trade-off: Autoplay oder zu große Dateien beeinträchtigen Nutzererlebnis.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Player skalierbar, Bedienelemente ausreichend groß.
+- **Accessibility:** Transkripte bereitstellen, Tastaturbedienung sicherstellen.
+- **SEO:** Schema.org AudioObject, sprechende Dateinamen.
+- **Design-Guidelines:** Player-Farben und States definieren, Fortschrittsanzeige klar.
+- **Rechtliches:** Urheberrechte, Lizenzen und ggf. GEMA-Klärung beachten.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Streaming adaptiv, Download-Option optional.
+- **Accessibility:** `aria-labels` für Buttons, Lautstärkeregelung per Tastatur erreichbar.
+- **SEO:** Transkript als HTML bereitstellen, Metadaten im Head ergänzen.
+- **Best Practices:**
+  - Ladezeiten durch Kompression (AAC/Opus) optimieren.
+  - Player erst nach Interaktion laden (Lazyload).
+  - Download-Link und Episodennotizen bereitstellen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Media-Player, CDN, Transkript
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/audio-embed.html](../content-elements-examples/audio-embed.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<figure class="audio">
+  <figcaption>Podcast Folge 12</figcaption>
+  <audio controls preload="none">
+    <source src="podcast-12.mp3" type="audio/mpeg">
+    Ihr Browser unterstützt das Audio-Element nicht.
+  </audio>
+</figure>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Audio ist für Content-Marketing weiterhin relevant, vor allem für barrierefreie Alternativen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Audio Embed gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Audio Embed tastatur- und screenreader-freundlich gestalten.
+- Performance: Audio Embed nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Audio Embed direkt neben dem Code dokumentieren.
+
+## Fazit
+Audio Embed bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-breadcrumbs.md
+++ b/_posts/2025-09-30-content-elements-breadcrumbs.md
@@ -1,0 +1,86 @@
+---
+title: "Breadcrumbs: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Breadcrumbs unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-breadcrumbs
+original_path: content-elements/breadcrumbs.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Breadcrumbs** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Breadcrumbs nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Breadcrumbs
+
+## Beschreibung
+Hierarchische Navigation zur Orientierung im Seitensystem.
+
+## Warum dieses Element?
+- Nutzer auf tiefen Kategoriestrukturen unterstützen.
+- SEO-verbesserte Navigation mit strukturierter Daten-Auszeichnung bieten.
+- Trade-off: Bei flacher Struktur wenig Mehrwert und zusätzlicher Pflegeaufwand.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Horizontale Liste, auf Mobile kürzen oder scrollen lassen.
+- **Accessibility:** `nav` mit `aria-label`, Trennzeichen nur dekorativ.
+- **SEO:** `BreadcrumbList`-Markup für Rich Snippets.
+- **Design-Guidelines:** Dezente Typografie, ausreichende Abstände, Chevron-Icons optional.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Nur letzte zwei Ebenen zeigen, Rest einklappbar.
+- **Accessibility:** Aktuelle Seite mit `aria-current=page` kennzeichnen.
+- **SEO:** Links auf wichtige Kategorie-Seiten setzen, Duplicate vermeiden.
+- **Best Practices:**
+  - Automatisch aus URL/Navigation generieren.
+  - Home-Link immer anbieten.
+  - Trennzeichen als CSS-Pseudo-Element rendern.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Hauptnavigation, Routing
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/breadcrumbs.html](../content-elements-examples/breadcrumbs.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<nav aria-label="Breadcrumb">
+  <ol class="breadcrumbs">
+    <li><a href="/">Start</a></li>
+    <li><a href="/shop">Shop</a></li>
+    <li aria-current="page">Sneaker</li>
+  </ol>
+</nav>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Breadcrumbs bleiben wichtig für Orientierung und SEO.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Breadcrumbs gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Breadcrumbs tastatur- und screenreader-freundlich gestalten.
+- Performance: Breadcrumbs nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Breadcrumbs direkt neben dem Code dokumentieren.
+
+## Fazit
+Breadcrumbs bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-callout-box.md
+++ b/_posts/2025-09-30-content-elements-callout-box.md
@@ -1,0 +1,83 @@
+---
+title: "Callout Box: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Callout Box unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-callout-box
+original_path: content-elements/callout-box.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Callout Box** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Callout Box nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Callout Box
+
+## Beschreibung
+Hervorgehobene Boxen für Hinweise, Warnungen oder Erfolgsnachrichten innerhalb von Inhalten.
+
+## Warum dieses Element?
+- Wichtige Hinweise in Dokumentationen oder Anleitungen hervorheben.
+- Statusmeldungen in Knowledge-Base-Artikeln kommunizieren.
+- Trade-off: Übermäßiger Einsatz verringert Aufmerksamkeit und führt zu Informationsrauschen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Breite und Padding an Viewport anpassen, Icons skalierbar halten.
+- **Accessibility:** Korrekte Rollen (`status`, `alert`) je nach Kontext, ausreichender Kontrast und Fokus für Links.
+- **SEO:** Klarer Kontext im Fließtext, optionale `<aside>`-Semantik.
+- **Design-Guidelines:** Farbcodierte Varianten (Info, Warnung, Erfolg), konsistente Typografie und Iconografie.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Vertikale Layouts bevorzugen, Icons oberhalb des Textes platzieren, wenn Platz fehlt.
+- **Accessibility:** Rollen nur bei dynamischen Updates setzen, sonst semantisch neutral halten.
+- **SEO:** Boxen nicht für kritische Überschriften missbrauchen, semantisch im Textfluss belassen.
+- **Best Practices:**
+  - Varianten in Designsystem definieren.
+  - Icons als dekorativ markieren (`aria-hidden`).
+  - Nicht mehr als zwei Callouts pro Bildschirmhöhe verwenden.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Iconset, Alert-Komponenten
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/callout-box.html](../content-elements-examples/callout-box.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<aside class="callout callout--info">
+  <h3 class="callout__title">Hinweis</h3>
+  <p>Bitte sichern Sie Ihre Daten regelmäßig.</p>
+</aside>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Callouts unterstützen Lesbarkeit, sollten aber gezielt eingesetzt werden.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Callout Box gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Callout Box tastatur- und screenreader-freundlich gestalten.
+- Performance: Callout Box nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Callout Box direkt neben dem Code dokumentieren.
+
+## Fazit
+Callout Box bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-code-snippets.md
+++ b/_posts/2025-09-30-content-elements-code-snippets.md
@@ -1,0 +1,84 @@
+---
+title: "Code Snippets: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Code Snippets unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-code-snippets
+original_path: content-elements/code-snippets.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Code Snippets** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Code Snippets nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Code Snippets
+
+## Beschreibung
+Darstellung von Codebeispielen als Inline- oder Block-Elemente inkl. Kopierfunktion.
+
+## Warum dieses Element?
+- Developer-Dokumentationen und API-Referenzen präsentieren.
+- How-to-Artikel mit konkreten Codeausschnitten anreichern.
+- Trade-off: Syntax-Highlighting kann Performance und Barrierefreiheit beeinträchtigen, wenn schlecht umgesetzt.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Codeblöcke horizontal scrollbar machen, Inline-Code mit Wrap-Strategien versehen.
+- **Accessibility:** ARIA-Labels für Kopier-Buttons, Screenreader-kompatible Spracheinstellung, ausreichender Kontrast.
+- **SEO:** Strukturierte Daten für Code (`<pre><code>`) korrekt einsetzen, optionale `<figure>`-Einbettung.
+- **Design-Guidelines:** Monospace-Fonts, dezente Hintergrundflächen, klare Abstände und Hover-/Focus-States für Aktionen.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Kurze Codezeilen bevorzugen, ansonsten Scrollcontainer mit sichtbarer Scrollbarkeit.
+- **Accessibility:** `aria-live`-Feedback für erfolgreiche Kopieraktionen, Fokusreihenfolge beibehalten.
+- **SEO:** Konsistente Sprachangabe per `lang`-Attribut, nicht renderrelevanten Code vermeiden.
+- **Best Practices:**
+  - Syntax-Highlighting serverseitig oder per leichtgewichtiges Skript.
+  - Kopier-Button erst nach dem Code rendern, um Tab-Reihenfolge logisch zu halten.
+  - Codeblöcke in `<figure>` mit `<figcaption>` erläutern.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Buttons, Clipboard-API, Syntax-Highlighting-Utility
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/code-snippets.html](../content-elements-examples/code-snippets.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<figure class="code-snippet">
+  <figcaption>cURL-Beispiel</figcaption>
+  <pre><code>curl https://api.example.com/v1</code></pre>
+  <button type="button" aria-label="Code kopieren">Copy</button>
+</figure>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Codebeispiele bleiben essenziell für Developer-Content und Wissensvermittlung.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Code Snippets gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Code Snippets tastatur- und screenreader-freundlich gestalten.
+- Performance: Code Snippets nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Code Snippets direkt neben dem Code dokumentieren.
+
+## Fazit
+Code Snippets bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-contact-form.md
+++ b/_posts/2025-09-30-content-elements-contact-form.md
@@ -1,0 +1,86 @@
+---
+title: "Contact Form: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Contact Form unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-contact-form
+original_path: content-elements/contact-form.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Contact Form** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Contact Form nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Contact Form
+
+## Beschreibung
+Formular zur Kontaktaufnahme mit Validierung und Spam-Schutz.
+
+## Warum dieses Element?
+- Support-Anfragen sammeln.
+- Sales-Leads auf Landingpages generieren.
+- Trade-off: Zu viele Felder senken Conversion und erhöhen Absprungrate.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Einspaltiges Layout auf Mobile, mehrspaltig auf Desktop möglich.
+- **Accessibility:** Labels, Fehlerfeedback, Fokus-Reihenfolge, Captcha-barrierefrei.
+- **SEO:** Kontaktseiten für lokale Suche optimieren (`LocalBusiness`-Markup).
+- **Design-Guidelines:** Klare Hierarchie, Call-to-Action, Fehlermeldungen konsistent.
+- **Rechtliches:** Datenschutzhinweis und Einwilligung gem. DSGVO, Double-Opt-In optional.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Kurze Felder, AutoComplete nutzen, Soft-Keyboard steuern.
+- **Accessibility:** Serverseitige Fehler wiedergeben, `aria-live` für Bestätigungen.
+- **SEO:** `rel="noopener"` bei externen Links, strukturierte Daten für Kontakt hinzufügen.
+- **Best Practices:**
+  - Spam-Schutz (Honeypot, Rate-Limiting).
+  - Erfolgsmeldung klar anzeigen.
+  - Pflichtfelder auf ein Minimum reduzieren.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Form-Backend, Spam-Schutz, CRM
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/contact-form.html](../content-elements-examples/contact-form.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<form class="contact-form">
+  <label for="name">Name</label>
+  <input id="name" name="name" required>
+  <label for="message">Nachricht</label>
+  <textarea id="message" name="message"></textarea>
+  <button type="submit">Senden</button>
+</form>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Kontaktformulare bleiben primärer Kanal für Leads und Support.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Contact Form gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Contact Form tastatur- und screenreader-freundlich gestalten.
+- Performance: Contact Form nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Contact Form direkt neben dem Code dokumentieren.
+
+## Fazit
+Contact Form bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-cookie-consent.md
+++ b/_posts/2025-09-30-content-elements-cookie-consent.md
@@ -1,0 +1,88 @@
+---
+title: "Cookie Consent: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Cookie Consent unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-cookie-consent
+original_path: content-elements/cookie-consent.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Cookie Consent** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Cookie Consent nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Cookie Consent
+
+## Beschreibung
+Consent-Banner oder Layer zur Einholung der DSGVO-konformen Zustimmung für Cookies.
+
+## Warum dieses Element?
+- Tracking- und Marketing-Cookies rechtskonform einholen.
+- Einwilligungen für externe Dienste (Maps, Videos) verwalten.
+- Trade-off: Schlechte UX führt zu Ablehnung oder rechtlichen Risiken.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Fullscreen-Layer auf Mobile, dezenter Banner auf Desktop.
+- **Accessibility:** Tastaturbedienbar, Fokus-Trap, klare Beschriftungen, Screenreader-freundlich.
+- **SEO:** Consent-Banner darf Inhalte nicht dauerhaft verdecken, sonst Rankingrisiko.
+- **Design-Guidelines:** Klares Layout, Buttons für „Akzeptieren“, „Ablehnen“, „Einstellungen“, farblich differenziert.
+- **Rechtliches:** DSGVO, TTDSG: Granulare Einwilligung, Dokumentation, Widerrufsmöglichkeit, Datenschutzerklärung verlinken.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Schnelle Auswahl, aber granularer Zugriff über Einstellungen gewährleisten.
+- **Accessibility:** Fokus auf ersten Button setzen, `aria-modal` nutzen, Einstellungsdialog beschreiben.
+- **SEO:** Banner erst nach Page Load anzeigen, Consent-Status serverseitig speichern.
+- **Best Practices:**
+  - Voreinstellungen auf technisch notwendige Cookies beschränken.
+  - Consent-Logs revisionssicher speichern.
+  - Regelmäßige rechtliche Prüfung durchführen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Consent-Management-Plattform, Tag-Manager, Legal
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/cookie-consent.html](../content-elements-examples/cookie-consent.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<div class="cookie-consent" role="dialog" aria-modal="true" aria-labelledby="cookie-title">
+  <h2 id="cookie-title">Datenschutz-Einstellungen</h2>
+  <p>Wir verwenden Cookies, um unsere Website zu verbessern.</p>
+  <div class="cookie-consent__actions">
+    <button type="button">Alle akzeptieren</button>
+    <button type="button">Nur notwendige</button>
+    <button type="button">Einstellungen</button>
+  </div>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Cookie-Consent bleibt rechtlich zwingend und entwickelt sich weiter.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Cookie Consent gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Cookie Consent tastatur- und screenreader-freundlich gestalten.
+- Performance: Cookie Consent nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Cookie Consent direkt neben dem Code dokumentieren.
+
+## Fazit
+Cookie Consent bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-date-picker.md
+++ b/_posts/2025-09-30-content-elements-date-picker.md
@@ -1,0 +1,81 @@
+---
+title: "Date Picker: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Date Picker unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-date-picker
+original_path: content-elements/date-picker.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Date Picker** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Date Picker nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Date Picker
+
+## Beschreibung
+Komponente zur Auswahl einzelner Daten oder Zeitspannen.
+
+## Warum dieses Element?
+- Buchungen oder Terminplanungen ermöglichen.
+- Filter nach Zeitraum in Reports oder Dashboards anbieten.
+- Trade-off: Komplexe Kalenderlogik kann Fehler hervorrufen und ist schwer barrierefrei umzusetzen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Kalender auf Mobile als Vollbild oder Listenansicht.
+- **Accessibility:** Tastaturbedienung (Pfeiltasten), Screenreader-Beschriftungen, Ansagen der Auswahl.
+- **SEO:** Keine direkte Relevanz.
+- **Design-Guidelines:** Hervorhebung von aktiven, ausgewählten und deaktivierten Tagen, klare Navigation.
+- **Rechtliches:** Bei Buchungen gesetzliche Aufbewahrung von Daten beachten.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Native Picker nutzen, wenn verfügbar, oder optimierte Touch-Gesten.
+- **Accessibility:** `aria-live` für Monatswechsel, `aria-selected` für Tage pflegen.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Min-/Max-Daten definieren.
+  - Datumsformat klar kommunizieren.
+  - Range-Auswahl mit Drag oder zwei Feldern ermöglichen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Lokalisierung, Zeitbibliothek
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/date-picker.html](../content-elements-examples/date-picker.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<label for="date">Datum</label>
+<input id="date" name="date" type="date">
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Datumsauswahl bleibt komplex, aber unverzichtbar für Transaktionen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Date Picker gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Date Picker tastatur- und screenreader-freundlich gestalten.
+- Performance: Date Picker nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Date Picker direkt neben dem Code dokumentieren.
+
+## Fazit
+Date Picker bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-dropdown-select.md
+++ b/_posts/2025-09-30-content-elements-dropdown-select.md
@@ -1,0 +1,84 @@
+---
+title: "Dropdown Select: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Dropdown Select unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-dropdown-select
+original_path: content-elements/dropdown-select.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Dropdown Select** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Dropdown Select nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Dropdown Select
+
+## Beschreibung
+Auswahlliste als Native-Select oder erweiterte Combobox.
+
+## Warum dieses Element?
+- Filter- oder Sortieroptionen bereitstellen.
+- Formulareingaben mit vorgegebenen Werten strukturieren.
+- Trade-off: Custom Selects können A11y-Probleme verursachen, wenn native Funktionen ersetzt werden.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Volle Breite auf kleinen Screens, Listenhöhe begrenzen.
+- **Accessibility:** `label`-Zuordnung, `aria-expanded`, Tastaturnavigation.
+- **SEO:** Kein direkter Einfluss.
+- **Design-Guidelines:** Pfeil-Icon, States (hover/focus/disabled), konsistente Höhe.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Native Select bevorzugen, da optimierte Mobile UI vorhanden.
+- **Accessibility:** Combobox-Rollen nur verwenden, wenn Funktionalität vollständig unterstützt.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Optionen logisch gruppieren (`optgroup`).
+  - Leeren Default-State klar kennzeichnen.
+  - Maximale Optionsanzahl begrenzen oder Suche anbieten.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Form-Controller, Such-API (optional)
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/dropdown-select.html](../content-elements-examples/dropdown-select.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<label for="country">Land</label>
+<select id="country" name="country">
+  <option value="">Bitte wählen</option>
+  <option value="de">Deutschland</option>
+</select>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Dropdowns bleiben häufig, doch Usability hängt von sauberer Umsetzung ab.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Dropdown Select gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Dropdown Select tastatur- und screenreader-freundlich gestalten.
+- Performance: Dropdown Select nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Dropdown Select direkt neben dem Code dokumentieren.
+
+## Fazit
+Dropdown Select bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-empty-state.md
+++ b/_posts/2025-09-30-content-elements-empty-state.md
@@ -1,0 +1,85 @@
+---
+title: "Empty State: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Empty State unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-empty-state
+original_path: content-elements/empty-state.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Empty State** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Empty State nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Empty State
+
+## Beschreibung
+Darstellung, wenn keine Daten oder Ergebnisse vorliegen.
+
+## Warum dieses Element?
+- Suche ohne Treffer informativ gestalten.
+- Neue Nutzer in Dashboards an Funktionen heranführen.
+- Trade-off: Unpassende Illustrationen oder Texte können Nutzer verwirren.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Illustrationen und Text skalieren, Buttons darunter anordnen.
+- **Accessibility:** Alternativtexte für Illustrationen, klare Anweisungen auch in Text.
+- **SEO:** Keine direkte Relevanz.
+- **Design-Guidelines:** Illustration, Headline, Body-Text, CTA optional, konsistente Farben.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Kurze Texte, klare Handlungsoptionen, Buttons full-width.
+- **Accessibility:** Keine rein ikonografischen Aussagen; Text beschreibt Situation.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Konkrete nächste Schritte anbieten.
+  - Optional Hilfelinks einblenden.
+  - Tonfall empathisch wählen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Illustrationen, CTA-Komponenten
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/empty-state.html](../content-elements-examples/empty-state.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<section class="empty-state">
+  <img src="../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
+  <h2>Keine Ergebnisse</h2>
+  <p>Passen Sie Ihre Filter an oder starten Sie eine neue Suche.</p>
+  <button type="button">Filter zurücksetzen</button>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Gute Empty States steigern Engagement und helfen bei der Orientierung.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Empty State gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Empty State tastatur- und screenreader-freundlich gestalten.
+- Performance: Empty State nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Empty State direkt neben dem Code dokumentieren.
+
+## Fazit
+Empty State bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-file-uploader.md
+++ b/_posts/2025-09-30-content-elements-file-uploader.md
@@ -1,0 +1,84 @@
+---
+title: "File Uploader: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum File Uploader unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-file-uploader
+original_path: content-elements/file-uploader.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **File Uploader** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt File Uploader nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: File Uploader
+
+## Beschreibung
+Komponente zum Hochladen von Dateien inklusive Fortschritt und Validierung.
+
+## Warum dieses Element?
+- Bewerbungs- oder Support-Uploads ermöglichen.
+- Medienverwaltung in CMS oder Kundenportalen.
+- Trade-off: Große Dateien erfordern Chunking, Sicherheit und Storage-Kosten.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Drag-and-Drop-Bereich skalierbar, Fortschrittsanzeigen gut lesbar.
+- **Accessibility:** Klare Statusmeldungen, Tastaturbedienung, Screenreader-freundliche Feedbacks.
+- **SEO:** Keine direkte Relevanz.
+- **Design-Guidelines:** Drop-Zonen, Buttons, Fortschrittsbalken konsistent gestalten.
+- **Rechtliches:** Datenschutz und sichere Übertragung (TLS), Dateitypen-Policy, ggf. AV-Verträge.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Dateiauswahl über native Picker, klare Hinweise zur Maximalgröße.
+- **Accessibility:** Statusupdates via `aria-live`, Fehler klar beschreiben.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Serverseitige Validierung ergänzen.
+  - Uploads pausieren/fortsetzen ermöglichen.
+  - Virenscan oder Sicherheitschecks einplanen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Storage-Service, Validation, Progress-API
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/file-uploader.html](../content-elements-examples/file-uploader.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<form class="uploader">
+  <label for="file" class="uploader__dropzone">Datei hier ablegen oder klicken</label>
+  <input id="file" name="file" type="file" hidden>
+  <progress value="0" max="100" aria-live="polite"></progress>
+</form>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Datei-Uploads sind häufig und erfordern hohe UX- und Sicherheitsstandards.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um File Uploader gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: File Uploader tastatur- und screenreader-freundlich gestalten.
+- Performance: File Uploader nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu File Uploader direkt neben dem Code dokumentieren.
+
+## Fazit
+File Uploader bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-filter-facets.md
+++ b/_posts/2025-09-30-content-elements-filter-facets.md
@@ -1,0 +1,83 @@
+---
+title: "Filter Facets: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Filter Facets unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-filter-facets
+original_path: content-elements/filter-facets.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Filter Facets** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Filter Facets nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Filter Facets
+
+## Beschreibung
+Facettierte Filtersteuerung mit Chips, Listen oder Slidern.
+
+## Warum dieses Element?
+- Produkt- oder Artikellisten zielgerichtet einschränken.
+- Suchergebnisse nach Kategorien, Preisen oder Tags verfeinern.
+- Trade-off: Zu viele Filteroptionen überfordern Nutzer und erhöhen Komplexität.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Auf Mobile als Akkordeon oder Off-Canvas, auf Desktop nebeneinander.
+- **Accessibility:** Checkbox-/Radio-Labels klar benennen, `aria-pressed` für Chips.
+- **SEO:** Filter-URLs sauber handhaben, Duplicate Content vermeiden.
+- **Design-Guidelines:** Visuelle Hierarchie, aktive Filter hervorheben, Reset-Option.
+- **Rechtliches:** Tracking von Filterinteraktionen DSGVO-konform behandeln.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Filter über Button einblenden, Prioritäten setzen.
+- **Accessibility:** Statusänderungen per `aria-live` ankündigen, Fokus nach Anwendung sinnvoll setzen.
+- **SEO:** Kanonsiche URLs definieren, Parameter whitelisten.
+- **Best Practices:**
+  - Aktive Filter deutlich anzeigen und entfernen lassen.
+  - Filterzustand in URL speichern.
+  - Serverseitige und clientseitige Filter synchron halten.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Such-API, State-Management, Analytics
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/filter-facets.html](../content-elements-examples/filter-facets.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<section class="filters">
+  <button type="button" class="filter-chip" aria-pressed="true">Sofort lieferbar</button>
+  <label><input type="checkbox" name="brand" value="acme"> ACME</label>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Komplexe Kataloge brauchen weiterhin leistungsfähige Filtersteuerungen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Filter Facets gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Filter Facets tastatur- und screenreader-freundlich gestalten.
+- Performance: Filter Facets nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Filter Facets direkt neben dem Code dokumentieren.
+
+## Fazit
+Filter Facets bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-image-carousel.md
+++ b/_posts/2025-09-30-content-elements-image-carousel.md
@@ -1,0 +1,86 @@
+---
+title: "Image Carousel: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Image Carousel unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-image-carousel
+original_path: content-elements/image-carousel.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Image Carousel** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Image Carousel nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Image Carousel
+
+## Beschreibung
+Slider-Komponente für mehrere Bilder mit optionaler Lightbox.
+
+## Warum dieses Element?
+- Produktgalerien auf E-Commerce-Seiten.
+- Event- oder Referenz-Slideshows auf Landingpages.
+- Trade-off: Zu viele Slides reduzieren Aufmerksamkeit, Interaktion oft gering.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Touch- und Mausbedienung, Breakpoints für Anzahl sichtbarer Slides.
+- **Accessibility:** Fokusreihenfolge, `aria-live` für Slide-Wechsel, Pause-/Play-Controls.
+- **SEO:** Bilder mit Alt-Text und Lazyload, Lightbox nicht indexrelevant.
+- **Design-Guidelines:** Navigationselemente konsistent, Dot-/Arrow-Styling, Übergänge dezent.
+- **Rechtliches:** Bildrechte beachten, Tracking in Lightbox vermeiden.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Einzelne Slides, Swipe-Gesten, geringe Dateigrößen.
+- **Accessibility:** Autoplay standardmäßig deaktiviert, klare Fokusindikatoren.
+- **SEO:** `loading="lazy"`, strukturierte Daten für Produktbilder möglich.
+- **Best Practices:**
+  - Slides per Keyboard navigierbar machen.
+  - Progressive Enhancement bei deaktiviertem JS.
+  - Bildvorab-Laden für nächstes Slide optimieren.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Slider-Library, Lightbox, Bild-CDN
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/image-carousel.html](../content-elements-examples/image-carousel.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<div class="carousel" aria-roledescription="Karussell">
+  <button class="carousel__prev" aria-label="Vorheriges Bild">‹</button>
+  <ul class="carousel__track">
+    <li class="carousel__slide"><img src="../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy"></li>
+  </ul>
+  <button class="carousel__next" aria-label="Nächstes Bild">›</button>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Karussells bleiben gängig, müssen jedoch nutzerzentriert optimiert werden.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Image Carousel gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Image Carousel tastatur- und screenreader-freundlich gestalten.
+- Performance: Image Carousel nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Image Carousel direkt neben dem Code dokumentieren.
+
+## Fazit
+Image Carousel bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-image-with-caption.md
+++ b/_posts/2025-09-30-content-elements-image-with-caption.md
@@ -1,0 +1,83 @@
+---
+title: "Image With Caption: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Image With Caption unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-image-with-caption
+original_path: content-elements/image-with-caption.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Image With Caption** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Image With Caption nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Image with Caption
+
+## Beschreibung
+Bilddarstellung mit erläuternder Bildunterschrift.
+
+## Warum dieses Element?
+- Produktfotos oder Screenshots mit erklärender Caption einsetzen.
+- Blogartikel mit Bildnachweisen oder Quellenangaben versehen.
+- Trade-off: Große Bilder beeinflussen Ladezeiten, erfordern Optimierung.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Fluides Verhalten, `srcset`/`sizes` nutzen, Captions unterhalb anordnen.
+- **Accessibility:** Alternativtexte bereitstellen, Caption als ergänzende Beschreibung, ausreichender Kontrast.
+- **SEO:** Alt-Texte und strukturierte Daten (`figure`, `figcaption`) verbessern Bild-Sichtbarkeit.
+- **Design-Guidelines:** Bildgrößen definieren, Weißraum um Caption, Typografie harmonisch.
+- **Rechtliches:** Bildrechte beachten, Quellenangabe bei Lizenzanforderung integrieren.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Bilder zunächst klein laden, progressive Vergrößerung via `srcset`.
+- **Accessibility:** Kontrast für Text auf Caption-Hintergrund sicherstellen, keine rein dekorativen Captions.
+- **SEO:** Dateinamen beschreibend, Lazyloading (`loading="lazy"`) einsetzen.
+- **Best Practices:**
+  - Moderne Formate (WebP/AVIF) mit Fallback anbieten.
+  - Responsive Container mit `max-width` begrenzen.
+  - Caption optional mit Quellenlink versehen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Bild-CDN, Lightbox (optional)
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/image-with-caption.html](../content-elements-examples/image-with-caption.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<figure class="image">
+  <img src="../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
+  <figcaption>Agentin und Roboter beobachten die Stadtlichter.</figcaption>
+</figure>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Bilder mit Kontext bleiben wichtig für Storytelling und Compliance.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Image With Caption gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Image With Caption tastatur- und screenreader-freundlich gestalten.
+- Performance: Image With Caption nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Image With Caption direkt neben dem Code dokumentieren.
+
+## Fazit
+Image With Caption bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-input-field.md
+++ b/_posts/2025-09-30-content-elements-input-field.md
@@ -1,0 +1,81 @@
+---
+title: "Input Field: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Input Field unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-input-field
+original_path: content-elements/input-field.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Input Field** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Input Field nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Input Field
+
+## Beschreibung
+Standardisierte Eingabefelder für Text, E-Mail oder Nummern mit optionalen Masken.
+
+## Warum dieses Element?
+- Kontakt- und Registrierungsformulare erstellen.
+- Datenpflege in internen Tools ermöglichen.
+- Trade-off: Falsche Masken oder Validierungen frustrieren Nutzer.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Volle Breite auf Mobile, angepasste Feldbreiten auf Desktop.
+- **Accessibility:** Label-Verknüpfung, Fehlermeldungen beschreiben, ausreichende Touch-Ziele.
+- **SEO:** Relevanz nur bei Formular-Landingpages (Micro-Conversions).
+- **Design-Guidelines:** Konsistente Höhen, Zustände für Fokus/Fehler, lesbare Typografie.
+- **Rechtliches:** Datenschutz bei personenbezogenen Daten beachten (z. B. TLS, Speicherung).
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Passende Keyboard-Typen (`inputmode`, `type`) definieren.
+- **Accessibility:** Fehlerhinweise via `aria-live`, Pflichtfelder kennzeichnen.
+- **SEO:** Formulare beschleunigen Conversion-Rate, Schema.org `ContactPoint` optional.
+- **Best Practices:**
+  - AutoComplete-Attribute setzen.
+  - Masken nur bei klaren Formaten nutzen.
+  - Client- und Server-Validierung kombinieren.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Form-Validation, Masking-Library
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/input-field.html](../content-elements-examples/input-field.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<label for="email">E-Mail</label>
+<input id="email" name="email" type="email" required inputmode="email">
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Eingabefelder sind Kernbausteine jeder Interaktion und bleiben unverzichtbar.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Input Field gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Input Field tastatur- und screenreader-freundlich gestalten.
+- Performance: Input Field nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Input Field direkt neben dem Code dokumentieren.
+
+## Fazit
+Input Field bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-loading-spinner.md
+++ b/_posts/2025-09-30-content-elements-loading-spinner.md
@@ -1,0 +1,82 @@
+---
+title: "Loading Spinner: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Loading Spinner unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-loading-spinner
+original_path: content-elements/loading-spinner.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Loading Spinner** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Loading Spinner nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Loading Spinner
+
+## Beschreibung
+Animierter Indikator für laufende Prozesse.
+
+## Warum dieses Element?
+- Kurze Ladezeiten bei Formularen oder API-Calls anzeigen.
+- Asynchrone Aktionen wie Datenabrufe visualisieren.
+- Trade-off: Reine Spinner ohne Kontext frustrieren, wenn Ladezeiten länger dauern.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Größe skaliert mit Container, Kontrast zum Hintergrund.
+- **Accessibility:** `role="status"` und beschreibender Text, `aria-live=polite`.
+- **SEO:** Keine Relevanz.
+- **Design-Guidelines:** Konsistente Animation, Designsystem-konforme Farben.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Spinner nicht zu groß, damit Inhalte sichtbar bleiben.
+- **Accessibility:** Zusätzlichen Text wie „Lädt…“ bereitstellen.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Maximale Ladezeit definieren und Fehlerzustand zeigen.
+  - Spinner erst nach 500 ms anzeigen, um Flackern zu vermeiden.
+  - Mit Skeletons kombinieren, wenn längere Wartezeiten zu erwarten sind.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Animationslibrary, State-Management
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/loading-spinner.html](../content-elements-examples/loading-spinner.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<div class="spinner" role="status" aria-live="polite">
+  <span class="sr-only">Lädt…</span>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Ladeindikatoren bleiben Standard, sollten aber immer mit Kontext kombiniert werden.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Loading Spinner gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Loading Spinner tastatur- und screenreader-freundlich gestalten.
+- Performance: Loading Spinner nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Loading Spinner direkt neben dem Code dokumentieren.
+
+## Fazit
+Loading Spinner bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-map-embed.md
+++ b/_posts/2025-09-30-content-elements-map-embed.md
@@ -1,0 +1,83 @@
+---
+title: "Map Embed: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Map Embed unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-map-embed
+original_path: content-elements/map-embed.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Map Embed** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Map Embed nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Map Embed
+
+## Beschreibung
+Interaktive Karte zur Standortanzeige oder Wegbeschreibung.
+
+## Warum dieses Element?
+- Standortübersicht auf Kontakt- oder Filialseiten.
+- Event-Locations oder Veranstaltungsorte darstellen.
+- Trade-off: Externe Maps erhöhen Ladezeit und bergen Datenschutzrisiken.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Adaptive Höhe/Breite, Touch-Gesten unterstützen.
+- **Accessibility:** Alternativbeschreibung und Adresse als Text, Fokusfalle vermeiden.
+- **SEO:** Strukturierte Daten für Organisation/LocalBusiness, statische Karte als Fallback.
+- **Design-Guidelines:** Kartenrahmen, Marker-Branding, klare Buttons.
+- **Rechtliches:** DSGVO-konforme Einwilligung vor Laden externer Dienste (Google Maps), Datenschutzhinweis bereitstellen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Statische Karte oder Screenshot bis Interaktion, geringe Datenlast.
+- **Accessibility:** Tastaturbedienung prüfen, Zoomkontrollen beschriftet, Adresse zusätzlich in HTML.
+- **SEO:** `loading="lazy"` für iframes, strukturierte Adresse in Microdata.
+- **Best Practices:**
+  - Privacy-Proxy oder Selbsthosting (OSM) bevorzugen.
+  - Fallback-Link zu Routenplanung anbieten.
+  - Interaktion nur nach Consent aktivieren.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Consent-Tool, Map-Provider, Standortdaten
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/map-embed.html](../content-elements-examples/map-embed.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<section class="map">
+  <button type="button" data-action="load-map">Karte laden (externer Inhalt)</button>
+  <p>Adresse: Beispielstraße 1, 12345 Musterstadt</p>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Standortinformationen bleiben wichtig, Datenschutzanforderungen steigen jedoch.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Map Embed gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Map Embed tastatur- und screenreader-freundlich gestalten.
+- Performance: Map Embed nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Map Embed direkt neben dem Code dokumentieren.
+
+## Fazit
+Map Embed bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-mini-cart.md
+++ b/_posts/2025-09-30-content-elements-mini-cart.md
@@ -1,0 +1,88 @@
+---
+title: "Mini Cart: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Mini Cart unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-mini-cart
+original_path: content-elements/mini-cart.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Mini Cart** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Mini Cart nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Mini Cart
+
+## Beschreibung
+Warenkorb-Vorschau als Off-Canvas oder Dropdown.
+
+## Warum dieses Element?
+- Schnellen Zugriff auf Warenkorb-Inhalte bieten.
+- Upselling im Warenkorb-Kontext ermöglichen.
+- Trade-off: Zu komplexe Interaktionen im Mini-Cart können zu Fehlern führen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Off-Canvas auf Mobile, Dropdown auf Desktop, Scrollbereich für lange Listen.
+- **Accessibility:** `aria-modal` bei Overlays, Tastaturbedienbarkeit, Screenreader-Labels.
+- **SEO:** Nicht indexrelevant.
+- **Design-Guidelines:** Klares Layout, Produktbilder klein, Gesamtpreis deutlich, Checkout-CTA.
+- **Rechtliches:** Preisangaben (MwSt., Versand) verpflichtend anzeigen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Schnell sichtbar, einfache Änderungen (Menge, Entfernen).
+- **Accessibility:** Änderungen per `aria-live` ankündigen, Fokus beim Öffnen setzen.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Persistenten Warenkorbstatus synchronisieren.
+  - Checkout-Link deutlich hervorheben.
+  - Produkte entfernen/ändern ohne Seitenwechsel.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Cart-API, Modal-System, Analytics
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/mini-cart.html](../content-elements-examples/mini-cart.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<button type="button" aria-haspopup="dialog" aria-expanded="false">Warenkorb</button>
+<aside class="mini-cart" role="dialog" aria-modal="true" hidden>
+  <h2>Warenkorb</h2>
+  <ul>
+    <li>Produkt A ×1</li>
+  </ul>
+  <p>Summe: 89 €</p>
+  <a href="/checkout">Zum Checkout</a>
+</aside>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Mini-Carts bleiben für Conversion und Übersicht essenziell.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Mini Cart gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Mini Cart tastatur- und screenreader-freundlich gestalten.
+- Performance: Mini Cart nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Mini Cart direkt neben dem Code dokumentieren.
+
+## Fazit
+Mini Cart bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-modal.md
+++ b/_posts/2025-09-30-content-elements-modal.md
@@ -1,0 +1,87 @@
+---
+title: "Modal: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Modal unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-modal
+original_path: content-elements/modal.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Modal** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Modal nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Modal
+
+## Beschreibung
+Dialog-Overlay, das den restlichen Inhalt überlagert und fokussierte Interaktion verlangt.
+
+## Warum dieses Element?
+- Bestätigungsdialoge oder wichtige Hinweise anzeigen.
+- Formulare oder Medien ohne Seitenwechsel bereitstellen.
+- Trade-off: Unterbrechung des Nutzerflusses, daher sparsam einsetzen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Auf kleinen Screens fullscreen, auf Desktop zentriert mit max-width.
+- **Accessibility:** Focus-Trap, `aria-modal`, Escape-Handling, beschreibende Titel.
+- **SEO:** Kein direkter Einfluss, Inhalte sollten auch anderweitig zugänglich sein.
+- **Design-Guidelines:** Overlay-Opacity, Schatten, Close-Icon, klare Buttons.
+- **Rechtliches:** Bei rechtlich relevanten Hinweisen (z. B. AGB) Dokumentation der Zustimmung sichern.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Fullwidth-Layout, große Touch-Ziele, Scrollverhalten prüfen.
+- **Accessibility:** Fokus beim Öffnen auf Heading setzen, beim Schließen zum Trigger zurückführen.
+- **SEO:** Modal-Inhalte indexierbar im DOM halten oder serverseitig rendern.
+- **Best Practices:**
+  - Schließen per ESC, Button und Overlay-Klick ermöglichen.
+  - Hintergrund scrollbar sperren.
+  - Eindeutige Beschriftung (Heading) verwenden.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Overlay-System, Focus-Trap, Scroll-Lock
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/modal.html](../content-elements-examples/modal.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<button type="button" data-open="modal">Modal öffnen</button>
+<div id="modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+  <div class="modal__content">
+    <h2 id="modal-title">Hinweis</h2>
+    <p>Bitte bestätigen Sie die Aktion.</p>
+    <button type="button" data-close>Schließen</button>
+  </div>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Modale Dialoge bleiben Standard, wenn sie zugänglich und sparsam eingesetzt werden.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Modal gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Modal tastatur- und screenreader-freundlich gestalten.
+- Performance: Modal nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Modal direkt neben dem Code dokumentieren.
+
+## Fazit
+Modal bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-multi-step-wizard.md
+++ b/_posts/2025-09-30-content-elements-multi-step-wizard.md
@@ -1,0 +1,86 @@
+---
+title: "Multi Step Wizard: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Multi Step Wizard unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-multi-step-wizard
+original_path: content-elements/multi-step-wizard.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Multi Step Wizard** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Multi Step Wizard nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Multi-Step Wizard
+
+## Beschreibung
+Mehrschrittige Benutzerführung für komplexe Prozesse.
+
+## Warum dieses Element?
+- Onboarding oder Registrierung in Etappen aufteilen.
+- Konfiguratoren und Formulare mit vielen Feldern strukturieren.
+- Trade-off: Höherer Implementierungsaufwand und potenzielle Abbrüche zwischen Schritten.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Schritte vertikal stacken, Fortschritt klar anzeigen.
+- **Accessibility:** Fokus zwischen Schritten managen, `aria-current` für aktiven Schritt.
+- **SEO:** Kein direkter Einfluss.
+- **Design-Guidelines:** Klare Navigation, Buttons (Weiter/Zürück), Zwischenspeicherung.
+- **Rechtliches:** Zwischenspeicherung personenbezogener Daten rechtlich absichern.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Jeden Schritt auf das Wesentliche reduzieren, Auto-Save integrieren.
+- **Accessibility:** Schrittwechsel ankündigen (`aria-live`), Escape aus Fokusfallen vermeiden.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Fortschritt speichern und wiederaufnehmen ermöglichen.
+  - Zusammenfassung vor Abschluss anzeigen.
+  - Validierung pro Schritt durchführen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Progress-Steps, Form-Validation, State-Management
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/multi-step-wizard.html](../content-elements-examples/multi-step-wizard.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<form class="wizard">
+  <section aria-labelledby="step1">
+    <h2 id="step1">Schritt 1: Konto</h2>
+    <label>Name<input name="name"></label>
+    <button type="button">Weiter</button>
+  </section>
+</form>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Mehrschrittprozesse bleiben nötig, wenn komplexe Eingaben zu strukturieren sind.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Multi Step Wizard gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Multi Step Wizard tastatur- und screenreader-freundlich gestalten.
+- Performance: Multi Step Wizard nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Multi Step Wizard direkt neben dem Code dokumentieren.
+
+## Fazit
+Multi Step Wizard bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-newsletter-optin.md
+++ b/_posts/2025-09-30-content-elements-newsletter-optin.md
@@ -1,0 +1,85 @@
+---
+title: "Newsletter Optin: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Newsletter Optin unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-newsletter-optin
+original_path: content-elements/newsletter-optin.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Newsletter Optin** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Newsletter Optin nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Newsletter Opt-in
+
+## Beschreibung
+Formular zum Anmelden für einen Newsletter mit Double-Opt-In.
+
+## Warum dieses Element?
+- Newsletter-Anmeldungen auf Landingpages erhöhen.
+- Content-Angebote oder Downloads mit E-Mail-Opt-In koppeln.
+- Trade-off: Zu aggressive Platzierung kann Nutzer abschrecken und Bounce-Rate erhöhen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Einspaltig, klar strukturierte Abstände, Button gut erreichbar.
+- **Accessibility:** Labels, Fehlermeldungen, Fokusmanagement für Bestätigung.
+- **SEO:** Nicht indexrelevant, aber kann Conversion beeinflussen.
+- **Design-Guidelines:** Vertrauensaufbau durch Social Proof, DSGVO-Hinweis, konsistente Buttons.
+- **Rechtliches:** Double-Opt-In verpflichtend, Datenschutzhinweis und Widerrufsrecht klar kommunizieren.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Kurz gehaltene Texte, AutoComplete für E-Mail, schneller Abschluss.
+- **Accessibility:** Bestätigungen via `aria-live`, klare Checkbox für Einwilligung.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Transparenz über Versandfrequenz schaffen.
+  - Captcha barrierefrei gestalten.
+  - Bestätigungsseite mit Tracking-Opt-In dokumentieren.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- E-Mail-Service, Consent-Management, CRM
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/newsletter-optin.html](../content-elements-examples/newsletter-optin.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<form class="newsletter">
+  <label for="newsletter-email">E-Mail</label>
+  <input id="newsletter-email" name="email" type="email" required>
+  <label><input type="checkbox" required> Ich stimme dem Erhalt des Newsletters zu.</label>
+  <button type="submit">Anmelden</button>
+</form>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Newsletter sind weiterhin wichtig, müssen aber rechtlich sauber umgesetzt werden.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Newsletter Optin gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Newsletter Optin tastatur- und screenreader-freundlich gestalten.
+- Performance: Newsletter Optin nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Newsletter Optin direkt neben dem Code dokumentieren.
+
+## Fazit
+Newsletter Optin bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-notification-banner.md
+++ b/_posts/2025-09-30-content-elements-notification-banner.md
@@ -1,0 +1,83 @@
+---
+title: "Notification Banner: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Notification Banner unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-notification-banner
+original_path: content-elements/notification-banner.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Notification Banner** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Notification Banner nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Notification Banner
+
+## Beschreibung
+Seitenweite Hinweise oder Promotions am oberen Rand.
+
+## Warum dieses Element?
+- Zeitlich begrenzte Aktionen oder Rabatte kommunizieren.
+- Systemmeldungen wie Wartungsfenster ankündigen.
+- Trade-off: Dauerhafte Banner können Nutzer nerven und Banner-Blindheit erzeugen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Volle Breite, Text umbrechen, Close-Button gut erreichbar.
+- **Accessibility:** `role="region"` mit Label, Fokus auf Dismiss-Button möglich, ausreichender Kontrast.
+- **SEO:** Kein direkter Einfluss, jedoch sollte Banner den Content nicht verdecken.
+- **Design-Guidelines:** Farbige Hintergründe, klare Typografie, optional Icon und CTA.
+- **Rechtliches:** Preisaktionen mit Bedingungen verlinken, Pflichtinformationen anzeigen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Höhe minimieren, Dismiss-Button groß genug.
+- **Accessibility:** Banner per Tastatur schließbar, `aria-live` für zeitkritische Infos.
+- **SEO:** Keine Cloaking-Praktiken, Banner nicht Inhalt überdecken.
+- **Best Practices:**
+  - Nur eine aktive Botschaft gleichzeitig anzeigen.
+  - Dauer und Wiederholung begrenzen.
+  - Dismiss-State speichern (Cookie/LocalStorage).
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Analytics, Feature Flags, Consent (bei Tracking)
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/notification-banner.html](../content-elements-examples/notification-banner.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<div class="notification-banner" role="region" aria-label="Hinweis">
+  <p>Gratis Versand bis Sonntag!</p>
+  <button type="button" class="notification-banner__close" aria-label="Banner schließen">×</button>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Banner bleiben ein zentrales Mittel für dringliche Kommunikation.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Notification Banner gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Notification Banner tastatur- und screenreader-freundlich gestalten.
+- Performance: Notification Banner nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Notification Banner direkt neben dem Code dokumentieren.
+
+## Fazit
+Notification Banner bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-pagination.md
+++ b/_posts/2025-09-30-content-elements-pagination.md
@@ -1,0 +1,86 @@
+---
+title: "Pagination: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Pagination unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-pagination
+original_path: content-elements/pagination.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Pagination** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Pagination nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Pagination
+
+## Beschreibung
+Seitenweise Navigation für Listen und Suchergebnisse.
+
+## Warum dieses Element?
+- Produkt- oder Bloglisten seitenweise anzeigen.
+- Suchergebnisse strukturieren und Crawlability verbessern.
+- Trade-off: Paginierte Inhalte können Nutzerfluss unterbrechen und SEO-Herausforderungen erzeugen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Nummern und Buttons vergrößern, auf Mobile simplifiziert (Vor/Zurück).
+- **Accessibility:** `nav` mit `aria-label`, Fokusreihenfolge, `aria-current` für aktive Seite.
+- **SEO:** `rel=next/prev` (wenn sinnvoll), canonical URLs, strukturierte Daten.
+- **Design-Guidelines:** Kontrastreiche Buttons, Hover-/Focus-States, Platz für viele Seiten.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Vor/Zurück plus Seitenanzahl anzeigen, Infinite-Scroll-Alternative prüfen.
+- **Accessibility:** Screenreader-Labels wie „Seite 2 von 10“ ergänzen.
+- **SEO:** Indexierung steuern, Parameter konsistent halten.
+- **Best Practices:**
+  - Aktuelle Seite klar hervorheben.
+  - First/Last optional ergänzen.
+  - Paginierung auch am Seitenende platzieren.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Routing, API-Pagination, Analytics
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/pagination.html](../content-elements-examples/pagination.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<nav class="pagination" aria-label="Seiten">
+  <a href="?page=1" aria-label="Vorherige Seite">«</a>
+  <a href="?page=1">1</a>
+  <span aria-current="page">2</span>
+  <a href="?page=3">3</a>
+  <a href="?page=3" aria-label="Nächste Seite">»</a>
+</nav>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Klassische Pagination bleibt relevant, auch wenn Infinite Scroll zunimmt.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Pagination gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Pagination tastatur- und screenreader-freundlich gestalten.
+- Performance: Pagination nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Pagination direkt neben dem Code dokumentieren.
+
+## Fazit
+Pagination bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-popover.md
+++ b/_posts/2025-09-30-content-elements-popover.md
@@ -1,0 +1,85 @@
+---
+title: "Popover: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Popover unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-popover
+original_path: content-elements/popover.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Popover** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Popover nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Popover
+
+## Beschreibung
+Kontextbezogene Overlays mit weiterführenden Inhalten oder Aktionen.
+
+## Warum dieses Element?
+- Detailinformationen in Tabellen oder Dashboards anzeigen.
+- Kleine Formulare oder Aktionen ohne Seitenwechsel anbieten.
+- Trade-off: Zu komplexe Inhalte in kleinen Overlays beeinträchtigen Usability.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Auf Mobile bildschirmfüllend oder als Bottom Sheet darstellen.
+- **Accessibility:** Fokusmanagement, `aria-modal` bei exklusiven Popovern, Escape zum Schließen.
+- **SEO:** Dynamische Inhalte nicht indexrelevant, daher im DOM verfügbar halten.
+- **Design-Guidelines:** Schatten, Abstände, Pfeile anpassen, klare Close-Icons.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Popover als Vollbild-Overlay oder expandierbaren Bereich planen.
+- **Accessibility:** Fokus auf erstes interaktives Element setzen, Rücksprung zum Trigger ermöglichen.
+- **SEO:** Inhalte serverseitig rendern, falls für SEO wichtig.
+- **Best Practices:**
+  - Offene Popover schließen, wenn außerhalb geklickt wird.
+  - Transitions kurz halten (<200 ms).
+  - Popover-Größe begrenzen und Scroll innerhalb erlauben.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Dialog-System, Overlay-Layer, Focus-Trap
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/popover.html](../content-elements-examples/popover.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<button type="button" aria-haspopup="dialog" aria-expanded="false">Details</button>
+<div class="popover" role="dialog" hidden>
+  <h3>Mehr Infos</h3>
+  <p>Zusätzliche Details.</p>
+  <button type="button" class="popover__close">Schließen</button>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Popover bleiben vielseitig, benötigen aber klare Regeln für Mobile und A11y.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Popover gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Popover tastatur- und screenreader-freundlich gestalten.
+- Performance: Popover nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Popover direkt neben dem Code dokumentieren.
+
+## Fazit
+Popover bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-price-comparison.md
+++ b/_posts/2025-09-30-content-elements-price-comparison.md
@@ -1,0 +1,89 @@
+---
+title: "Price Comparison: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Price Comparison unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-price-comparison
+original_path: content-elements/price-comparison.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Price Comparison** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Price Comparison nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Price Comparison
+
+## Beschreibung
+Kompakte Vergleichstabelle für Tarife oder Pakete.
+
+## Warum dieses Element?
+- SaaS-Preise oder Abos übersichtlich darstellen.
+- Feature-Vergleich verschiedener Varianten zeigen.
+- Trade-off: Komplexe Tabellen können auf Mobile schwer lesbar sein.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Kartenlayout für Mobile, Tabelle auf Desktop.
+- **Accessibility:** Tabellenbeschriftungen, `aria-describedby` für Besonderheiten.
+- **SEO:** Preisangaben mit `Product`/`Offer` Markup.
+- **Design-Guidelines:** Highlight des empfohlenen Plans, klare Buttons, Farben abgestimmt.
+- **Rechtliches:** Preisangaben, Laufzeit, MwSt., Kündigungsfristen transparent kommunizieren.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Swipebare Karten oder Akkordeon für Details.
+- **Accessibility:** Fokus zwischen Plan-Karten steuerbar, Preisänderungen ansagen.
+- **SEO:** Rich Snippets für Preise, keine versteckten Kosten.
+- **Best Practices:**
+  - Wichtigste Unterschiede klar hervorheben.
+  - Call-to-Action pro Plan konsistent.
+  - Zahlungsintervalle wählbar machen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Produktdaten, Analytics, CTA-Komponenten
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/price-comparison.html](../content-elements-examples/price-comparison.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<section class="pricing">
+  <article class="pricing__plan pricing__plan--highlight">
+    <h3>Pro</h3>
+    <p class="pricing__price">29 € / Monat</p>
+    <ul>
+      <li>Unbegrenzte Projekte</li>
+    </ul>
+    <button type="button">Jetzt starten</button>
+  </article>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Preisvergleiche bleiben kaufentscheidend, müssen jedoch mobilfreundlich sein.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Price Comparison gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Price Comparison tastatur- und screenreader-freundlich gestalten.
+- Performance: Price Comparison nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Price Comparison direkt neben dem Code dokumentieren.
+
+## Fazit
+Price Comparison bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-product-card.md
+++ b/_posts/2025-09-30-content-elements-product-card.md
@@ -1,0 +1,89 @@
+---
+title: "Product Card: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Product Card unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-product-card
+original_path: content-elements/product-card.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Product Card** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Product Card nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Product Card
+
+## Beschreibung
+Produktkachel mit Bild, Preis, Bewertung und CTA.
+
+## Warum dieses Element?
+- Produktlisten in Shops darstellen.
+- Empfehlungen oder Upselling-Module einbinden.
+- Trade-off: Zu viele Informationen können die Vergleichbarkeit erschweren.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Card-Layout responsive stacken, Bildverhältnis beibehalten.
+- **Accessibility:** Komplette Karte als Link, aber Fokus auf einzelne Aktionen erlauben.
+- **SEO:** Strukturierte Daten (`Product`) und Rich Snippets.
+- **Design-Guidelines:** Bildgrößen, Typografie, Badge-Positionen, Hover-Styling.
+- **Rechtliches:** Preisangabenverordnung beachten, inkl. MwSt. und Versandhinweis.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Wichtige Infos priorisieren, CTA prominent.
+- **Accessibility:** Alt-Texte für Produktbilder, Preis als Text, klare Fokus-States.
+- **SEO:** `itemprop`-Attribute oder JSON-LD einsetzen.
+- **Best Practices:**
+  - Lazyload für Bilder.
+  - Varianten/Verfügbarkeiten klar kennzeichnen.
+  - CTA mit eindeutiger Aktion beschriften.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Bewertungen, Preis-API, Tracking
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/product-card.html](../content-elements-examples/product-card.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<article class="product-card" itemscope itemtype="https://schema.org/Product">
+  <a href="/produkt" class="product-card__link">
+    <img src="../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy" itemprop="image">
+    <h3 itemprop="name">Sneaker X</h3>
+    <p class="product-card__price" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+      <span itemprop="price">89,90</span> €
+    </p>
+  </a>
+  <button type="button">In den Warenkorb</button>
+</article>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Produktkacheln sind zentral für E-Commerce und Conversion-relevant.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Product Card gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Product Card tastatur- und screenreader-freundlich gestalten.
+- Performance: Product Card nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Product Card direkt neben dem Code dokumentieren.
+
+## Fazit
+Product Card bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-progress-stepper.md
+++ b/_posts/2025-09-30-content-elements-progress-stepper.md
@@ -1,0 +1,84 @@
+---
+title: "Progress Stepper: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Progress Stepper unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-progress-stepper
+original_path: content-elements/progress-stepper.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Progress Stepper** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Progress Stepper nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Progress Stepper
+
+## Beschreibung
+Visualisierung des Fortschritts in mehreren Schritten oder Phasen.
+
+## Warum dieses Element?
+- Status in Checkouts oder Formularen anzeigen.
+- Projekt- oder Onboarding-Fortschritt visualisieren.
+- Trade-off: Falsche oder irreführende Schritte steigern Frust.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Horizontal auf Desktop, vertikal oder kompakt auf Mobile.
+- **Accessibility:** `aria-current` für aktiven Schritt, klare Beschriftungen.
+- **SEO:** Keine Relevanz.
+- **Design-Guidelines:** Abstände, Nummern, Icons; aktive und abgeschlossene States klar differenzieren.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Text kürzen, Symbole mit Tooltips kombinieren.
+- **Accessibility:** Stepper in `<nav>` mit `aria-label` einbetten.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Schritte anklickbar machen, wenn sinnvoll.
+  - Fortschritt synchron mit Wizard-State halten.
+  - Klar kommunizieren, wie viele Schritte folgen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Multi-Step-Wizard, Designsystem
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/progress-stepper.html](../content-elements-examples/progress-stepper.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<ol class="stepper">
+  <li class="stepper__item stepper__item--done">1. Konto</li>
+  <li class="stepper__item stepper__item--current" aria-current="step">2. Adresse</li>
+  <li class="stepper__item">3. Abschluss</li>
+</ol>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Fortschrittsanzeigen bleiben wichtig für Transparenz in Prozessen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Progress Stepper gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Progress Stepper tastatur- und screenreader-freundlich gestalten.
+- Performance: Progress Stepper nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Progress Stepper direkt neben dem Code dokumentieren.
+
+## Fazit
+Progress Stepper bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-radio-checkbox-toggle.md
+++ b/_posts/2025-09-30-content-elements-radio-checkbox-toggle.md
@@ -1,0 +1,84 @@
+---
+title: "Radio Checkbox Toggle: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Radio Checkbox Toggle unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-radio-checkbox-toggle
+original_path: content-elements/radio-checkbox-toggle.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Radio Checkbox Toggle** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Radio Checkbox Toggle nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Radio / Checkbox / Toggle
+
+## Beschreibung
+Steuerelemente für Einzel- oder Mehrfachauswahl inklusive Switches.
+
+## Warum dieses Element?
+- Einstellungen oder Präferenzen erfassen.
+- Filteroptionen in Listen oder Formularen anbieten.
+- Trade-off: Custom Styles ohne native Elemente können Barrieren erzeugen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Gruppen vertikal auf Mobile, horizontal auf Desktop.
+- **Accessibility:** Labels klickbar, Status per Screenreader lesbar, Tastaturnavigation.
+- **SEO:** Keine direkte Wirkung.
+- **Design-Guidelines:** Klar sichtbare Zustände, Gruppierung, Abstände.
+- **Rechtliches:** Bei Einwilligungen Nachweisbarkeit sicherstellen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Touch-Ziele mind. 44 px, Gruppierungen logisch.
+- **Accessibility:** Fieldset/Legend für Gruppen, `aria-checked` bei Custom Controls pflegen.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Native Inputs verwenden und visuell stylen.
+  - States (hover/focus/disabled) testen.
+  - Toggles nur für sofort wirksame Aktionen nutzen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Form-Validation, State-Management
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/radio-checkbox-toggle.html](../content-elements-examples/radio-checkbox-toggle.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<fieldset>
+  <legend>Newsletter Frequenz</legend>
+  <label><input type="radio" name="freq" value="weekly"> Wöchentlich</label>
+  <label><input type="radio" name="freq" value="monthly"> Monatlich</label>
+</fieldset>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Auswahlkontrollen bleiben Standard und benötigen sorgfältige Gestaltung.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Radio Checkbox Toggle gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Radio Checkbox Toggle tastatur- und screenreader-freundlich gestalten.
+- Performance: Radio Checkbox Toggle nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Radio Checkbox Toggle direkt neben dem Code dokumentieren.
+
+## Fazit
+Radio Checkbox Toggle bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-review-form.md
+++ b/_posts/2025-09-30-content-elements-review-form.md
@@ -1,0 +1,88 @@
+---
+title: "Review Form: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Review Form unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-review-form
+original_path: content-elements/review-form.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Review Form** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Review Form nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Review Form
+
+## Beschreibung
+Formular zum Abgeben von Bewertungen mit Rating und Textfeld.
+
+## Warum dieses Element?
+- Produkt- oder Service-Bewertungen einholen.
+- Feedback auf Kurs- oder Eventseiten sammeln.
+- Trade-off: Aufwendig in Moderation und Spam-Schutz.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Formularelemente stacken, Sterne groß genug.
+- **Accessibility:** Rating per Tastatur bedienbar, Labels, Fehlermeldungen.
+- **SEO:** Generierter Content steigert Sichtbarkeit, Schema.org `Review`.
+- **Design-Guidelines:** Sternewahl, Textarea, Upload für Bilder optional, Hinweis auf Richtlinien.
+- **Rechtliches:** Transparenzpflichten, DSGVO (personenbezogene Daten) und Nutzungsbedingungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Einfache Eingabe, AutoComplete für Name/E-Mail.
+- **Accessibility:** Rating-Widget mit `role="radiogroup"`, Fehlerfeedback via `aria-live`.
+- **SEO:** Reviews moderieren, Duplicate Content vermeiden.
+- **Best Practices:**
+  - Spam-Filter (Honeypot, Captcha) einsetzen.
+  - Richtlinien und Moderationshinweise anzeigen.
+  - Bestätigungsmail zur Verifikation senden.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Auth, Moderation, Storage
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/review-form.html](../content-elements-examples/review-form.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<form class="review-form">
+  <fieldset role="radiogroup" aria-labelledby="rating-label">
+    <legend id="rating-label">Bewertung</legend>
+    <label><input type="radio" name="rating" value="5"> ★★★★★</label>
+  </fieldset>
+  <label for="review-text">Ihre Erfahrung</label>
+  <textarea id="review-text" name="review"></textarea>
+  <button type="submit">Absenden</button>
+</form>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Nutzerfeedback bleibt wertvoll, erfordert jedoch gute Moderation.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Review Form gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Review Form tastatur- und screenreader-freundlich gestalten.
+- Performance: Review Form nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Review Form direkt neben dem Code dokumentieren.
+
+## Fazit
+Review Form bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-review-stars.md
+++ b/_posts/2025-09-30-content-elements-review-stars.md
@@ -1,0 +1,83 @@
+---
+title: "Review Stars: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Review Stars unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-review-stars
+original_path: content-elements/review-stars.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Review Stars** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Review Stars nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Review Stars
+
+## Beschreibung
+Darstellung von Bewertungen mit Sterne-Rating.
+
+## Warum dieses Element?
+- Produktbewertungen in Listen oder Detailseiten anzeigen.
+- Testimonials und Social Proof hervorheben.
+- Trade-off: Durchschnittswerte können Erwartungen verzerren, wenn zu wenige Bewertungen vorliegen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Sternegröße anpassen, Text daneben umbrechen lassen.
+- **Accessibility:** `aria-label` für Bewertung, numerische Werte ausgeben.
+- **SEO:** Schema.org `AggregateRating` für Rich Snippets.
+- **Design-Guidelines:** Farbige Sterne, klarer Kontrast, optional Text (4,5/5).
+- **Rechtliches:** Echtheit der Bewertungen sicherstellen (UWG).
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Komprimierte Darstellung, Sterne neben Text.
+- **Accessibility:** Bewertung zusätzlich in Textform ausgeben.
+- **SEO:** JSON-LD mit Review-Daten pflegen.
+- **Best Practices:**
+  - Anzahl der Bewertungen anzeigen.
+  - Filter oder Sortierung nach Bewertung ermöglichen.
+  - Manipulation vermeiden und Kennzeichnungspflicht beachten.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Bewertungs-API, Produktdaten, Schema-Markup
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/review-stars.html](../content-elements-examples/review-stars.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<div class="rating" aria-label="4,5 von 5 Sternen">
+  <span aria-hidden="true">★★★★☆</span>
+  <span class="rating__value">4,5/5 (120 Bewertungen)</span>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Bewertungen bleiben kaufentscheidend und stärken Vertrauen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Review Stars gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Review Stars tastatur- und screenreader-freundlich gestalten.
+- Performance: Review Stars nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Review Stars direkt neben dem Code dokumentieren.
+
+## Fazit
+Review Stars bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-search.md
+++ b/_posts/2025-09-30-content-elements-search.md
@@ -1,0 +1,84 @@
+---
+title: "Search: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Search unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-search
+original_path: content-elements/search.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Search** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Search nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Search
+
+## Beschreibung
+Suchfeld mit optionaler Autosuggest-Funktion.
+
+## Warum dieses Element?
+- Produktsuche in Shops oder Verzeichnissen.
+- Suche in Knowledge-Bases oder Blogs.
+- Trade-off: Schlechte Ergebnisse oder langsame Suggests schaden Vertrauen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Eingabefeld volle Breite, Suggest-Panel adaptiv.
+- **Accessibility:** `aria-expanded`, `aria-controls`, Tastaturnavigation im Suggest.
+- **SEO:** Interne Suche kann für Site-Search-Snippets genutzt werden.
+- **Design-Guidelines:** Lupe-Icon, deutlicher Fokus, Loading-Indicator für Suggests.
+- **Rechtliches:** Suchlogs datenschutzkonform speichern und anonymisieren.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Fullscreen-Suche mit On-Screen-Keyboard, History-Vorschläge.
+- **Accessibility:** Ergebnisse in `role=listbox`, Items mit `role=option` versehen.
+- **SEO:** Suchseiten indexieren oder bewusst ausschließen (noindex).
+- **Best Practices:**
+  - Fehlertoleranz (Fuzzy Search) anbieten.
+  - Analytics zur Suchnutzung integrieren.
+  - Leere Ergebnisse mit Hilfestellungen versehen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Search-API, Analytics, Autosuggest-Service
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/search.html](../content-elements-examples/search.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<form role="search">
+  <label for="search" class="sr-only">Suche</label>
+  <input id="search" name="q" type="search" placeholder="Suche">
+  <button type="submit">Suchen</button>
+</form>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Suche bleibt zentral für Nutzerzufriedenheit und Conversions.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Search gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Search tastatur- und screenreader-freundlich gestalten.
+- Performance: Search nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Search direkt neben dem Code dokumentieren.
+
+## Fazit
+Search bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-share-buttons.md
+++ b/_posts/2025-09-30-content-elements-share-buttons.md
@@ -1,0 +1,83 @@
+---
+title: "Share Buttons: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Share Buttons unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-share-buttons
+original_path: content-elements/share-buttons.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Share Buttons** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Share Buttons nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Share Buttons
+
+## Beschreibung
+Buttons zum Teilen von Inhalten in sozialen Netzwerken oder per Link.
+
+## Warum dieses Element?
+- Blogbeiträge oder Produkte schnell teilen lassen.
+- Eventseiten viral verbreiten.
+- Trade-off: Zu viele Netzwerke verlangsamen die Seite und verwirren Nutzer.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Icons in flexiblen Layouts, Touch-Ziele ausreichend groß.
+- **Accessibility:** Buttons beschriften (`aria-label`), Fokus sichtbar, Tastaturbedienung.
+- **SEO:** Indirekter Effekt durch erhöhte Sichtbarkeit und Backlinks.
+- **Design-Guidelines:** Markenfarben der Netzwerke oder neutrale Icons, Hover-/Focus-States.
+- **Rechtliches:** Social Plugins datenschutzkonform integrieren (2-Klick-Lösung).
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Horizontale Scroll-Leiste oder Dropdown für zusätzliche Optionen.
+- **Accessibility:** Teilen-Dialog per Tastatur bedienbar, Clipboard-Option anbieten.
+- **SEO:** UTM-Parameter konsistent setzen, Sharing-Meta-Tags (OG, Twitter Cards) pflegen.
+- **Best Practices:**
+  - Nur relevante Netzwerke anzeigen.
+  - Copy-Link-Funktion anbieten.
+  - Lade Social-Skripte erst nach Interaktion.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Social APIs, Consent-Tool, Analytics
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/share-buttons.html](../content-elements-examples/share-buttons.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<div class="share">
+  <button type="button" aria-label="Bei LinkedIn teilen">LinkedIn</button>
+  <button type="button" aria-label="Link kopieren">Link kopieren</button>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Teilen-Funktionen bleiben wichtig, müssen aber datenschutzfreundlich umgesetzt werden.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Share Buttons gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Share Buttons tastatur- und screenreader-freundlich gestalten.
+- Performance: Share Buttons nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Share Buttons direkt neben dem Code dokumentieren.
+
+## Fazit
+Share Buttons bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-skeleton-loader.md
+++ b/_posts/2025-09-30-content-elements-skeleton-loader.md
@@ -1,0 +1,83 @@
+---
+title: "Skeleton Loader: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Skeleton Loader unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-skeleton-loader
+original_path: content-elements/skeleton-loader.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Skeleton Loader** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Skeleton Loader nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Skeleton Loader
+
+## Beschreibung
+Platzhalter-Layouts, die die spätere Struktur andeuten, während Inhalte laden.
+
+## Warum dieses Element?
+- Listen oder Karten während Datenabruf darstellen.
+- Dashboard-Widgets ohne Layoutverschiebung laden.
+- Trade-off: Falsche Skeletons können Erwartungen enttäuschen, wenn Inhalte anders aussehen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Skeleton-Elemente spiegeln spätere Layoutgrößen, fluid skalieren.
+- **Accessibility:** `aria-hidden` für Skeletons, tatsächliche Inhalte bei Verfügbarkeit ansagen.
+- **SEO:** Kein direkter Einfluss, aber reduziert Cumulative Layout Shift.
+- **Design-Guidelines:** Animierte Shimmer-Effekte dezent, Farben aus Neutraltönen.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Skeletons für kritische Bereiche priorisieren, um wahrgenommene Geschwindigkeit zu erhöhen.
+- **Accessibility:** Skeletons entfernen, sobald Content geladen ist, `aria-busy` nutzen.
+- **SEO:** Nicht relevant.
+- **Best Practices:**
+  - Skeletons an reale Content-Höhen anpassen.
+  - Nicht zu viele Animationen verwenden (Performance).
+  - Mit echten Ladezeiten abstimmen und Timeout setzen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Designsystem, State-Management
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/skeleton-loader.html](../content-elements-examples/skeleton-loader.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<div class="skeleton-card" aria-hidden="true">
+  <div class="skeleton skeleton--image"></div>
+  <div class="skeleton skeleton--text"></div>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Skeletons verbessern wahrgenommene Performance und bleiben relevant.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Skeleton Loader gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Skeleton Loader tastatur- und screenreader-freundlich gestalten.
+- Performance: Skeleton Loader nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Skeleton Loader direkt neben dem Code dokumentieren.
+
+## Fazit
+Skeleton Loader bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-table-of-contents.md
+++ b/_posts/2025-09-30-content-elements-table-of-contents.md
@@ -1,0 +1,85 @@
+---
+title: "Table Of Contents: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Table Of Contents unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-table-of-contents
+original_path: content-elements/table-of-contents.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Table Of Contents** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Table Of Contents nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Table of Contents
+
+## Beschreibung
+Strukturierte Liste von Ankern, die durch längere Inhalte navigiert.
+
+## Warum dieses Element?
+- Lange Blog- oder Doku-Artikel navigierbar machen.
+- FAQ- oder Richtlinientexte schnell erschließen.
+- Trade-off: Pflegeaufwand, wenn Überschriften dynamisch generiert oder häufig geändert werden.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Sticky-Verhalten auf Desktop, ausklappbar auf Mobile.
+- **Accessibility:** ARIA-Labeling für Navigation, Fokusreihenfolge beachten, Skip-Link anbieten.
+- **SEO:** Sprungmarken unterstützen Sitelinks und Rich Snippets.
+- **Design-Guidelines:** Klarer Abstand zum Inhalt, aktive Zustände markieren, dezente Typografie.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Als Akkordeon oder Dropdown starten und auf größeren Screens erweitern.
+- **Accessibility:** `nav` mit `aria-label` nutzen, Fokuszustände gut sichtbar machen.
+- **SEO:** Anker-IDs sprechend benennen, keine doppelten IDs.
+- **Best Practices:**
+  - Automatisierte Generierung aus der H-Struktur.
+  - Aktuelle Sektion via Intersection Observer hervorheben.
+  - Scroll-Offset für Fixed Header berücksichtigen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Anchor-Links, Sticky-Header, Scrollspy
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/table-of-contents.html](../content-elements-examples/table-of-contents.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<nav class="toc" aria-label="Inhaltsverzeichnis">
+  <ol>
+    <li><a href="#section-1">Einleitung</a></li>
+    <li><a href="#section-2">Details</a></li>
+  </ol>
+</nav>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Längere Inhalte bleiben verbreitet, daher ist eine gute Orientierung weiter wichtig.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Table Of Contents gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Table Of Contents tastatur- und screenreader-freundlich gestalten.
+- Performance: Table Of Contents nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Table Of Contents direkt neben dem Code dokumentieren.
+
+## Fazit
+Table Of Contents bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-table.md
+++ b/_posts/2025-09-30-content-elements-table.md
@@ -1,0 +1,88 @@
+---
+title: "Table: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Table unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-table
+original_path: content-elements/table.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Table** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Table nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Table
+
+## Beschreibung
+Tabellarische Darstellung von Daten mit Headern, Spalten und optionaler Sortierung.
+
+## Warum dieses Element?
+- Vergleichstabellen für Spezifikationen oder Features.
+- Reporting- oder Statistik-Daten innerhalb von Artikeln darstellen.
+- Trade-off: Viele Spalten auf kleinen Screens erschweren Lesbarkeit, erfordern alternative Layouts.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Scrollbare Container oder Kartenlayout für mobile Endgeräte bereitstellen.
+- **Accessibility:** Korrekte `<th>`-Zuordnungen, `scope`/`headers` einsetzen, ausreichend Kontrast.
+- **SEO:** Saubere Tabellenstruktur unterstützt Featured Snippets.
+- **Design-Guidelines:** Konsistente Zellabstände, zebra stripes optional, klare Sortier-Icons.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Wichtige Spalten priorisieren, horizontales Scrollen klar kennzeichnen.
+- **Accessibility:** Sortier-Buttons mit `aria-sort` pflegen, Tabellenzusammenfassung (`caption`) nutzen.
+- **SEO:** Relevante Keywords in Header-Zellen platzieren, keine leeren Zellen.
+- **Best Practices:**
+  - Tabellen mit `<caption>` einführen.
+  - Responsives Verhalten testen (Stacking, Scroll).
+  - Sortierung und Filterung server- oder clientseitig konsistent halten.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Filter, Sortier-Controls, Datenquellen
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/table.html](../content-elements-examples/table.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<table class="data-table">
+  <caption>Leistungsdaten</caption>
+  <thead>
+    <tr><th scope="col">Feature</th><th scope="col">Wert</th></tr>
+  </thead>
+  <tbody>
+    <tr><th scope="row">Latenz</th><td>120 ms</td></tr>
+  </tbody>
+</table>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Datenvisualisierung bleibt kritisch, responsive Tabellen sind unverzichtbar.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Table gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Table tastatur- und screenreader-freundlich gestalten.
+- Performance: Table nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Table direkt neben dem Code dokumentieren.
+
+## Fazit
+Table bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-tags-badges.md
+++ b/_posts/2025-09-30-content-elements-tags-badges.md
@@ -1,0 +1,83 @@
+---
+title: "Tags Badges: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Tags Badges unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-tags-badges
+original_path: content-elements/tags-badges.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Tags Badges** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Tags Badges nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Tags & Badges
+
+## Beschreibung
+Labels oder Chips zur Kennzeichnung von Kategorien, Status oder Highlights.
+
+## Warum dieses Element?
+- Produkte mit Attributen wie „Neu“ oder „Sale“ markieren.
+- Blogartikel nach Themen filtern oder kategorisieren.
+- Trade-off: Zu viele Tags wirken unübersichtlich und reduzieren Klarheit.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Chips umbrechen lassen, horizontale Scrollleisten für Tag-Listen.
+- **Accessibility:** `aria-pressed` für toggelbare Chips, ausreichender Kontrast.
+- **SEO:** Tags können Landingpages generieren, sollten aber gepflegt sein.
+- **Design-Guidelines:** Farbcodierung, abgerundete Ecken, kleine Typografie, Hover-/Focus-States.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Tags als Scroll-Liste darstellen, wichtige Tags priorisieren.
+- **Accessibility:** Chips per Tastatur steuerbar machen, Entfernen-Buttons beschriften.
+- **SEO:** Tag-Seiten canonicalisieren, Duplicate Content vermeiden.
+- **Best Practices:**
+  - Maximale Tag-Anzahl pro Item begrenzen.
+  - Farben aus Designsystem nutzen.
+  - Optional Icons oder Prefixe für Status verwenden.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Filter-System, Design-Tokens
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/tags-badges.html](../content-elements-examples/tags-badges.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<ul class="tags">
+  <li><span class="tag tag--new">Neu</span></li>
+  <li><span class="tag tag--sale">Sale</span></li>
+</ul>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Tags bleiben wichtig zur schnellen Kontextualisierung von Inhalten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Tags Badges gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Tags Badges tastatur- und screenreader-freundlich gestalten.
+- Performance: Tags Badges nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Tags Badges direkt neben dem Code dokumentieren.
+
+## Fazit
+Tags Badges bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-toast.md
+++ b/_posts/2025-09-30-content-elements-toast.md
@@ -1,0 +1,80 @@
+---
+title: "Toast: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Toast unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-toast
+original_path: content-elements/toast.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Toast** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Toast nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Toast
+
+## Beschreibung
+Kurzlebige Benachrichtigungen, die temporär eingeblendet werden.
+
+## Warum dieses Element?
+- Feedback nach Formularaktionen geben.
+- Hintergrundprozesse wie Speichern oder Sync bestätigen.
+- Trade-off: Können von Screenreadern überhört werden, wenn nicht korrekt implementiert.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Position adaptiv, ausreichend Abstand vom Rand, Stapel auf Mobile vermeiden.
+- **Accessibility:** `role="status"` oder `role="alert"`, sichtbare und hörbare Dauer.
+- **SEO:** Kein Einfluss.
+- **Design-Guidelines:** Farbvarianten, dezente Animation, Close-Icon optional.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Zentrierte oder untere Platzierung, Buttons groß genug.
+- **Accessibility:** Lesezeit ausreichend (mind. 5 Sekunden), Fokus nicht unerwartet verschieben.
+- **SEO:** Nicht relevant, da dynamisch.
+- **Best Practices:**
+  - Toast-Queue begrenzen.
+  - Manuelles Schließen ermöglichen.
+  - Animationen reduziert und bevorzugt per CSS implementieren.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Notification-System, Event-Bus
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/toast.html](../content-elements-examples/toast.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<div class="toast toast--success" role="status" aria-live="polite">Erfolg gespeichert.</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Kurze Benachrichtigungen bleiben wichtig für Feedback in Webanwendungen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Toast gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Toast tastatur- und screenreader-freundlich gestalten.
+- Performance: Toast nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Toast direkt neben dem Code dokumentieren.
+
+## Fazit
+Toast bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-tooltip.md
+++ b/_posts/2025-09-30-content-elements-tooltip.md
@@ -1,0 +1,82 @@
+---
+title: "Tooltip: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Tooltip unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-tooltip
+original_path: content-elements/tooltip.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Tooltip** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Tooltip nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Tooltip
+
+## Beschreibung
+Kurze Hilfetexte, die bei Hover oder Fokus zusätzliche Informationen geben.
+
+## Warum dieses Element?
+- Formularfelder mit Kontextinformationen versehen.
+- Tabellenwerte oder Icons erläutern, ohne Layout zu überladen.
+- Trade-off: Nicht auf Touch-Geräten verfügbar, daher alternative Darstellung nötig.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Positionierung relativ zum Trigger, auf Mobile ggf. als Inline-Hinweis.
+- **Accessibility:** `aria-describedby` verwenden, Fokus-Management beachten.
+- **SEO:** Kein direkter Einfluss, Inhalte sollten auch ohne Tooltip verfügbar sein.
+- **Design-Guidelines:** Klarer Kontrast, dezente Animation, Pfeile optional.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Tooltip als Click-to-toggle oder Inline-Expand umsetzen.
+- **Accessibility:** Tooltip bei Fokus sichtbar halten, Escape zum Schließen ermöglichen.
+- **SEO:** Tooltip-Inhalte nicht exklusiv halten, immer auch im Fließtext erwähnen.
+- **Best Practices:**
+  - Trigger als Button oder Link deklarieren.
+  - Tooltip mit `role="tooltip"` und IDs verknüpfen.
+  - Autohide mit Verzögerung, um Flickern zu vermeiden.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Popover-System, Focus-Management
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/tooltip.html](../content-elements-examples/tooltip.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<button type="button" aria-describedby="tip-id">?
+</button>
+<span id="tip-id" role="tooltip">Erklärt das Feld</span>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Tooltips bleiben relevant, solange Touch-Alternativen berücksichtigt werden.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Tooltip gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Tooltip tastatur- und screenreader-freundlich gestalten.
+- Performance: Tooltip nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Tooltip direkt neben dem Code dokumentieren.
+
+## Fazit
+Tooltip bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-trust-badges.md
+++ b/_posts/2025-09-30-content-elements-trust-badges.md
@@ -1,0 +1,83 @@
+---
+title: "Trust Badges: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Trust Badges unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-trust-badges
+original_path: content-elements/trust-badges.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Trust Badges** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Trust Badges nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Trust Badges
+
+## Beschreibung
+Sicherheits- und Vertrauenssiegel wie Zahlungsanbieter oder Zertifikate.
+
+## Warum dieses Element?
+- Checkout-Seiten mit Gütesiegeln versehen.
+- Landingpages mit Referenzen und Zertifizierungen stärken.
+- Trade-off: Zu viele Badges wirken unseriös oder ablenkend.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Icons skalierbar, Raster flexibel.
+- **Accessibility:** Alternativtexte für Logos, dekorative Elemente mit `aria-hidden`.
+- **SEO:** Alt-Texte tragen zu Markensichtbarkeit bei.
+- **Design-Guidelines:** Konsistente Größe, ausreichender Abstand, monochrome Varianten.
+- **Rechtliches:** Nur tatsächlich vorhandene Zertifikate nutzen, Nutzungsrechte prüfen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Badges gruppieren oder in Slider packen, ohne Scroll zu erzwingen.
+- **Accessibility:** Logos, die nur dekorativ sind, per `aria-hidden` ausblenden.
+- **SEO:** Dateinamen beschreibend wählen, Lazyload bei vielen Logos.
+- **Best Practices:**
+  - Maximal fünf relevante Badges gleichzeitig zeigen.
+  - Badges bei Bedarf verlinken (z. B. TÜV Zertifikat).
+  - Kontrast zum Hintergrund sicherstellen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Asset-Management, Legal-Team
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/trust-badges.html](../content-elements-examples/trust-badges.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<ul class="trust-badges">
+  <li><img src="../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht"></li>
+  <li><img src="../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht"></li>
+</ul>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Vertrauenssiegel beeinflussen weiterhin Conversion und Glaubwürdigkeit.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Trust Badges gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Trust Badges tastatur- und screenreader-freundlich gestalten.
+- Performance: Trust Badges nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Trust Badges direkt neben dem Code dokumentieren.
+
+## Fazit
+Trust Badges bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-typography.md
+++ b/_posts/2025-09-30-content-elements-typography.md
@@ -1,0 +1,88 @@
+---
+title: "Typography: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Typography unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-typography
+original_path: content-elements/typography.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Typography** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Typography nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Typography
+
+## Beschreibung
+Basis-Elemente für Textstruktur wie Überschriften, Absätze, Listen und Zitate, die Inhalte lesbar und hierarchisch gliedern.
+
+## Warum dieses Element?
+- Landingpages und Blogposts klar strukturieren.
+- Dokumentationen und Wissensdatenbanken gliedern.
+- Trade-off: Zu viele Formatvarianten erschweren Konsistenz und Pflege.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Schriftgrößen und Zeilenabstände fluid skalieren, Lesbarkeit auf allen Viewports sicherstellen.
+- **Accessibility:** Semantische Heading-Hierarchie, ausreichender Kontrast, Fokusreihenfolge für Sprungmarken.
+- **SEO:** Korrekte H-Struktur, strukturierte Inhalte, Schema für Zitate optional.
+- **Design-Guidelines:** Definierte Typografie-Skala, konsistente Margins und Zeilenhöhen, Zustände für Links.
+- **Rechtliches:** Keine speziellen Anforderungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Basisgrößen für kleine Screens festlegen und nach oben progressiv vergrößern.
+- **Accessibility:** Screenreader-freundliche Hierarchie, Skip-Links für lange Inhalte.
+- **SEO:** Nur ein H1 pro Seite, Überschriften nicht für reines Styling missbrauchen.
+- **Best Practices:**
+  - Systemschrift-Fallbacks definieren.
+  - Zeilenlänge auf 60–80 Zeichen begrenzen.
+  - Listen mit `ul`/`ol` semantisch korrekt einsetzen.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Layout-Raster, Komponentenbibliothek
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/typography.html](../content-elements-examples/typography.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<article>
+  <h1>Überschrift H1</h1>
+  <p>Absatztext mit <strong>Betonung</strong> und <a href="#">Link</a>.</p>
+  <h2>Liste</h2>
+  <ul>
+    <li>Listenpunkt</li>
+  </ul>
+  <blockquote>Zitat mit Quellenangabe.</blockquote>
+</article>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Typografie bleibt Grundlage für jede Content-Seite und beeinflusst Lesbarkeit sowie SEO direkt.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Typography gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Typography tastatur- und screenreader-freundlich gestalten.
+- Performance: Typography nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Typography direkt neben dem Code dokumentieren.
+
+## Fazit
+Typography bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-content-elements-video-embed.md
+++ b/_posts/2025-09-30-content-elements-video-embed.md
@@ -1,0 +1,87 @@
+---
+title: "Video Embed: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Video Embed unsere Content Elements-Notizen inspiriert."
+layout: post
+categories: [content-elements]
+slug: content-elements-video-embed
+original_path: content-elements/video-embed.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Video Embed** passte heute perfekt in unsere Content Elements-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Video Embed nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Content-Element: Video Embed
+
+## Beschreibung
+Einbettung von Videos mit Poster, Controls und optionaler Lazyload-Lösung.
+
+## Warum dieses Element?
+- Produktdemos oder Tutorials direkt im Content zeigen.
+- Kundenreferenzen oder Interviews einbetten.
+- Trade-off: Streaming kann Performance belasten und Datenschutzpflichten auslösen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Aspect-Ratio-Container, adaptive Playergröße.
+- **Accessibility:** Untertitel, Transkript und Tastaturbedienbarkeit sicherstellen.
+- **SEO:** Schema.org VideoObject, sprechende Titles und Thumbnails.
+- **Design-Guidelines:** Posterbild definieren, Player-Farben ans Designsystem anpassen.
+- **Rechtliches:** Einbettung externer Plattformen nur mit DSGVO-konformer Einwilligung und Hinweis auf Datenübertragung.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Automatisch muted starten, adaptive Bitrate, Bandbreite berücksichtigen.
+- **Accessibility:** `controls` aktivieren, Untertiteldateien (`track`) anbieten, Fokusmanagement prüfen.
+- **SEO:** Lazyload über Consent-Gate lösen, strukturierte Daten bereitstellen.
+- **Best Practices:**
+  - Posterbilder optimiert bereitstellen (WebP).
+  - Fallback-Link zum Download oder externen Player anbieten.
+  - Consent-Management für YouTube/Vimeo integrieren.
+
+## Checkliste
+- [ ] Darstellung auf allen Breakpoints geprüft
+- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
+- [ ] Semantik korrekt (HTML)
+- [ ] Performance optimiert (Lazyload/Kompression)
+
+## Abhängigkeiten / Überschneidungen
+- Consent-Tool, CDN/Player, Transkript
+
+## Akzeptanzkriterien
+- Technische Funktion OK
+- Konsistenz zum Designsystem
+- A11y & rechtliche Vorgaben erfüllt
+
+## Beispiel / Code
+[content-elements-examples/video-embed.html](../content-elements-examples/video-embed.html)
+
+```html
+<!-- Minimales, valides HTML-Beispiel -->
+<figure class="video">
+  <video controls preload="none" poster="video-poster.webp">
+    <source src="demo.mp4" type="video/mp4">
+    <track kind="captions" src="demo-de.vtt" srclang="de" label="Deutsch">
+    Ihr Browser unterstützt das Video-Element nicht.
+  </video>
+  <figcaption>Kurze Produktdemo.</figcaption>
+</figure>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐ Videoinhalte gewinnen weiter an Relevanz, müssen aber datenschutzkonform bereitgestellt werden.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Video Embed gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Video Embed tastatur- und screenreader-freundlich gestalten.
+- Performance: Video Embed nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Video Embed direkt neben dem Code dokumentieren.
+
+## Fazit
+Video Embed bleibt ein schönes Beispiel dafür, wie Content Elements-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-checkout-checkout.md
+++ b/_posts/2025-09-30-frontend-checkout-checkout.md
@@ -1,0 +1,77 @@
+---
+title: "Checkout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Checkout unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-checkout-checkout
+original_path: frontend/checkout/checkout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Checkout** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Checkout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Checkout
+
+## Kundenanforderung  
+Als Kunde:in möchte ich sämtliche nötigen Schritte (Versand, Zahlung, Adresse) in einem klaren, sicheren Ablauf abschließen können, um meinen Kauf zu finalisieren.
+
+## Warum ist das so?  
+Der Checkout ist der entscheidende Conversion-Hebel. Abbrüche hier kosten Umsatz. Klarheit, Vertrauen und minimale Friktion sind essenziell.
+
+## Anforderungen & Besonderheiten  
+- Validierung & Fehlerbehandlung  
+- Zahlungsoptionen & Integrationen  
+- Adressprüfung / Auto-Complete  
+- Sicherheit (SSL, Tokenisierung)  
+- Datenschutz & PCI Compliance  
+- Gast-Checkout (optional)  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Einspaltiger Ablauf, Progress Bar  
+- **Accessibility:** Beschriftete Felder, ARIA-Fehlermeldungen, Fokus beim Fehler  
+- **SEO:** keine Indexierung  
+- **Best Practices:**  
+ • Validierung asynchron  
+ • Inline-Fehlermeldungen  
+ • Caching sensibel (keine persönlichen Daten)  
+ • Payment-Fallbacks  
+
+## Checkliste  
+- [ ] Alle Schritte vollständig  
+- [ ] Fehlerbehandlung & Hinweise  
+- [ ] Sicherheitsmaßnahmen integriert  
+- [ ] Performance & Ladezeiten  
+
+## Abhängigkeiten / Überschneidungen  
+- Zahlungs-Gateway  
+- Nutzerkonto / Session  
+- Produkt-API  
+
+## Akzeptanzkriterien  
+- Checkout durchführbar ohne Fehler  
+- Sicherheit gewährleistet  
+- Mobile & Desktop funktionsfähig  
+- Klarer Fortschrittsindikator  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Absolut zentral – jeder E-Commerce hängt vom Checkout ab.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Checkout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Checkout tastatur- und screenreader-freundlich gestalten.
+- Performance: Checkout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Checkout direkt neben dem Code dokumentieren.
+
+## Fazit
+Checkout bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-checkout-discount-code.md
+++ b/_posts/2025-09-30-frontend-checkout-discount-code.md
@@ -1,0 +1,73 @@
+---
+title: "Discount Code: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Discount Code unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-checkout-discount-code
+original_path: frontend/checkout/discount-code.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Discount Code** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Discount Code nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Gutscheincode / Rabattcode
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich beim Checkout oder Warenkorb Rabattcode eingeben können, um einen Preisnachlass zu erhalten.
+
+## Warum ist das so?  
+Rabatte und Aktionen sind Marketinginstrumente, die häufig Käufe auslösen oder erhöhen.
+
+## Anforderungen & Besonderheiten  
+- Formatvalidierung  
+- Automatische Aktualisierung des Warenkorbs  
+- Kombination mehrerer Codes? Regelwerk  
+- Ablaufdatum / Einschränkungen  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Eingabefeld sichtbar, gute UX  
+- **Accessibility:** Beschriftungen, Tastaturzugänglich  
+- **SEO:** Codes nicht indexieren  
+- **Best Practices:**  
+ • Echtzeit-Applikation bei Eingabe  
+ • Klarer Fehler- oder Erfolgshinweis  
+ • Rücksetzoption  
+
+## Checkliste  
+- [ ] Code einlösbar  
+- [ ] Betrag aktualisiert  
+- [ ] Fehlerbehandlung  
+- [ ] Kombinierbarkeit geprüft  
+
+## Abhängigkeiten / Überschneidungen  
+- Warenkorb / Checkout  
+- Rabatt-Engine / Promotion-Service  
+- Session / Benutzer-Status  
+
+## Akzeptanzkriterien  
+- Code gültig / ungültig korrekt behandelt  
+- Preisänderung sichtbar  
+- UX auf allen Geräten  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Sehr relevant – fast Standard in Online-Shops, besonders für Aktionen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Discount Code gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Discount Code tastatur- und screenreader-freundlich gestalten.
+- Performance: Discount Code nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Discount Code direkt neben dem Code dokumentieren.
+
+## Fazit
+Discount Code bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-checkout-mini-cart.md
+++ b/_posts/2025-09-30-frontend-checkout-mini-cart.md
@@ -1,0 +1,73 @@
+---
+title: "Mini Cart: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Mini Cart unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-checkout-mini-cart
+original_path: frontend/checkout/mini-cart.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Mini Cart** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Mini Cart nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Mini-Cart / Off-Canvas Warenkorb
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich jederzeit über eine kleine Übersichtsbox (Mini-Cart) sehen, was aktuell im Warenkorb ist, ohne Seite zu verlassen.
+
+## Warum ist das so?  
+Reduziert Friktion, Nutzer sehen schnell Änderungen und können Inhalte prüfen, bevor sie weiter navigieren.
+
+## Anforderungen & Besonderheiten  
+- Live-Aktualisierung bei Artikeländerung  
+- Anzeige von Preis, Mini-Bild, Menge  
+- Mögliches Entfernen/Ändern direkt im Mini-Cart  
+- Keine Ablenkung (Overlay mit Schließmöglichkeit)  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Off-Canvas Slide-In / Drawer  
+- **Accessibility:** Fokusmanagement beim Öffnen/Schließen, ARIA-Labels  
+- **SEO:** Nicht indexierbar  
+- **Best Practices:**  
+ • Animationen sparsam einsetzen  
+ • Minimale Verzögerung bei Aktualisierung  
+ • Skeleton Loading  
+
+## Checkliste  
+- [ ] Mini-Cart öffnet & schließt korrekt  
+- [ ] Inhalt aktuell  
+- [ ] Aktionen (Entfernen, Menge) möglich  
+- [ ] Performance akzeptabel  
+
+## Abhängigkeiten / Überschneidungen  
+- Warenkorb-API  
+- Produktseite  
+- Checkout  
+
+## Akzeptanzkriterien  
+- Live-Update funktioniert  
+- Interaktion im Mini-Cart möglich  
+- Keine Layoutprobleme  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Sehr hoch – Nutzer erwarten direktes Feedback ohne Seitenwechsel.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Mini Cart gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Mini Cart tastatur- und screenreader-freundlich gestalten.
+- Performance: Mini Cart nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Mini Cart direkt neben dem Code dokumentieren.
+
+## Fazit
+Mini Cart bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-layout-accordion.md
+++ b/_posts/2025-09-30-frontend-layout-accordion.md
@@ -1,0 +1,73 @@
+---
+title: "Accordion: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Accordion unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-layout-accordion
+original_path: frontend/layout/accordion.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Accordion** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Accordion nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Akkordeon (Collapsible Panels)
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich Inhalte (z. B. Produktdetails, FAQs) in aufklappbaren Panels sehen, um die Seite übersichtlich zu halten und nur bei Bedarf Details anzuzeigen.
+
+## Warum ist das so?  
+Akkordeons sparen Platz, verbessern Übersichtlichkeit und vermeiden überfrachtete Layouts, besonders auf mobilen Geräten.
+
+## Anforderungen & Besonderheiten  
+- Animation / Transition verzichten auf zu große Bewegungen  
+- Inhalte vollständig aus dem DOM – nicht nur via JS versteckt  
+- Barrierefreiheit: ARIA, Fokussteuerung  
+- SEO: Inhalte bleiben im DOM, idealerweise auch indexierbar  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Panels mit Touch-Tap, große Klickflächen  
+- **Accessibility:** `aria-expanded`, `aria-controls`, Tastatursteuerung (Enter / Space)  
+- **SEO:** Inhalte im DOM vorhanden, nicht nur via JS  
+- **Best Practices:**  
+ • Minimale Repaint-Kosten  
+ • Zustand persistieren (z. B. per Hash)  
+ • Offen ggf. Markierung  
+
+## Checkliste  
+- [ ] Panels korrekt öffnen/schließen  
+- [ ] ARIA-Attribute korrekt  
+- [ ] Animation sanft & performant  
+- [ ] Inhalte immer zugreifbar  
+
+## Abhängigkeiten / Überschneidungen  
+- Produktdetailseite  
+- FAQ-Seite  
+- UI-Komponenten  
+
+## Akzeptanzkriterien  
+- Panels funktionieren mit Maus, Touch, Tastatur  
+- Inhalte sichtbar & versteckt korrekt  
+- Barrierefreie Navigation  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Sehr häufig eingesetzt – besonders bei mobilen Versionen von Detailseiten oder FAQs.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Accordion gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Accordion tastatur- und screenreader-freundlich gestalten.
+- Performance: Accordion nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Accordion direkt neben dem Code dokumentieren.
+
+## Fazit
+Accordion bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-layout-footer.md
+++ b/_posts/2025-09-30-frontend-layout-footer.md
@@ -1,0 +1,72 @@
+---
+title: "Footer: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Footer unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-layout-footer
+original_path: frontend/layout/footer.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Footer** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Footer nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Footer (Fußbereich)
+
+## Kundenanforderung  
+Als Besucher:in möchte ich unten auf der Seite wichtige Links (Impressum, Datenschutz, Kontakt, Shop-Kategorien etc.) sehen, um Orientierung zu erhalten.
+
+## Warum ist das so?  
+Der Footer ist ein häufig genutzter Ort für rechtliche Informationen, Navigation, Social Links und Service-Hinweise.
+
+## Anforderungen & Besonderheiten  
+- Pflichtangaben (Impressum, AGB, Datenschutz)  
+- Sitemap / Kategorieübersicht  
+- Social-Media-Links  
+- Optimierung für kleine Bildschirme  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** kompakte Darstellung, evtl. Akkordeons  
+- **Accessibility:** Überschriftenstruktur, Fokus-Logik  
+- **SEO:** interne Verlinkung relevant  
+- **Best Practices:**  
+ • Links konsistent  
+ • Keine übermäßige Tiefe  
+ • Klarer visuelle Hierarchie  
+
+## Checkliste  
+- [ ] Impressum / Datenschutz verlinkt  
+- [ ] Service-Links eingebunden  
+- [ ] Social Links funktional  
+- [ ] Mobile Darstellung geprüft  
+
+## Abhängigkeiten / Überschneidungen  
+- CMS / Navigation  
+- Rechtstexte  
+
+## Akzeptanzkriterien  
+- Footer zeigt alle erforderlichen Links  
+- Layout bei allen Geräten korrekt  
+- Keine defekten Links  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Fundament jeder professionellen Website – rechtlich und UX wichtig.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Footer gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Footer tastatur- und screenreader-freundlich gestalten.
+- Performance: Footer nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Footer direkt neben dem Code dokumentieren.
+
+## Fazit
+Footer bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-layout-hero-banner.md
+++ b/_posts/2025-09-30-frontend-layout-hero-banner.md
@@ -1,0 +1,79 @@
+---
+title: "Hero Banner: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Hero Banner unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-layout-hero-banner
+original_path: frontend/layout/hero-banner.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Hero Banner** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Hero Banner nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Hero Banner
+
+## Kundenanforderung  
+Als Besucher:in der Website möchte ich direkt beim Laden der Seite eine prägnante visuelle Botschaft (z. B. Kampagne, Angebot, Markenimage) sehen, damit ich schnell erfasse, worum es hier geht und motiviert werde, weiterzuscrollen.
+
+## Warum ist das so?  
+Der Hero-Bereich ist oft der erste visuelle Eindruck. Ein starkes Hero-Banner fokussiert Aufmerksamkeit, kommuniziert zentralen USP oder Aktion und hilft, die Customer Journey direkt zu steuern (Call-to-Action). Für viele Shops ist der Hero der Einstiegspunkt in die Hauptnavigation.  
+
+## Anforderungen & Besonderheiten  
+- Bilder oder Videos im Hero sollten performant geladen werden (Lazy-Loading, Responsive, optimierte Formate).  
+- Für Barrierefreiheit: Alternativtexte, Texte auch als echtes HTML-Overlay, nicht nur eingebettet ins Bild.  
+- Im EU-Kontext: keine automatische Einbindung externer Skripte (z. B. Tracking, Video) ohne Einwilligung gemäß Datenschutz / DSGVO.  
+- In vielen Shops wird der Hero dynamisch aus Daten (CMS, Content-Modul) befüllbar sein müssen.  
+- Rücksicht auf mobile Devices: verkürzte Versionen oder andere Motive pro Breakpoint.
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Verschiedene Bildgrößen je Breakpoint, `srcset` / `<picture>` mit WebP/AVIF.  
+- **Accessibility:** Alt-Attribute, kontrastreiche Texte, Fokus-Management, Stop/Pause-Option bei Animationen.  
+- **SEO:** Texte als HTML (nicht in Bild gerendert), Überschriften (H1 / H2) falls sinnvoll im Overlay.  
+- **Best Practices:**  
+ • Bildoptimierung und Kompression  
+ • Lazy Loading / Intersection Observer  
+ • A/B-Testing von Varianten  
+ • Fallback-Banner falls Bild ausfällt  
+ • Konsistenter Aspect-Ratio für verschiedene Geräte  
+
+## Checkliste  
+- [ ] Hauptmotiv in allen Breakpoints sichtbar  
+- [ ] Alt-Text gesetzt  
+- [ ] CTA-Button korrekt verlinkt  
+- [ ] Performance-Score > Zielwert  
+- [ ] Overlay-Text korrekt positioniert  
+
+## Abhängigkeiten / Überschneidungen  
+- CMS / Content-Module  
+- Marketing / Kampagnensteuerung  
+- SEO / Copywriting  
+- Responsive-Design-Grid  
+
+## Akzeptanzkriterien  
+- Banner lädt und zeigt korrekt in Desktop / Tablet / Mobile  
+- Text & CTA über dem Bild gut lesbar (Kontrast)  
+- Kein Layout-Verschieben (CLS minimal)  
+- CMS-fähig für Nicht-Entwickler:innen  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Sehr hoch – Hero-Banner bleiben Standard, aber werden 2025 stark durch Performance (Core Web Vitals) und Barrierefreiheit beeinflusst.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Hero Banner gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Hero Banner tastatur- und screenreader-freundlich gestalten.
+- Performance: Hero Banner nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Hero Banner direkt neben dem Code dokumentieren.
+
+## Fazit
+Hero Banner bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-layout-navigation-megamenu.md
+++ b/_posts/2025-09-30-frontend-layout-navigation-megamenu.md
@@ -1,0 +1,77 @@
+---
+title: "Navigation Megamenu: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Navigation Megamenu unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-layout-navigation-megamenu
+original_path: frontend/layout/navigation-megamenu.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Navigation Megamenu** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Navigation Megamenu nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Navigation & Mega-Menu
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich eine klare, intuitive Navigation mit Kategorien und Unterkategorien sehen, idealerweise mit Vorschaufunktion (Mega-Menu), damit ich schnell finde, was mich interessiert.
+
+## Warum ist das so?  
+In großen Shops gibt es viele Kategorien. Nutzer:innen wollen möglichst wenig klicken, um zu relevanten Produkten zu kommen. Ein Mega-Menu bietet Übersicht über Unterkategorien, Promotions und wichtige Seiten.  
+
+## Anforderungen & Besonderheiten  
+- Für Mobilgeräte: eventuell Off-Canvas oder Dropdown statt Mega-Menu.  
+- Barrierefreiheit: Keyboard-Navigation, Fokussteuerung, ARIA-Rollen.  
+- SEO: Kategorien und Unterseiten sollten crawlfähig bleiben.  
+- Performance: Menüs sollten asynchron geladen werden (z. B. via AJAX).  
+- Contentpflege: Menüstruktur sollte im Backend / CMS pflegbar sein.
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** für kleinere Bildschirme das Mega-Menu in mobile Variante (Side Drawer).  
+- **Accessibility:** ARIA-Attribute (aria-haspopup, aria-expanded), Fokus-Management, Escape-Verhalten.  
+- **SEO:** Menülinks sind echte `<a>`-Links, keine reinen JS-Handler.  
+- **Best Practices:**  
+ • Lazy load tieferer Ebenen  
+ • Caching von Menüstruktur  
+ • Verwendung von CSS statt JS, wo möglich  
+ • Maximale Tiefe sinnvoll begrenzen  
+
+## Checkliste  
+- [ ] Alle Kategorien und Unterkategorien erreichbar  
+- [ ] Keyboard-Navigation möglich  
+- [ ] Menüstruktur im CMS editierbar  
+- [ ] Menü in Mobil-Variante nutzbar  
+
+## Abhängigkeiten / Überschneidungen  
+- Kategorie-Struktur / Taxonomie  
+- CMS / Backend  
+- SEO (Kategorieseiten)  
+- Responsive-Design-Komponenten  
+
+## Akzeptanzkriterien  
+- Navigation funktioniert mit Maus & Tastatur  
+- Kein Überlagern von Inhalten oder Scrollprobleme  
+- Menüstruktur korrekt im Backend editierbar  
+- Ladezeit im Menü akzeptabel (kein Fake-Lag)  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Hoch – in großen Shops fast unverzichtbar, aber für kleine Shops eher simplified Navigation.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Navigation Megamenu gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Navigation Megamenu tastatur- und screenreader-freundlich gestalten.
+- Performance: Navigation Megamenu nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Navigation Megamenu direkt neben dem Code dokumentieren.
+
+## Fazit
+Navigation Megamenu bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-layout-notification-banner.md
+++ b/_posts/2025-09-30-frontend-layout-notification-banner.md
@@ -1,0 +1,67 @@
+---
+title: "Notification Banner: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Notification Banner unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-layout-notification-banner
+original_path: frontend/layout/notification-banner.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Notification Banner** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Notification Banner nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Benachrichtigungs-Banner / Alert-Banner
+
+## Kundenanforderung  
+Als Besucher:in möchte ich gelegentlich wichtige Meldungen (z. B. Versandkostenfrei-Threshold, Sale, Hinweis) prominent angezeigt bekommen.
+
+## Warum ist das so?  
+Wichtige Informationen können Aufmerksamkeit steigern und Aktionen auslösen.
+
+## Anforderungen & Besonderheiten  
+- Deaktivierung möglich (Schließen)  
+- Cookie-/Session-Speicherung, damit Banner nicht ständig wiederkommt  
+- Keine störende Overlays  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Banner top oder bottom, mobil optimiert  
+- **Accessibility:** Text passt auf Screenreader, Button gut erreichbar  
+- **SEO:** Banner nicht indexierbar  
+- **Best Practices:**  
+ • Anzeige nur, wenn relevant  
+ • Schließ-Status speichern  
+ • Fallback bei JS aus  
+
+## Checkliste  
+- [ ] Banner korrekt angezeigt  
+- [ ] Schließen möglich  
+- [ ] Status persistiert  
+- [ ] Anzeige nur bei Bedarf  
+
+## Akzeptanzkriterien  
+- Banner erscheint / verschwindet korrekt  
+- Nutzer kann schließen  
+- Kein mehrfaches Wiedererscheinen  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Hilfreich für Kampagnen & Hinweise, oft erwartet bei Verkaufsseiten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Notification Banner gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Notification Banner tastatur- und screenreader-freundlich gestalten.
+- Performance: Notification Banner nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Notification Banner direkt neben dem Code dokumentieren.
+
+## Fazit
+Notification Banner bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-layout-responsive-design.md
+++ b/_posts/2025-09-30-frontend-layout-responsive-design.md
@@ -1,0 +1,73 @@
+---
+title: "Responsive Design: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Responsive Design unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-layout-responsive-design
+original_path: frontend/layout/responsive-design.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Responsive Design** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Responsive Design nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Responsive Design / Mobile-Optimierung
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich, egal welches Gerät (Smartphone, Tablet, Desktop), eine intuitive und gut nutzbare Darstellung der Shopseite sehen.
+
+## Warum ist das so?  
+Mobile Traffic ist oft gleichbedeutend oder größer als Desktop. Schlechte mobile Darstellung führt zu Absprüngen.
+
+## Anforderungen & Besonderheiten  
+- Flexible Layouts, Breakpoints  
+- Touch-Optimierung  
+- Unterschiedliche Bildgrößen / Ressourcen je Gerät  
+- Schnelle Ladezeiten selbst auf mobilen Netzen  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Design zuerst für kleine Bildschirme entwickeln  
+- **Accessibility:** große Touch-Ziele, gut lesbare Texte  
+- **SEO:** Google Mobile-Friendly  
+- **Best Practices:**  
+ • CSS-Grid / Flexbox  
+ • Media Queries & Container Queries  
+ • Lazy load & Priorisierung kritischer Ressourcen  
+
+## Checkliste  
+- [ ] Design an verschiedenen Breakpoints geprüft  
+- [ ] Touch Interaktionen optimiert  
+- [ ] Performance-Tests auf Mobile  
+- [ ] Layout-Störungen bei Rotation  
+
+## Abhängigkeiten / Überschneidungen  
+- Theme / Layoutsystem  
+- Image-Rendering  
+- Interaktive Komponenten  
+
+## Akzeptanzkriterien  
+- Seitenlayout passt sich fließend an  
+- Keine horizontale Scrollbars  
+- Ladezeiten innerhalb Ziel  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Absolut essentiell – responsives Design ist kein Nice-to-have mehr.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Responsive Design gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Responsive Design tastatur- und screenreader-freundlich gestalten.
+- Performance: Responsive Design nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Responsive Design direkt neben dem Code dokumentieren.
+
+## Fazit
+Responsive Design bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-layout-sticky-header.md
+++ b/_posts/2025-09-30-frontend-layout-sticky-header.md
@@ -1,0 +1,66 @@
+---
+title: "Sticky Header: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Sticky Header unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-layout-sticky-header
+original_path: frontend/layout/sticky-header.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Sticky Header** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Sticky Header nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Sticky Header / Fixed Navigation
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich, dass die Kopfzeile (Navigation, Logo, ggf. Warenkorb) beim Scrollen sichtbar bleibt, um jederzeit navigieren zu können.
+
+## Warum ist das so?  
+Verkürzt Wege zurück zur Navigation oder zum Warenkorb – besonders in langen Seiten.
+
+## Anforderungen & Besonderheiten  
+- Nicht zu viel Platz einnehmen (reduziert Viewport)  
+- Ausblendlogik (z. B. versteckt beim Scroll nach unten)  
+- Kompatibilität mit mobilen Geräten  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** schlanker Header bei kleinen Geräten  
+- **Accessibility:** Fokus sichtbar, keine verdeckenden Elemente  
+- **SEO:** keine besonderen Anforderungen  
+- **Best Practices:**  
+ • Transition beim Ein-/Ausblenden  
+ • Performance beachten (kein Layout-Shift)  
+ • Z-Index sauber planen  
+
+## Checkliste  
+- [ ] Header fixiert & nutzbar  
+- [ ] Keine Layout-Verschiebung  
+- [ ] Verhalten bei geöffnetem Menü  
+
+## Akzeptanzkriterien  
+- Header bleibt sichtbar  
+- Navigation funktional  
+- Kein störender Platzverbrauch  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Moderne Shops verwenden das oft – UX-Steigerung bei längeren Seiten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Sticky Header gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Sticky Header tastatur- und screenreader-freundlich gestalten.
+- Performance: Sticky Header nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Sticky Header direkt neben dem Code dokumentieren.
+
+## Fazit
+Sticky Header bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-misc-accessibility.md
+++ b/_posts/2025-09-30-frontend-misc-accessibility.md
@@ -1,0 +1,74 @@
+---
+title: "Accessibility: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Accessibility unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-misc-accessibility
+original_path: frontend/misc/accessibility.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Accessibility** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Accessibility nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Accessibility / Barrierefreiheit
+
+## Kundenanforderung  
+Als Nutzer:in mit besonderen Anforderungen möchte ich die Website barrierefrei verwenden können (z. B. per Tastatur, Screenreader).
+
+## Warum ist das so?  
+Barrierefreiheit ist gesetzlich vorgeschrieben (z. B. EU-Richtlinien) und erweitert den Nutzerkreis. Zudem verbessert sie Grundqualität des Frontends.
+
+## Anforderungen & Besonderheiten  
+- WCAG 2.1 / 2.2 (AA) Richtlinien erfüllen  
+- Tastaturnavigation, Fokus-Indikatoren  
+- Alt-Texte, kontrastreicher Text  
+- ARIA-Rollen, Landmarken  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Fokusflächen ausreichend groß  
+- **Accessibility:** Semantische HTML-Elemente, ARIA-Attribute  
+- **SEO:** Barrierefreiheit unterstützt SEO indirekt  
+- **Best Practices:**  
+ • Skip-Links  
+ • Überspringbare Navigation  
+ • Color-Contrast-Tests automatisiert  
+ • Test mit Screenreadern  
+
+## Checkliste  
+- [ ] WCAG AA erfüllt  
+- [ ] Tastaturnavigation durchgängig  
+- [ ] Alt-Texte & Beschriftungen  
+- [ ] Fokus- & ARIA-Attribute  
+
+## Abhängigkeiten / Überschneidungen  
+- Alle Frontend-Komponenten  
+- Templates / HTML-Struktur  
+- CSS / Design-System  
+
+## Akzeptanzkriterien  
+- Site nutzbar nur mit Tastatur  
+- Screenreader-Tests erfolgreich  
+- Farbkombinationen konform  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Unverzichtbar – gesetzlich und UX-technisch relevant.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Accessibility gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Accessibility tastatur- und screenreader-freundlich gestalten.
+- Performance: Accessibility nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Accessibility direkt neben dem Code dokumentieren.
+
+## Fazit
+Accessibility bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-misc-newsletter-optin.md
+++ b/_posts/2025-09-30-frontend-misc-newsletter-optin.md
@@ -1,0 +1,73 @@
+---
+title: "Newsletter Optin: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Newsletter Optin unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-misc-newsletter-optin
+original_path: frontend/misc/newsletter-optin.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Newsletter Optin** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Newsletter Optin nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Newsletter-Anmeldung / Opt-In
+
+## Kundenanforderung  
+Als Besucher:in möchte ich mich mit meiner E-Mail-Adresse für einen Newsletter anmelden, um über Aktionen und Neuheiten informiert zu werden.
+
+## Warum ist das so?  
+Newsletter sind wichtiges Marketinginstrument; E-Mail-Marketing gehört zu den effektivsten Kanälen.
+
+## Anforderungen & Besonderheiten  
+- DSGVO / Double Opt-In Pflicht  
+- Bestätigungsmails / Willkommens-Mail  
+- Opt-Out möglich  
+- Eingabevalidierung & Captcha  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Eingabefeld prominent, aber dezent  
+- **Accessibility:** Label, Aria-Attribute  
+- **SEO:** Formularseiten nicht indexieren  
+- **Best Practices:**  
+ • Fehler- / Erfolgsmeldung direkt anzeigen  
+ • Spam-Schutz (Captcha / Honeypot)  
+ • Integration mit E-Mail-System / Marketing-Tool  
+
+## Checkliste  
+- [ ] Eintragungsformular sichtbar  
+- [ ] Double Opt-In umgesetzt  
+- [ ] Fehlerbehandlung / Feedback  
+- [ ] Opt-Out-Link  
+
+## Abhängigkeiten / Überschneidungen  
+- E-Mail-Service / Marketing-Tool  
+- Datenschutz / Consent-Lösung  
+
+## Akzeptanzkriterien  
+- Anmeldung funktioniert korrekt  
+- Willkommensmail gesendet  
+- Abmeldung möglich  
+- Datenschutzrichtlinien eingehalten  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Sehr hoch – E-Mail-Marketing bleibt Kernkanal mit hoher Bedeutung.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Newsletter Optin gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Newsletter Optin tastatur- und screenreader-freundlich gestalten.
+- Performance: Newsletter Optin nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Newsletter Optin direkt neben dem Code dokumentieren.
+
+## Fazit
+Newsletter Optin bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-misc-storefinder.md
+++ b/_posts/2025-09-30-frontend-misc-storefinder.md
@@ -1,0 +1,73 @@
+---
+title: "Storefinder: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Storefinder unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-misc-storefinder
+original_path: frontend/misc/storefinder.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Storefinder** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Storefinder nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Storefinder / Filial-Locator
+
+## Kundenanforderung  
+Als Kund:in möchte ich sehen, wo sich physische Filialen befinden und welche Filiale in meiner Nähe ist.
+
+## Warum ist das so?  
+Verbindung zwischen Online und Offline stärkt Vertrauen und ermöglicht Click-and-Collect oder Filialbesuche.
+
+## Anforderungen & Besonderheiten  
+- Map-Darstellung (z. B. Google Maps, OpenStreetMap)  
+- Standorte mit Adresse, Öffnungszeiten, Kontakt  
+- Suchfilter (PLZ, Radius)  
+- DSGVO: keine Standortdaten speichern ohne Zustimmung  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Kartenansicht mobil optimiert  
+- **Accessibility:** Karten mit Alternativtext, Tastaturkompatibilität  
+- **SEO:** Standortseiten individualisiert und indexierbar  
+- **Best Practices:**  
+ • Clustering bei vielen Points  
+ • Lazy load Karten  
+ • Fallback-Ansicht ohne Karte  
+
+## Checkliste  
+- [ ] Alle Filialdaten korrekt  
+- [ ] Filter & Suchfunktion  
+- [ ] Karten-Integration funktioniert  
+- [ ] Mobile & Desktop Layout  
+
+## Abhängigkeiten / Überschneidungen  
+- Standortdaten / Datenbank  
+- Karten-API  
+- CMS / Admin-Backend  
+
+## Akzeptanzkriterien  
+- Filiale in Nähe korrekt angezeigt  
+- Karte lädt & zoomt  
+- Kartenfehlerbehandlung  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐☆☆  
+Relevanter für Omnichannel-Shops mit Filialen; für reine Online-Händler oft optional.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Storefinder gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Storefinder tastatur- und screenreader-freundlich gestalten.
+- Performance: Storefinder nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Storefinder direkt neben dem Code dokumentieren.
+
+## Fazit
+Storefinder bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-misc-trust-elements.md
+++ b/_posts/2025-09-30-frontend-misc-trust-elements.md
@@ -1,0 +1,73 @@
+---
+title: "Trust Elements: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Trust Elements unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-misc-trust-elements
+original_path: frontend/misc/trust-elements.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Trust Elements** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Trust Elements nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Vertrauens- / Trust-Elemente
+
+## Kundenanforderung  
+Als Besucher:in möchte ich Sicherheits- und Vertrauenssignale (z. B. Zahlungssymbole, Gütesiegel) sehen, damit ich dem Shop vertrauen kann.
+
+## Warum ist das so?  
+Vertrauen ist ein wichtiger Faktor im Online-Handel. Sicherheitssymbole und Zertifikate vermindern Unsicherheit und fördern Konversion.
+
+## Anforderungen & Besonderheiten  
+- Aktuelle Logos (SSL, Zahlungsanbieter, Datenschutz)  
+- Echtheit der Siegel prüfen  
+- Barrierefreiheit: Alternativtexte, lesbare Logos  
+- Positionierung ohne Überfrachtung  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** kompakter Footer oder Badge-Sektion  
+- **Accessibility:** Alt-Texte, klare Beschriftung  
+- **SEO:** keine überflüssigen Bild-Links  
+- **Best Practices:**  
+ • Lazy load Logos  
+ • Link auf Erklärseite (z. B. “Sicherheit erklärt”)  
+ • Konsistente Markenfarben  
+
+## Checkliste  
+- [ ] Alle relevanten Trust-Logos vorhanden  
+- [ ] Alt-Texte korrekt  
+- [ ] Logos verlinkt (wenn sinnvoll)  
+- [ ] Layout konsistent  
+
+## Abhängigkeiten / Überschneidungen  
+- Footer  
+- Payment / SSL  
+- Datenschutz & Impressum  
+
+## Akzeptanzkriterien  
+- Logos sichtbar & lesbar  
+- Keine defekten Bild-URLs  
+- Vertrauenssignale konsistent  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Standard in professionellen Shops – besonders wichtig bei Zahlungsdienstintegration.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Trust Elements gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Trust Elements tastatur- und screenreader-freundlich gestalten.
+- Performance: Trust Elements nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Trust Elements direkt neben dem Code dokumentieren.
+
+## Fazit
+Trust Elements bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-navigation-breadcrumbs.md
+++ b/_posts/2025-09-30-frontend-navigation-breadcrumbs.md
@@ -1,0 +1,72 @@
+---
+title: "Breadcrumbs: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Breadcrumbs unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-navigation-breadcrumbs
+original_path: frontend/navigation/breadcrumbs.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Breadcrumbs** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Breadcrumbs nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Breadcrumb-Navigation
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich eine Pfadnavigation („Home > Kategorie > Subkategorie“) sehen, damit ich weiß, wo ich mich befinde und zurück navigieren kann.
+
+## Warum ist das so?  
+Breadcrumbs verbessern Orientierung, Navigationsgeschwindigkeit und reduzieren „Lost in navigation“.  
+
+## Anforderungen & Besonderheiten  
+- Dynamisch generiert entsprechend Kategorie-Hierarchie  
+- Klickbare Pfade  
+- Rücksicht auf SEO (Breadcrumbs von Suchmaschinen nutzbar)  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** ggf. gekürzte Breadcrumbs oder „… > Unterkategorie“  
+- **Accessibility:** ARIA „breadcrumb“ Landmark  
+- **SEO:** strukturierte Daten (BreadcrumbList)  
+- **Best Practices:**  
+ • Konsistentes Format  
+ • Trennung mit Separator  
+ • Keine redundanten Segmentnamen  
+
+## Checkliste  
+- [ ] Pfad korrekt aufgebaut  
+- [ ] Alle Segmente klickbar  
+- [ ] Strukturierte Daten  
+- [ ] Mobile Anzeigelogik  
+
+## Abhängigkeiten / Überschneidungen  
+- Kategoriestruktur  
+- SEO / Schema  
+- Navigationssystem  
+
+## Akzeptanzkriterien  
+- Breadcrumbs funktionieren durchgängig  
+- Strukturielle SEO-Daten korrekt  
+- Anzeige passt für mobile Geräte  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐☆☆  
+Wichtig für Usability & SEO – aber nicht „sichtbar sexy“.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Breadcrumbs gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Breadcrumbs tastatur- und screenreader-freundlich gestalten.
+- Performance: Breadcrumbs nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Breadcrumbs direkt neben dem Code dokumentieren.
+
+## Fazit
+Breadcrumbs bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-navigation-filters-facets.md
+++ b/_posts/2025-09-30-frontend-navigation-filters-facets.md
@@ -1,0 +1,75 @@
+---
+title: "Filters Facets: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Filters Facets unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-navigation-filters-facets
+original_path: frontend/navigation/filters-facets.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Filters Facets** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Filters Facets nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Filter & Facettennavigation
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich auf Kategorieseiten Produkte durch Filter (z. B. Preis, Marke, Eigenschaften) einschränken, um schneller relevante Produkte zu finden.
+
+## Warum ist das so?  
+Ohne Filter scrollt man durch viele irrelevante Produkte. Filter verbessern Effizienz und Conversion-Pfad.
+
+## Anforderungen & Besonderheiten  
+- Logik bei mehrfacher Auswahl (AND / OR)  
+- Filter-Counts (Anzahl möglicher Produkte)  
+- SEO: keine zu viele Filterkombinationen indexieren  
+- Performance: Filterabanfragen schnell, Partial-Rendering  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Filter als Side Drawer / Off-Canvas  
+- **Accessibility:** ARIA, Fokus, klare Beschriftungen  
+- **SEO:** canonical tags, Maskierung von Facetten-URLs  
+- **Best Practices:**  
+ • Serverseitige Filterkomputation  
+ • Clientseitige Inkremente (AJAX)  
+ • Ergebniszählung (Counts)  
+ • Pagination-Kohärenz  
+
+## Checkliste  
+- [ ] Alle wesentlichen Filtertypen integriert  
+- [ ] Kombinationen möglich  
+- [ ] Performance bei hoher Last  
+- [ ] SEO-Filterstrategie definiert  
+
+## Abhängigkeiten / Überschneidungen  
+- Such-API / Backend  
+- Kategorie-Struktur  
+- Pagination / Sortierung  
+
+## Akzeptanzkriterien  
+- Filter schneiden richtig  
+- Kombinationen korrekt  
+- keine toten Filter (leerer Rückgabewert)  
+- SEO-konforme URL-Struktur  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Essentiell in mittelgroßen bis großen Shops – besonders bei umfangreichem Sortiment.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Filters Facets gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Filters Facets tastatur- und screenreader-freundlich gestalten.
+- Performance: Filters Facets nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Filters Facets direkt neben dem Code dokumentieren.
+
+## Fazit
+Filters Facets bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-navigation-search-autocomplete.md
+++ b/_posts/2025-09-30-frontend-navigation-search-autocomplete.md
@@ -1,0 +1,75 @@
+---
+title: "Search Autocomplete: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Search Autocomplete unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-navigation-search-autocomplete
+original_path: frontend/navigation/search-autocomplete.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Search Autocomplete** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Search Autocomplete nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Suchfunktion mit Autocomplete
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich bei Eingabe im Suchfeld Vorschläge (Produkte, Kategorien, Schlagwörter) sehen, um schneller zum Ziel zu kommen.
+
+## Warum ist das so?  
+Suchfunktion ist zentrale Navigation. Vorschläge reduzieren Tippfehler, führen schneller zum Ziel und verbessern Conversion.  
+
+## Anforderungen & Besonderheiten  
+- Typo-Toleranz / fuzzy matching  
+- Anzeige von Produktvorschlägen + Kategorien + Aktionen  
+- Caching und Performance unter Last  
+- Datenschutz: keine ungewollte Speicherung personenbezogener Suchdaten.
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Vorschlagsliste unter dem Suchfeld passend zum Viewport.  
+- **Accessibility:** ARIA-Combobox, Listen mit Rollen, Fokusmanagement.  
+- **SEO:** keine Indexierung von Autocomplete-URLs, nur Hauptseiten.  
+- **Best Practices:**  
+ • Debounce / Throttle der Eingaben  
+ • Minimaler Request-Länge (z. B. 2 Zeichen)  
+ • Caching auf Client und Server  
+ • Synonymliste & Stoppwörter  
+
+## Checkliste  
+- [ ] Vorschläge erscheinen ab x Zeichen  
+- [ ] Auswahl via Tastatur möglich  
+- [ ] Performance unter Last getestet  
+- [ ] Datenschutz eingehalten  
+
+## Abhängigkeiten / Überschneidungen  
+- Produktdaten-API / Backend-Suche  
+- Taxonomie / Kategorien  
+- Cache-Layer  
+
+## Akzeptanzkriterien  
+- Vorschlagsliste korrekt gefüllt  
+- Auswahl via Enter oder Klick möglich  
+- Latency unter Zielwert (z. B. 100 ms)  
+- Keine Fehler bei Edge Cases  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Sehr hoch – Nutzergewöhntheit, Conversion-Wirkung, Performance entscheidend.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Search Autocomplete gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Search Autocomplete tastatur- und screenreader-freundlich gestalten.
+- Performance: Search Autocomplete nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Search Autocomplete direkt neben dem Code dokumentieren.
+
+## Fazit
+Search Autocomplete bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-navigation-sorting-options.md
+++ b/_posts/2025-09-30-frontend-navigation-sorting-options.md
@@ -1,0 +1,73 @@
+---
+title: "Sorting Options: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Sorting Options unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-navigation-sorting-options
+original_path: frontend/navigation/sorting-options.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Sorting Options** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Sorting Options nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Sortieroptionen
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich Produkte sortieren nach Preis, Relevanz, Beliebtheit, Neuheiten etc., um meine Auswahl besser steuern zu können.
+
+## Warum ist das so?  
+Sortierung ist Usability-Standard: Nutzer erwarten Kontrolle über Reihenfolge. Ohne Sortierung kann Relevanz leiden.
+
+## Anforderungen & Besonderheiten  
+- Sorte der Optionen: Preis auf/ab, Name, Neuheit, Bewertung  
+- Kombination mit Filter & Paginierung  
+- SEO: Vermeidung von Duplicate Content  
+- Performance: Sortierung effizient backendseitig  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** einfache Dropdowns oder Buttons  
+- **Accessibility:** Label, ARIA, Fokus-Elemente  
+- **SEO:** canonical oder parameterbereinigte URLs  
+- **Best Practices:**  
+ • Standard-Sortierung definieren  
+ • Parameter konsistent (z. B. `?sort=price_asc`)  
+ • Vermeidung überflüssiger Kombinationen  
+
+## Checkliste  
+- [ ] Alle relevanten Sortieroptionen vorhanden  
+- [ ] Sortierung funktioniert mit Filter/Pagination  
+- [ ] SEO-Parameterstrategie vorhanden  
+- [ ] Performance unter Last  
+
+## Abhängigkeiten / Überschneidungen  
+- Filter / Facetten  
+- Pagination  
+- Backend-Sortier-API  
+
+## Akzeptanzkriterien  
+- Sortierung korrekt und stabil  
+- URLs repräsentieren Sortierung  
+- Keine unerwarteten Nebeneffekte  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Hoch – Standard in fast jedem Shop, aber kein Killer-Feature in kleinen Shops.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Sorting Options gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Sorting Options tastatur- und screenreader-freundlich gestalten.
+- Performance: Sorting Options nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Sorting Options direkt neben dem Code dokumentieren.
+
+## Fazit
+Sorting Options bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-product-compare-products.md
+++ b/_posts/2025-09-30-frontend-product-compare-products.md
@@ -1,0 +1,73 @@
+---
+title: "Compare Products: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Compare Products unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-product-compare-products
+original_path: frontend/product/compare-products.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Compare Products** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Compare Products nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Produktvergleich (Compare)
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich mehrere Produkte nebeneinander vergleichen (Eigenschaften, Preis etc.), um eine fundierte Entscheidung zu treffen.
+
+## Warum ist das so?  
+Vergleich minimiert Aufwand, erhöht Vertrauen und vermeidet Rückfragen.
+
+## Anforderungen & Besonderheiten  
+- Vergleichbare Merkmale definieren  
+- Maximalzahl von Produkten beschränken (z. B. 3–4)  
+- Layout auf kleinen Geräten – meist Scroll oder Tabs  
+- Datenschutz: nur öffentliche Produktdaten  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Vergleich als nebeneinander scrollbares Raster oder Tabs  
+- **Accessibility:** Tabellenstruktur mit `thead`/`tbody`, ARIA-Labels  
+- **SEO:** Vergleichsseiten ggf. nicht indexieren  
+- **Best Practices:**  
+ • Sync mit Auswahl  
+ • Vorkonfigurierte Template-Vergleiche  
+ • UX: Hervorhebung der Unterschiede  
+
+## Checkliste  
+- [ ] Vergleichsfunktion aktiviert  
+- [ ] Detailmerkmale abgebildet  
+- [ ] Übersichtliche Darstellung  
+- [ ] Mobile-kompatibel  
+
+## Abhängigkeiten / Überschneidungen  
+- Produktdaten / API  
+- UI-Komponenten  
+- Filter / Eigenschaften  
+
+## Akzeptanzkriterien  
+- Vergleich funktioniert korrekt  
+- Layout responsiv  
+- Auswahl & Entfernen funktioniert  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐☆☆  
+Nützlich in großen Shops mit vielen ähnlichen Produkten, aber kein Muss in kleinen Shops.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Compare Products gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Compare Products tastatur- und screenreader-freundlich gestalten.
+- Performance: Compare Products nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Compare Products direkt neben dem Code dokumentieren.
+
+## Fazit
+Compare Products bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-product-cross-selling.md
+++ b/_posts/2025-09-30-frontend-product-cross-selling.md
@@ -1,0 +1,75 @@
+---
+title: "Cross Selling: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Cross Selling unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-product-cross-selling
+original_path: frontend/product/cross-selling.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Cross Selling** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Cross Selling nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Cross-Selling / Upselling
+
+## Kundenanforderung  
+Als Kunde:in möchte ich passende Zusatzprodukte oder höherwertige Varianten zu meinem aktuellen Produkt sehen, damit ich ggf. mehr kaufe oder bessere Varianten entdecke.
+
+## Warum ist das so?  
+Upselling / Cross-Selling erhöht Umsatz pro Kunde. Es lenkt auf relevante Angebote, erweitert den Warenkorb sinnvoll.
+
+## Anforderungen & Besonderheiten  
+- Empfehlung mit sinnvoller Logik (Kombi, Ergänzung, Zubehör)  
+- Darstellung auf PDP oder im Checkout  
+- Datenschutz: Empfehlung basierend auf anonymen Mustern, nicht personenbezogene Daten ohne Einwilligung  
+- Einfaches Management im Backend  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Empfehlung unterhalb Produkttab oder „weitere Produkte“ scrollbar  
+- **Accessibility:** ARIA-Labels, klare Linkstruktur  
+- **SEO:** Empfehlungstitel als Link, kein Cloaking  
+- **Best Practices:**  
+ • Empfehlung basierend auf Algorithmen (kaufhistorisch, collaborative filtering)  
+ • Caching von Empfehlungen  
+ • Fallback bei fehlendem Vorschlag  
+ • Metriken (Klickraten)  
+
+## Checkliste  
+- [ ] Empfehlungslogik definiert  
+- [ ] Anzeigen an sinnvollen Stellen  
+- [ ] Empfehlungen korrekt verlinkt  
+- [ ] Performance getestet  
+
+## Abhängigkeiten / Überschneidungen  
+- Product-API / Daten  
+- Analytics / Tracking  
+- Backend / Empfehlungsservice  
+
+## Akzeptanzkriterien  
+- Empfehlungen passen thematisch  
+- Links führen zur korrekten Seite  
+- Keine Performance-Einbrüche  
+- Anzeigen nicht störend  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Wichtig, aber weniger kritisch als Produktdetailseite – vor allem in mittleren Shops sinnvoll.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Cross Selling gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Cross Selling tastatur- und screenreader-freundlich gestalten.
+- Performance: Cross Selling nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Cross Selling direkt neben dem Code dokumentieren.
+
+## Fazit
+Cross Selling bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-product-personalized-recommendations.md
+++ b/_posts/2025-09-30-frontend-product-personalized-recommendations.md
@@ -1,0 +1,73 @@
+---
+title: "Personalized Recommendations: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Personalized Recommendations unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-product-personalized-recommendations
+original_path: frontend/product/personalized-recommendations.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Personalized Recommendations** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Personalized Recommendations nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Personalisierte Empfehlungen
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich individuelle Produktempfehlungen sehen (basierend auf meinem Verhalten, Interessen), um spannende Artikel zu entdecken.
+
+## Warum ist das so?  
+Personalisierung steigert Conversion, Warenkorb-Wert und Bindung.
+
+## Anforderungen & Besonderheiten  
+- Empfehlung basierend auf anonymem Nutzerverhalten  
+- Transparenz & Datenschutz (Opt-In / Opt-Out)  
+- Algorithmen & Caching  
+- Relevanz & Filterung  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Empfehlungsspuren prominent, aber unaufdringlich  
+- **Accessibility:** Karten/Listen ARIA-freundlich  
+- **SEO:** Empfehlungsbereiche als Links, aber nicht indexierbar als separate Seiten  
+- **Best Practices:**  
+ • A/B-Tests für Algorithmen  
+ • Echtzeit- vs Batch-Empfehlungen  
+ • Fallback-Logiken  
+
+## Checkliste  
+- [ ] Empfehlungslogik definiert  
+- [ ] Personalisierungsmechanismus aktiv  
+- [ ] Opt-Out / Transparenz  
+- [ ] Performance getestet  
+
+## Abhängigkeiten / Überschneidungen  
+- Analytics / Nutzerverhalten  
+- Empfehlungssystem / Backend  
+- Produktsystem  
+
+## Akzeptanzkriterien  
+- Empfehlungen passen zum Nutzer  
+- Verhalten ändert Empfehlungen  
+- Keine großen Performance-Einbußen  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Wird zunehmend Standard – große Shops setzen stark darauf.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Personalized Recommendations gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Personalized Recommendations tastatur- und screenreader-freundlich gestalten.
+- Performance: Personalized Recommendations nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Personalized Recommendations direkt neben dem Code dokumentieren.
+
+## Fazit
+Personalized Recommendations bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-product-product-detail.md
+++ b/_posts/2025-09-30-frontend-product-product-detail.md
@@ -1,0 +1,80 @@
+---
+title: "Product Detail: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Product Detail unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-product-product-detail
+original_path: frontend/product/product-detail.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Product Detail** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Product Detail nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Produktdetailseite (PDP)
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich auf einer Produktdetailseite alle relevanten Informationen (Bilder, Beschreibung, Preis, Varianten, Bewertungen etc.) sehen, um eine Kaufentscheidung treffen zu können.
+
+## Warum ist das so?  
+Die PDP ist der zentrale Conversion-Punkt. Eine gute PDP liefert Vertrauen und Klarheit, reduziert Abbrüche.
+
+## Anforderungen & Besonderheiten  
+- Varianten (Farben, Größen, Bundles)  
+- Lagerbestand / Verfügbarkeit  
+- Preis & Staffelpreise  
+- Bewertung & Rezensionen  
+- Cross-Selling / Upselling  
+- Rich Snippets / strukturierte Daten für SEO  
+- Datenschutz: keine personenbezogenen Elemente ohne Zustimmung  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** responsives Layout, Accordion für Details bei kleinen Geräten  
+- **Accessibility:** strukturierte Überschriften, Fokussteuerung, ARIA für Varianten  
+- **SEO:** JSON-LD für Produktdaten, Canonical, Meta-Daten  
+- **Best Practices:**  
+ • Pre-Rendering / SSR  
+ • Code-Splitting bei interaktiven Modulen  
+ • Deferred Loading von Sektionen (Bewertungen, Cross-Selling)  
+
+## Checkliste  
+- [ ] Bilder & Galerie korrekt  
+- [ ] Varianten-Auswahl funktionsfähig  
+- [ ] Preisanzeige & Verfügbarkeit  
+- [ ] Bewertungsabschnitt  
+- [ ] Rich Snippets eingebunden  
+- [ ] CTA (In den Warenkorb) präsent  
+
+## Abhängigkeiten / Überschneidungen  
+- Produkt-API Backend  
+- Reviews-Service  
+- Cross-Selling / Empfehlungssystem  
+- Lager-/Inventarsystem  
+
+## Akzeptanzkriterien  
+- Alle Varianten auswählbar  
+- Bilder galeriefähig  
+- Richtige Metadaten im HTML  
+- Kein Performance-Engpass  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Extrem wichtig – Kern jeder E-Commerce-Plattform.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Product Detail gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Product Detail tastatur- und screenreader-freundlich gestalten.
+- Performance: Product Detail nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Product Detail direkt neben dem Code dokumentieren.
+
+## Fazit
+Product Detail bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-product-product-gallery.md
+++ b/_posts/2025-09-30-frontend-product-product-gallery.md
@@ -1,0 +1,74 @@
+---
+title: "Product Gallery: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Product Gallery unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-product-product-gallery
+original_path: frontend/product/product-gallery.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Product Gallery** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Product Gallery nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Produktgalerie & Bilderansicht
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich mehrere Bilder eines Produkts sehen und zwischen ihnen wechseln bzw. hineinzoomen können.
+
+## Warum ist das so?  
+Visuelle Darstellung ist entscheidend – gute Bilder vermitteln Vertrauen, Detail und Produktwert.
+
+## Anforderungen & Besonderheiten  
+- Zoom-Funktion  
+- Thumbnails / Mini-Ansichten  
+- Fullscreen / Lightbox-Modus  
+- Lazy Loading der Bilder  
+- Hochauflösende Varianten  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Swipe-Galerie, Touch-Gesten  
+- **Accessibility:** Alt-Texte, Fokus in Lightbox, Tastatursteuerung  
+- **SEO:** Alt-Texte, Bildgröße optimiert  
+- **Best Practices:**  
+ • Progressive Bildformate  
+ • Lazy load mit Placeholder  
+ • Vorschaubilder vorher laden  
+ • Bild-Cache  
+
+## Checkliste  
+- [ ] Alle Bilder geladen  
+- [ ] Zoom & Lightbox funktionsfähig  
+- [ ] Alt-Texte korrekt  
+- [ ] Performance akzeptabel  
+
+## Abhängigkeiten / Überschneidungen  
+- Produktdetailseite  
+- CMS / Bildverwaltung  
+
+## Akzeptanzkriterien  
+- Galerie interaktiv  
+- Tastatur & Touch kompatibel  
+- Kein Fehler bei Bildwechsel  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Sehr hoch – gute visuelle Präsentation ist zentral für Kaufvertrauen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Product Gallery gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Product Gallery tastatur- und screenreader-freundlich gestalten.
+- Performance: Product Gallery nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Product Gallery direkt neben dem Code dokumentieren.
+
+## Fazit
+Product Gallery bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-product-product-grid.md
+++ b/_posts/2025-09-30-frontend-product-product-grid.md
@@ -1,0 +1,75 @@
+---
+title: "Product Grid: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Product Grid unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-product-product-grid
+original_path: frontend/product/product-grid.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Product Grid** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Product Grid nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Produkt-Grid / Kachelansicht
+
+## Kundenanforderung  
+Als Besucher:in möchte ich mehrere Produkte gleichzeitig in Form von Kacheln sehen, um schnell mein Interesse zu steuern und ggf. direkt in Produktdetailseiten zu springen.
+
+## Warum ist das so?  
+Grid-Darstellung ist effizient, visuell ansprechend und ermöglicht schnellen Überblick.
+
+## Anforderungen & Besonderheiten  
+- Einheitliche Kachelgrößen oder variabel (Masonry)  
+- Responsive Anzahl der Spalten  
+- Bildformatsoptimierung  
+- Lazy Loading (Infinite Scroll oder Paginierung)  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** 1–2 Spalten auf kleinen Geräten  
+- **Accessibility:** Fokus-States, Tab-Reihenfolge, ARIA-Labels  
+- **SEO:** Produktlinks als echte `<a>`-Tags  
+- **Best Practices:**  
+ • Bildoptimierung / lazy load  
+ • CSS Grid oder flexbox  
+ • Skeleton-Placeholder beim Laden  
+ • Überschrift & Preis direkt in Kachel  
+
+## Checkliste  
+- [ ] Responsive Spaltenanzahl implementiert  
+- [ ] Bilder mit Alt-Text  
+- [ ] Links in Kacheln korrekt  
+- [ ] Performance-Tests  
+
+## Abhängigkeiten / Überschneidungen  
+- Produkt-API  
+- Paginierung / Infinite Scroll  
+- Filter & Sortierung  
+
+## Akzeptanzkriterien  
+- Kacheln korrekt angezeigt über Breakpoints  
+- Klick auf Kachel führt zur Produktseite  
+- Kein Layout-Verschieben (CLS minimal)  
+- Schnelle Ladezeit  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Sehr hoch – Produkt-Grid ist Basis vieler Shop-Seiten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Product Grid gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Product Grid tastatur- und screenreader-freundlich gestalten.
+- Performance: Product Grid nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Product Grid direkt neben dem Code dokumentieren.
+
+## Fazit
+Product Grid bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-product-recently-viewed.md
+++ b/_posts/2025-09-30-frontend-product-recently-viewed.md
@@ -1,0 +1,67 @@
+---
+title: "Recently Viewed: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Recently Viewed unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-product-recently-viewed
+original_path: frontend/product/recently-viewed.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Recently Viewed** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Recently Viewed nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Zuletzt angesehene Produkte
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich eine Liste der zuletzt angesehenen Produkte sehen, um schnell zurückzukehren zu einem Artikel, den ich interessant fand.
+
+## Warum ist das so?  
+Fördert Wiederentdeckung, erhöht Engagement und erleichtert Navigation zwischen Produkten.
+
+## Anforderungen & Besonderheiten  
+- Session- oder Nutzer-basiert speichern  
+- Begrenzte Anzahl (z. B. 4–6 Items)  
+- Datenschutz: keine personenbezogenen Daten ohne Zustimmung  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** horizontale Scrollliste oder Carousel  
+- **Accessibility:** ARIA wandern, Fokussteuerung  
+- **SEO:** keine indexierten Links (nur interne Navigation)  
+- **Best Practices:**  
+ • Cache-basiert, nicht zu viele Anfragen  
+ • Fallback bei leeren Historien  
+ • Synchronisation über Geräte  
+
+## Checkliste  
+- [ ] Funktion aktiv  
+- [ ] Anzeige korrekt  
+- [ ] Updates bei neuen Ansichten  
+- [ ] Performance geprüft  
+
+## Akzeptanzkriterien  
+- Liste aktualisiert korrekt  
+- Klick auf Element führt zum Produkt  
+- Layout passt auf allen Geräten  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Sehr nützlich für UX, häufig erwartet.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Recently Viewed gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Recently Viewed tastatur- und screenreader-freundlich gestalten.
+- Performance: Recently Viewed nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Recently Viewed direkt neben dem Code dokumentieren.
+
+## Fazit
+Recently Viewed bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-product-reviews.md
+++ b/_posts/2025-09-30-frontend-product-reviews.md
@@ -1,0 +1,78 @@
+---
+title: "Reviews: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Reviews unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-product-reviews
+original_path: frontend/product/reviews.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Reviews** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Reviews nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Bewertungen & Rezensionen
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich sehen können, wie andere Kunden ein Produkt bewertet haben (Sterne, Text), um Vertrauen und eine informierte Kaufentscheidung zu treffen.
+
+## Warum ist das so?  
+Sozialer Beweis („Social Proof“) erhöht Glaubwürdigkeit. Kunden vertrauen oft Erfahrungen anderer. Außerdem verringert eine transparente Bewertungen-Komponente Retouren oder Frustrationen.
+
+## Anforderungen & Besonderheiten  
+- Aggregierte Sternewertung + einzelne Rezensionen  
+- Filter / Sortierung nach „neueste“, „hilfreichste“  
+- Möglichkeit, eigene Bewertung zu hinterlassen  
+- Moderation / Verifizierung (z. B. „echter Käufer“)  
+- Datenschutz: keine personenbezogenen Daten ohne Einwilligung  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Rezensionen in Accordion oder Tab-Ansicht auf kleinen Geräten  
+- **Accessibility:** Überschriftenstruktur, ARIA-Labels, Fokus beim Wechsel  
+- **SEO:** Strukturierte Daten (Schema.org `Review` / `AggregateRating`)  
+- **Best Practices:**  
+ • Lazy load für viele Bewertungen  
+ • Anzeige nur sinnvoller Ausschnitte + „mehr laden“  
+ • Verifizierte Käufe kennzeichnen  
+ • Stern-Icons skalierbar  
+
+## Checkliste  
+- [ ] Durchschnittsbewertung angezeigt  
+- [ ] Einzelne Rezensionen verfügbar  
+- [ ] Sortieren / Filtern möglich  
+- [ ] Nutzer können selbst bewerten  
+- [ ] Strukturierte Daten integriert  
+
+## Abhängigkeiten / Überschneidungen  
+- Produktdetailseite  
+- Nutzerkonto / Login  
+- Moderations-Backend / Admin  
+- API für Bewertungen  
+
+## Akzeptanzkriterien  
+- Bewertungsdaten korrekt aggregiert  
+- Neue Bewertung speicherbar  
+- Display funktioniert auf allen Geräten  
+- Rich Snippets korrekt ausgegeben  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Sehr relevant – Standards mittlerweile üblich. Besonders wichtig: Moderation & Qualität sichern.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Reviews gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Reviews tastatur- und screenreader-freundlich gestalten.
+- Performance: Reviews nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Reviews direkt neben dem Code dokumentieren.
+
+## Fazit
+Reviews bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-support-contact-form.md
+++ b/_posts/2025-09-30-frontend-support-contact-form.md
@@ -1,0 +1,72 @@
+---
+title: "Contact Form: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Contact Form unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-support-contact-form
+original_path: frontend/support/contact-form.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Contact Form** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Contact Form nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Kontaktformular / Kontaktseite
+
+## Kundenanforderung  
+Als Besucher:in möchte ich einfach Kontakt aufnehmen können (z. B. per E-Mail oder Formular), wenn ich Fragen habe.
+
+## Warum ist das so?  
+B2C-Kunden haben Fragen – und erwarten, dass Kontaktaufnahme möglich ist. Gute Erreichbarkeit stärkt Vertrauen.
+
+## Anforderungen & Besonderheiten  
+- Pflichtfelder & Validierung  
+- Spam-Schutz (Captcha, Honeypot)  
+- Datenschutz: Einwilligung zur Speicherung/Antwort  
+- Möglichkeit für mehrere Themen (z. B. Support, Rückgabe)  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Eingabefelder darauf optimiert  
+- **Accessibility:** Labels, Fehlermeldungen, ARIA  
+- **SEO:** keine Indexierung  
+- **Best Practices:**  
+ • Inline-Validierung  
+ • Erfolgs- und Fehlermeldung sichtbar  
+ • E-Mail-Versand im Backend  
+
+## Checkliste  
+- [ ] Feldvalidierung  
+- [ ] Spam-Schutz aktiv  
+- [ ] Eingabefehler & Hinweise  
+- [ ] Datenschutz-Hinweis  
+
+## Abhängigkeiten / Überschneidungen  
+- E-Mail / Backend-Service  
+- Nutzerkonto (optional)  
+
+## Akzeptanzkriterien  
+- Formular sendet korrekt  
+- Rückmeldung an Nutzer:in  
+- Fehlerhandling robust  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Standardfunktion in fast jedem Shop – oft unterschätzt in UX.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Contact Form gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Contact Form tastatur- und screenreader-freundlich gestalten.
+- Performance: Contact Form nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Contact Form direkt neben dem Code dokumentieren.
+
+## Fazit
+Contact Form bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-support-faq.md
+++ b/_posts/2025-09-30-frontend-support-faq.md
@@ -1,0 +1,73 @@
+---
+title: "Faq: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Faq unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-support-faq
+original_path: frontend/support/faq.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Faq** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Faq nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# FAQ (Häufige Fragen)
+
+## Kundenanforderung  
+Als Besucher:in der Seite möchte ich eine FAQ-Seite lesen können, um Antworten auf typische Fragen zu Produkten, Versand, Rückgabe etc. zu erhalten.
+
+## Warum ist das so?  
+FAQs reduzieren Supportbelastung, verbessern Self-Service und Vertrauen. Sie adressieren ständig wiederkehrende Fragen.
+
+## Anforderungen & Besonderheiten  
+- Logische Themenstruktur (z. B. Kategorien)  
+- Such- oder Filterfunktion auf FAQ  
+- Barrierefreiheit: Accordion- oder Tab-Ansicht, ARIA  
+- SEO: jede Frage ggf. als eigene URL oder Sprungziel  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** kompaktes Layout, eventuell Akkordeon  
+- **Accessibility:** ARIA, Fokussteuerung  
+- **SEO:** strukturierte Daten (FAQPage Schema)  
+- **Best Practices:**  
+ • Interne Verlinkung in Antworten  
+ • Paging / Lazy load bei vielen FAQs  
+ • Redakteur:innenfreundlich pflegbar  
+
+## Checkliste  
+- [ ] Alle relevanten Fragen abgedeckt  
+- [ ] Struktur & Kategorien  
+- [ ] ARIA korrekt implementiert  
+- [ ] Schema.org FAQ integriert  
+
+## Abhängigkeiten / Überschneidungen  
+- Support / Helpdesk  
+- Suchfunktion  
+- CMS  
+
+## Akzeptanzkriterien  
+- FAQ-Seite funktioniert vollständig  
+- Antworten erreichbar & korrekt  
+- SEO-Daten vorhanden  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Hoch – nahezu Standard. Besonders wichtig bei erklärungsbedürftigen Produkten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Faq gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Faq tastatur- und screenreader-freundlich gestalten.
+- Performance: Faq nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Faq direkt neben dem Code dokumentieren.
+
+## Fazit
+Faq bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-support-live-chat.md
+++ b/_posts/2025-09-30-frontend-support-live-chat.md
@@ -1,0 +1,73 @@
+---
+title: "Live Chat: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Live Chat unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-support-live-chat
+original_path: frontend/support/live-chat.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Live Chat** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Live Chat nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Live-Chat / Chat-Widget
+
+## Kundenanforderung  
+Als Kunde:in möchte ich direkt via Chat Kontakt aufnehmen oder Fragen klären, um schnell Hilfe zu erhalten.
+
+## Warum ist das so?  
+Ein Live-Chat reduziert Wartezeiten, steigert Kundenzufriedenheit und kann Conversion-Barrieren senken.
+
+## Anforderungen & Besonderheiten  
+- Plattformwahl (eigener Chat, Drittanbieter)  
+- Chat-Verfügbarkeit (Arbeitszeiten, Offline-Status)  
+- Datenschutz: Chat-Logs, Zustimmung zur Speicherung  
+- Möglichkeit zur Übergabe an E-Mail oder Ticket-System  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Chat-Widget unten rechts / Icon mit Ausklapp  
+- **Accessibility:** Tastaturzugänglich, Fokussteuerung, ARIA  
+- **SEO:** Chat-Skripte asynchron laden  
+- **Best Practices:**  
+ • Verzögerter Chat-Aufruf (nicht direkt bei Seitenstart)  
+ • Erkennbarer Offline-Status  
+ • Chatverläufe synchronisieren  
+
+## Checkliste  
+- [ ] Chat erreichbar auf allen Seiten  
+- [ ] Offline-Fallback implementiert  
+- [ ] Datenschutz & Zustimmung berücksichtigt  
+- [ ] Widget responsive & performant  
+
+## Abhängigkeiten / Überschneidungen  
+- Backend für Chat / Messaging  
+- Nutzerkonto (optional)  
+- Support-Systeme / CRM  
+
+## Akzeptanzkriterien  
+- Chat startet / öffnet zuverlässig  
+- Bedienung per Klick & Tastatur möglich  
+- Protokollierung & Übergabe funktioniert  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Wichtig in vielen Shops mit hohem Kundenservicebedarf; aber in kleinen Shops optional.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Live Chat gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Live Chat tastatur- und screenreader-freundlich gestalten.
+- Performance: Live Chat nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Live Chat direkt neben dem Code dokumentieren.
+
+## Fazit
+Live Chat bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-user-guest-checkout.md
+++ b/_posts/2025-09-30-frontend-user-guest-checkout.md
@@ -1,0 +1,72 @@
+---
+title: "Guest Checkout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Guest Checkout unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-user-guest-checkout
+original_path: frontend/user/guest-checkout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Guest Checkout** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Guest Checkout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Gast-Checkout
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich auch ohne Registrierung Bestellungen tätigen können, um Friktion zu vermeiden und den Kaufprozess zu beschleunigen.
+
+## Warum ist das so?  
+Viele Kunden wollen nicht erst ein Konto anlegen. Gast-Checkout reduziert Abbrüche insbesondere im Kaufprozess.
+
+## Anforderungen & Besonderheiten  
+- Speicherung der Versand-/Rechnungsadresse temporär  
+- Möglichkeit später Konto anzulegen / Informationen übertragen  
+- Datenschutz: Daten nur so lange wie nötig speichern  
+- Grenzen: kein komplettes Nutzerprofil möglich  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Checkout als einspaltiger Fluss  
+- **Accessibility:** Formularfelder klar beschriftet  
+- **SEO:** Checkout-Seiten nicht indexieren  
+- **Best Practices:**  
+ • Option „Konto anlegen aus Gastdaten“ anbieten  
+ • Warnung / Hinweis zur Registrierung  
+
+## Checkliste  
+- [ ] Gastbestellung möglich  
+- [ ] Adresseingabe & Validierung  
+- [ ] Optional Registrierung nachträglich  
+- [ ] Session sauber beendet  
+
+## Abhängigkeiten / Überschneidungen  
+- Checkout-Modul  
+- Nutzerkonto-System  
+- E-Mail-Service  
+
+## Akzeptanzkriterien  
+- Bestellung funktioniert als Gast  
+- Daten korrekt übergeben  
+- Möglichkeit zur späteren Registrierung  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Sehr relevant – besonders für Erstkäufer oder unentschlossene Nutzer.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Guest Checkout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Guest Checkout tastatur- und screenreader-freundlich gestalten.
+- Performance: Guest Checkout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Guest Checkout direkt neben dem Code dokumentieren.
+
+## Fazit
+Guest Checkout bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-user-login-registration.md
+++ b/_posts/2025-09-30-frontend-user-login-registration.md
@@ -1,0 +1,74 @@
+---
+title: "Login Registration: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Login Registration unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-user-login-registration
+original_path: frontend/user/login-registration.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Login Registration** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Login Registration nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Login / Registrierung
+
+## Kundenanforderung  
+Als Nutzer:in möchte ich mich registrieren oder einloggen können, damit ich Bestellungen durchführen, Wunschlisten nutzen oder meinen Account verwalten kann.
+
+## Warum ist das so?  
+Identifikation ermöglicht Personalisierung, Kundenbindung, Verlaufsspeicherung und schnelleren Checkout.
+
+## Anforderungen & Besonderheiten  
+- E-Mail-Verifizierung  
+- Passwort-Reset / Sicherheitsregeln  
+- Option für Social Login (OAuth, Google, Facebook etc.)  
+- Datenschutz: keine ungewollte Profilverknüpfung ohne Zustimmung  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Eingabeformulare für kleine Bildschirme optimieren  
+- **Accessibility:** Labels, ARIA, Fehlermeldungen klar und fokussierbar  
+- **SEO:** Login-/Registrierungsseiten nicht indexieren  
+- **Best Practices:**  
+ • Validierung client + serverseitig  
+ • Captcha / Bot-Schutz  
+ • Session Handling sicher & langlebig  
+
+## Checkliste  
+- [ ] Registrierung möglich  
+- [ ] Login mit E-Mail & Passwort  
+- [ ] Social Login optional  
+- [ ] E-Mail-Verifizierung  
+- [ ] Reset-Funktion  
+
+## Abhängigkeiten / Überschneidungen  
+- Nutzer- / Auth-System  
+- Session / Token-System  
+- E-Mail-Service  
+
+## Akzeptanzkriterien  
+- Registrierung & Login funktionieren  
+- Sicherheitsstandards erfüllt  
+- Mobile & Desktop getestet  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐⭐  
+Grundfunktion in nahezu jedem Shop – Sicherheit, UX & Datenschutz sind mittlerweile streng.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Login Registration gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Login Registration tastatur- und screenreader-freundlich gestalten.
+- Performance: Login Registration nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Login Registration direkt neben dem Code dokumentieren.
+
+## Fazit
+Login Registration bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-frontend-user-wishlist.md
+++ b/_posts/2025-09-30-frontend-user-wishlist.md
@@ -1,0 +1,73 @@
+---
+title: "Wishlist: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Wishlist unsere Frontend-Notizen inspiriert."
+layout: post
+categories: [frontend]
+slug: frontend-user-wishlist
+original_path: frontend/user/wishlist.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Wishlist** passte heute perfekt in unsere Frontend-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Wishlist nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Wunschliste / Merkliste
+
+## Kundenanforderung  
+Als registrierte:r Nutzer:in möchte ich Produkte auf eine Wunschliste setzen, um sie später zu überblicken oder zu teilen.
+
+## Warum ist das so?  
+Nutzer nutzen Wishlist zur Planung, zum Vergleich, zur Erinnerung – und oftmals wird später daraus ein Kauf. Es erhöht Engagement.
+
+## Anforderungen & Besonderheiten  
+- Bestände mitberücksichtigen  
+- Nutzerbindung & Synchronisation (z. B. zwischen Geräten)  
+- Teilen-Funktionen (optional)  
+- Datenschutz bei Teil-Links  
+
+## Umsetzung – Technische Leitplanken  
+- **Mobile First:** Button „Zur Wunschliste“ prominent erreichbar  
+- **Accessibility:** ARIA-Labels, Zustände (aktiv/inaktiv)  
+- **SEO:** Kein indexierter Link (Wunschlistenseiten privat)  
+- **Best Practices:**  
+ • Real-time Feedback („hinzugefügt“)  
+ • Synchronisation mit Nutzerkonto  
+ • Fallback für Gäste (Session-basiert)  
+
+## Checkliste  
+- [ ] Produkte zur Wunschliste hinzufügen / entfernen  
+- [ ] Wunschliste persistiert zwischen Sitzungen  
+- [ ] Synchronisation über Geräte  
+- [ ] Teilen-Option (falls geplant)  
+
+## Abhängigkeiten / Überschneidungen  
+- Nutzerkonto / Auth  
+- Produktdaten / API  
+- Session / Cache  
+
+## Akzeptanzkriterien  
+- Wunschliste editierbar  
+- Sichtbarkeit & Status korrekt  
+- Performance unter hoher Last  
+
+---
+
+## Bewertung der Relevanz 2025  
+⭐⭐⭐⭐☆  
+Mittel bis hoch – in vielen Shops bereits erwartet. Für kleinere Shops optional.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Wishlist gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Wishlist tastatur- und screenreader-freundlich gestalten.
+- Performance: Wishlist nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Wishlist direkt neben dem Code dokumentieren.
+
+## Fazit
+Wishlist bleibt ein schönes Beispiel dafür, wie Frontend-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-deprecated-fixed-footer.md
+++ b/_posts/2025-09-30-layouts-deprecated-fixed-footer.md
@@ -1,0 +1,78 @@
+---
+title: "Fixed Footer: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Fixed Footer unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-deprecated-fixed-footer
+original_path: layouts/deprecated/fixed-footer.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Fixed Footer** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Fixed Footer nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Fixed Footer
+
+## Beschreibung
+Ein dauerhaft fixierter Footer verdeckt auf mobilen Geräten häufig Inhalte oder Steuerungen und wird daher nicht mehr empfohlen.
+
+## Warum dieses Layout?
+- Kann für spezielle App-Bars genutzt werden.
+- Bietet permanente Sichtbarkeit für Aktionen.
+- Verhindert sichtbaren Content und verursacht Bedienprobleme.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Nur in Ausnahmen aktivieren, ausreichend Abstand zum Content einplanen.
+- **Accessibility:** Fokus und Screenreader dürfen nicht blockiert werden, Inhalte müssen erreichbar bleiben.
+- **SEO:** Kein direkter Mehrwert, eher Risiko für schlechte UX.
+- **Design-Guidelines:** Wenn unvermeidlich, transparente Hintergründe und ausreichende Höhen nutzen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Fixed Footer deaktivieren und stattdessen Sticky- oder Inline-Alternativen wählen.
+- **Accessibility:** Skip-Link oder Close-Button bereitstellen, wenn Footer unvermeidlich.
+- **SEO:** Keine übermäßigen Links im Footer platzieren.
+- **Best Practices:** Nur kontextuell einsetzen, Touch-Ziele groß halten, CLS vermeiden
+
+## Checkliste
+- [ ] Footer kann bei Bedarf ausgeblendet werden.
+- [ ] Inhalte bleiben vollständig sichtbar.
+- [ ] Tastaturfokus nicht blockiert.
+- [ ] A11y- und Performance-Check dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Legacy-App-Bars
+- CTA-Module
+
+## Akzeptanzkriterien
+- Alternatives Pattern liegt vor.
+- Screenreader können Inhalte hinter dem Footer erreichen.
+- Stakeholder stimmen dem Rückbau zu.
+
+## Beispiel / Code
+```html
+<footer class="fixed bottom-0 inset-x-0">
+  <nav>…</nav>
+</footer>
+```
+
+> ⚠️ Deprecated: Nicht mehr empfohlen für Mobile-First-Designs (nur zu Dokumentationszwecken).
+
+Bewertung der Relevanz 2025
+
+⭐⭐☆☆☆ Nur für Spezialfälle mit großer Vorsicht nutzen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Fixed Footer gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Fixed Footer tastatur- und screenreader-freundlich gestalten.
+- Performance: Fixed Footer nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Fixed Footer direkt neben dem Code dokumentieren.
+
+## Fazit
+Fixed Footer bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-deprecated-horizontal-scrolling.md
+++ b/_posts/2025-09-30-layouts-deprecated-horizontal-scrolling.md
@@ -1,0 +1,78 @@
+---
+title: "Horizontal Scrolling: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Horizontal Scrolling unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-deprecated-horizontal-scrolling
+original_path: layouts/deprecated/horizontal-scrolling.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Horizontal Scrolling** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Horizontal Scrolling nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Horizontal Scrolling Layout
+
+## Beschreibung
+Ein Layout mit horizontalem Scrollen als primäre Navigationsachse wirkt unnatürlich und ist auf mobilen Geräten schwer steuerbar.
+
+## Warum dieses Layout?
+- Kann besondere Storytelling-Experiences liefern.
+- Setzt visuelle Highlights in Szene.
+- Verursacht UX-Probleme bei Scroll-Gesten und Orientierung.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Klare Scroll-Hinweise, horizontale Scrollbereiche mit Touch-Unterstützung.
+- **Accessibility:** Alternativen für Tastatur und Screenreader bereitstellen, wheel-Events bedacht einsetzen.
+- **SEO:** Wichtige Inhalte auch vertikal zugänglich machen.
+- **Design-Guidelines:** Deutliche Pfeile, Pagination oder Snap-Punkte, um Orientierung zu sichern.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Standard-Layouts bevorzugen und horizontale Scrollstrecken nur optional einbinden.
+- **Accessibility:** Scroll-Mapping auf Trackpad/Wheel nur vorsichtig nutzen.
+- **SEO:** Vertikale Alternativansicht oder Jump-Links bereitstellen.
+- **Best Practices:** Scroll-Hints anzeigen, Snapping optional, Fallback auf vertikale Liste
+
+## Checkliste
+- [ ] Scroll-Hinweise sind sichtbar.
+- [ ] Tastaturbedienung möglich.
+- [ ] Vertikale Alternative vorhanden.
+- [ ] A11y- und Performance-Check dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Scroll- und Animation-Utilities
+- Fallback-Layouts
+
+## Akzeptanzkriterien
+- Nutzer verstehen Interaktion ohne Tutorial.
+- Screenreader erhalten linearen Alternativzugang.
+- Stakeholder akzeptieren Einsatz nur in Spezialfällen.
+
+## Beispiel / Code
+```html
+<section class="horizontal-scroll" aria-label="Galerie">
+  <div class="scroll-track">…</div>
+</section>
+```
+
+> ⚠️ Deprecated: Nicht mehr empfohlen für Mobile-First-Designs (nur zu Dokumentationszwecken).
+
+Bewertung der Relevanz 2025
+
+⭐⭐☆☆☆ Nur für spezielle Storytelling-Experimente erhalten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Horizontal Scrolling gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Horizontal Scrolling tastatur- und screenreader-freundlich gestalten.
+- Performance: Horizontal Scrolling nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Horizontal Scrolling direkt neben dem Code dokumentieren.
+
+## Fazit
+Horizontal Scrolling bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-deprecated-nested-columns.md
+++ b/_posts/2025-09-30-layouts-deprecated-nested-columns.md
@@ -1,0 +1,80 @@
+---
+title: "Nested Columns: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Nested Columns unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-deprecated-nested-columns
+original_path: layouts/deprecated/nested-columns.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Nested Columns** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Nested Columns nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Nested Columns
+
+## Beschreibung
+Mehrfach verschachtelte Spalten erzeugen komplexe Strukturen, die schwer zu pflegen und zu optimieren sind.
+
+## Warum dieses Layout?
+- Ermöglicht theoretisch sehr flexible Layouts.
+- Kann alte Enterprise-Portale widerspiegeln.
+- Führt zu hoher Komplexität, Wartungsaufwand und Performance-Problemen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Verschachtelung auflösen und durch flachere Grids ersetzen.
+- **Accessibility:** Lesereihenfolge testen, da verschachtelte Container häufig für Verwirrung sorgen.
+- **SEO:** Semantische Struktur leidet, daher Content möglichst flach halten.
+- **Design-Guidelines:** Grid Areas statt mehrfacher nested Columns bevorzugen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Auf flache Layouts migrieren und Nested Columns nur dokumentieren.
+- **Accessibility:** Struktur mit Überschriften und Landmarken stabilisieren.
+- **SEO:** Hauptinhalt im DOM priorisieren.
+- **Best Practices:** Migration zu modernen Layouts planen, Komplexität reduzieren, Performance messen
+
+## Checkliste
+- [ ] Verschachtelungstiefe dokumentiert.
+- [ ] Fallback-Layout vorhanden.
+- [ ] Performanceprofil erhoben.
+- [ ] A11y-Review durchgeführt.
+
+## Abhängigkeiten / Überschneidungen
+- Legacy-Grid-System
+- Refactoring-Roadmap
+
+## Akzeptanzkriterien
+- Migration zu flacheren Strukturen geplant.
+- Screenreader können Inhalte ohne Verlust wiedergeben.
+- Keine neuen Features mehr auf Nested Columns aufbauen.
+
+## Beispiel / Code
+```html
+<div class="grid grid-cols-12 gap-4">
+  <div class="col-span-8">
+    <div class="grid grid-cols-6 gap-2">…</div>
+  </div>
+</div>
+```
+
+> ⚠️ Deprecated: Nicht mehr empfohlen für Mobile-First-Designs (nur zu Dokumentationszwecken).
+
+Bewertung der Relevanz 2025
+
+⭐⭐☆☆☆ Nur zu Dokumentationszwecken für Legacy-Layouts.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Nested Columns gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Nested Columns tastatur- und screenreader-freundlich gestalten.
+- Performance: Nested Columns nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Nested Columns direkt neben dem Code dokumentieren.
+
+## Fazit
+Nested Columns bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-deprecated-sidebar-navigation.md
+++ b/_posts/2025-09-30-layouts-deprecated-sidebar-navigation.md
@@ -1,0 +1,82 @@
+---
+title: "Sidebar Navigation: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Sidebar Navigation unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-deprecated-sidebar-navigation
+original_path: layouts/deprecated/sidebar-navigation.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Sidebar Navigation** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Sidebar Navigation nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Sidebar Navigation
+
+## Beschreibung
+Eine permanent sichtbare Sidebar-Navigation stammt aus Desktop-Zeiten und wird heute häufig von responsiven Drawern ersetzt.
+
+## Warum dieses Layout?
+- Bietet konstant sichtbare Navigationspunkte.
+- Eignet sich für sehr breite Desktop-Layouts.
+- Verbraucht mobil wertvollen Platz und wirkt veraltet.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Mobile Alternativen wie Off-Canvas oder Overlay bereitstellen.
+- **Accessibility:** Navigation als <nav> kennzeichnen, Fokusmanagement für Drawer-Alternative.
+- **SEO:** Links bleiben im DOM, Priorisierung auf Hauptinhalte achten.
+- **Design-Guidelines:** Sichtbare aktive Zustände, klare Gruppierung von Links.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Primär einen Drawer oder Overlay planen und Sidebar nur als Desktop-Variante pflegen.
+- **Accessibility:** Tastaturbedienung sicherstellen, Skip-Link ergänzen.
+- **SEO:** Duplicate Navigation vermeiden.
+- **Best Practices:** Mobil Off-Canvas nutzen, Aktive Pfade markieren, Navigation vereinfachen
+
+## Checkliste
+- [ ] Off-Canvas-Alternative vorhanden.
+- [ ] Fokusmanagement geprüft.
+- [ ] Sidebar überdeckt keinen Content.
+- [ ] A11y- und Performance-Check dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Drawer-/Overlay-Komponente
+- Legacy-Navigationsstruktur
+
+## Akzeptanzkriterien
+- Mobil wird Sidebar ersetzt oder deaktiviert.
+- Screenreader erreichen Navigation ohne Umwege.
+- Stakeholder planen Migration zu moderneren Patterns.
+
+## Beispiel / Code
+```html
+<aside class="sidebar-nav">
+  <nav>
+    <ul>
+      <li><a href="#">Link</a></li>
+    </ul>
+  </nav>
+</aside>
+```
+
+> ⚠️ Deprecated: Nicht mehr empfohlen für Mobile-First-Designs (nur zu Dokumentationszwecken).
+
+Bewertung der Relevanz 2025
+
+⭐⭐☆☆☆ Nur für Legacy-Interfaces dokumentiert.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Sidebar Navigation gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Sidebar Navigation tastatur- und screenreader-freundlich gestalten.
+- Performance: Sidebar Navigation nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Sidebar Navigation direkt neben dem Code dokumentieren.
+
+## Fazit
+Sidebar Navigation bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-deprecated-split-header.md
+++ b/_posts/2025-09-30-layouts-deprecated-split-header.md
@@ -1,0 +1,79 @@
+---
+title: "Split Header: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Split Header unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-deprecated-split-header
+original_path: layouts/deprecated/split-header.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Split Header** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Split Header nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Split Header
+
+## Beschreibung
+Ein geteiltes Header-Layout mit gegensätzlichen Ausrichtungen bricht auf kleinen Screens leicht und erschwert mobile Navigation.
+
+## Warum dieses Layout?
+- Kann komplexe Markenbotschaften transportieren.
+- Erlaubt simultane Darstellung von Navigation und Aktionen.
+- Skaliert auf mobilen Geräten schlecht und erhöht Implementierungsaufwand.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Header sollte auf mobile Breakpoints vereinfacht werden.
+- **Accessibility:** Fokusreihenfolge sicherstellen, da Elemente weit auseinander liegen.
+- **SEO:** Kein direkter Vorteil, Risiko von unklaren Hierarchien.
+- **Design-Guidelines:** Branding und Aktionen priorisieren, redundante Inhalte streichen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Auf einfachere Header-Varianten umstellen und Split-Design nur dokumentieren.
+- **Accessibility:** Skip-Link und klare Landmarken bieten.
+- **SEO:** Wichtige Links logisch gruppieren.
+- **Best Practices:** Frühe Reduktion auf einspaltige Navigation, Aktionen priorisieren, Übergangsanimationen vermeiden
+
+## Checkliste
+- [ ] Fallback-Header vorhanden.
+- [ ] Navigation funktioniert auf Touch-Geräten.
+- [ ] Fokus-Indikatoren sichtbar.
+- [ ] A11y- und Performance-Prüfung dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Legacy-Header-Komponenten
+- Branding-Richtlinien
+
+## Akzeptanzkriterien
+- Mobile Ersatzlayout implementiert.
+- Screenreader navigieren Header ohne Verwirrung.
+- Stakeholder planen Umstellung auf modernes Pattern.
+
+## Beispiel / Code
+```html
+<header class="split-header">
+  <div class="left">Logo</div>
+  <div class="right">Aktionen</div>
+</header>
+```
+
+> ⚠️ Deprecated: Nicht mehr empfohlen für Mobile-First-Designs (nur zu Dokumentationszwecken).
+
+Bewertung der Relevanz 2025
+
+⭐⭐☆☆☆ Nur noch aus historischen Gründen vermerkt.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Split Header gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Split Header tastatur- und screenreader-freundlich gestalten.
+- Performance: Split Header nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Split Header direkt neben dem Code dokumentieren.
+
+## Fazit
+Split Header bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-deprecated-three-columns.md
+++ b/_posts/2025-09-30-layouts-deprecated-three-columns.md
@@ -1,0 +1,80 @@
+---
+title: "Three Columns: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Three Columns unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-deprecated-three-columns
+original_path: layouts/deprecated/three-columns.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Three Columns** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Three Columns nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Three Columns
+
+## Beschreibung
+Drei gleichbreite Spalten waren früher verbreitet, wirken heute aber überladen und sind mobil schwer nutzbar.
+
+## Warum dieses Layout?
+- Bietet viel Platz für Navigation, Inhalt und Zusatzmodule.
+- Kann historische Portale abbilden.
+- Auf mobilen Geräten entsteht häufig Scroll- und Priorisierungschaos.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Spalten müssen auf mobilen Geräten komplett gestapelt werden.
+- **Accessibility:** Inhaltliche Priorisierung klar kommunizieren, Reihenfolge logisch halten.
+- **SEO:** Wichtige Inhalte im DOM nach vorn ziehen, damit sie nicht von Sidebars verdrängt werden.
+- **Design-Guidelines:** Große Weißräume zur Entzerrung nutzen, klare Typo-Hierarchie.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Lieber ein- bis zweispaltige Alternativen wählen und Sidebars als Off-Canvas abbilden.
+- **Accessibility:** DOM-Struktur nicht für rein visuelle Zwecke verbiegen.
+- **SEO:** Hauptinhalt deutlich kennzeichnen.
+- **Best Practices:** Spalten priorisieren, Off-Canvas prüfen, Reduzierte Inhalte bereitstellen
+
+## Checkliste
+- [ ] Keine horizontale Scrollbar entsteht.
+- [ ] Reihenfolge der Spalten logisch.
+- [ ] Sidebars enthalten nur unbedingt nötige Inhalte.
+- [ ] A11y- und Performance-Check dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Historische Portallayouts
+- Legacy-Navigationsmodule
+
+## Akzeptanzkriterien
+- Mobile Stack funktioniert ohne Layoutbruch.
+- Screenreader erkennen Hauptinhalt zuerst.
+- Stakeholder akzeptieren Ersatz- oder Migrationsplan.
+
+## Beispiel / Code
+```html
+<section class="grid md:grid-cols-3 gap-4">
+  <div>Spalte 1</div>
+  <div>Spalte 2</div>
+  <div>Spalte 3</div>
+</section>
+```
+
+> ⚠️ Deprecated: Nicht mehr empfohlen für Mobile-First-Designs (nur zu Dokumentationszwecken).
+
+Bewertung der Relevanz 2025
+
+⭐⭐☆☆☆ Nur noch zur Pflege historischer Portale dokumentiert.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Three Columns gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Three Columns tastatur- und screenreader-freundlich gestalten.
+- Performance: Three Columns nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Three Columns direkt neben dem Code dokumentieren.
+
+## Fazit
+Three Columns bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-accordion-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-accordion-layout.md
@@ -1,0 +1,77 @@
+---
+title: "Accordion Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Accordion Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-accordion-layout
+original_path: layouts/relevant/accordion-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Accordion Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Accordion Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Accordion Layout
+
+## Beschreibung
+Ausklappbare Bereiche bündeln FAQs, Detailinfos oder Spezifikationen und halten Seiten kompakt.
+
+## Warum dieses Layout?
+- Hilft bei der Strukturierung langer Informationslisten.
+- Reduziert kognitive Last durch progressive Offenlegung.
+- Kann wichtige Inhalte vor Nutzern und Suchmaschinen verbergen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Accordion-Elemente passen sich in Breite und Typografie an.
+- **Accessibility:** WAI-ARIA Disclosure Pattern mit button, aria-expanded und aria-controls nutzen.
+- **SEO:** Wesentliche Inhalte sollten im initial geöffneten Zustand verfügbar sein.
+- **Design-Guidelines:** Klare Trennlinien, ausreichend Padding und deutliche Icons für Zustände.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Accordion ist Standard, Desktop kann parallele Spalten ergänzen.
+- **Accessibility:** Focus-Stati und Tastatursteuerung (Enter/Space) berücksichtigen.
+- **SEO:** Accordion-Inhalte im DOM belassen und nicht per JS nachladen.
+- **Best Practices:** Weiche Animationen einsetzen, Nur ein Panel optional offen halten, Status programmatisch speichern
+
+## Checkliste
+- [ ] Accordion lässt sich mit Tastatur komplett bedienen.
+- [ ] Icons und Labels kommunizieren den Zustand klar.
+- [ ] Wichtige Inhalte sind initial sichtbar oder angekündigt.
+- [ ] A11y- und Performance-Audit abgeschlossen.
+
+## Abhängigkeiten / Überschneidungen
+- Disclosure-Komponente
+- Content-Module
+
+## Akzeptanzkriterien
+- ARIA-Attribute entsprechen dem Disclosure-Pattern.
+- Panels lassen sich ohne Layoutsprünge öffnen und schließen.
+- Screenreader geben Statusänderungen korrekt wieder.
+
+## Beispiel / Code
+```html
+<section class="accordion">
+  <button aria-expanded="false" aria-controls="faq-1">Frage</button>
+  <div id="faq-1" hidden>Antwort…</div>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Standardmuster für FAQs und Detailinformationen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Accordion Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Accordion Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Accordion Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Accordion Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Accordion Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-asymmetric-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-asymmetric-layout.md
@@ -1,0 +1,78 @@
+---
+title: "Asymmetric Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Asymmetric Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-asymmetric-layout
+original_path: layouts/relevant/asymmetric-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Asymmetric Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Asymmetric Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Asymmetric Layout
+
+## Beschreibung
+Eine asymmetrische Grid-Struktur kombiniert große und kleine Kacheln für dynamische Seitenaufteilung. Perfekt für Editorials, Portfolio-Highlights oder Kampagnen.
+
+## Warum dieses Layout?
+- Erzeugt visuelle Spannung und lenkt Fokus gezielt.
+- Erlaubt flexible Kombination verschiedener Content-Typen.
+- Erfordert sorgfältige A11y-Prüfung der Lesereihenfolge.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Grid Areas reorganisieren sich auf mobilen Geräten zu logischer Reihenfolge.
+- **Accessibility:** DOM-Reihenfolge bleibt konsistent, aria-labelledby für große Hero-Kacheln.
+- **SEO:** Wichtige Inhalte in prominenten Bereichen semantisch hervorheben.
+- **Design-Guidelines:** Konsistente Spacing-Scale, Bildzuschnitt und Farbkontraste.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet als lineare Liste und erweitert sich zu komplexen Grids.
+- **Accessibility:** Alternative Reihenfolge über CSS Grid Areas ohne DOM-Manipulation.
+- **SEO:** Sektionen mit passenden Überschriften strukturieren.
+- **Best Practices:** Grid Areas definieren, Bildfokuspunkte beachten, Hover/Fokus-Effekte synchronisieren
+
+## Checkliste
+- [ ] Lesereihenfolge bleibt nachvollziehbar.
+- [ ] Kacheln skalieren ohne Bildverzerrung.
+- [ ] Hover/Fokus-Zustände klar sichtbar.
+- [ ] Performance- und A11y-Prüfung erfolgt.
+
+## Abhängigkeiten / Überschneidungen
+- Grid-System
+- Medien- und Text-Module
+
+## Akzeptanzkriterien
+- Layout reorganisiert sich ohne Inhaltssprünge.
+- Screenreader geben Reihenfolge logisch aus.
+- Visuelle Hierarchie unterstützt Content-Ziele.
+
+## Beispiel / Code
+```html
+<section class="grid md:grid-cols-3 gap-6">
+  <article class="md:col-span-2">Highlight</article>
+  <article>Teaser</article>
+  <article>Teaser</article>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Setzt Kampagnen und Stories aufmerksamkeitsstark in Szene.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Asymmetric Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Asymmetric Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Asymmetric Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Asymmetric Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Asymmetric Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-blog-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-blog-layout.md
@@ -1,0 +1,79 @@
+---
+title: "Blog Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Blog Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-blog-layout
+original_path: layouts/relevant/blog-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Blog Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Blog Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Blog Layout
+
+## Beschreibung
+Dieses Layout kombiniert Listenansicht und Detailseite für Blogartikel. Es unterstützt Content-Marketing, Knowledge-Sharing und redaktionelle Veröffentlichungen.
+
+## Warum dieses Layout?
+- Optimiert für längere Texte mit klarer Leseführung.
+- Ermöglicht flexible Kombination aus Karten, Prosa und Inhaltsverzeichnissen.
+- Braucht sorgfältige Inhaltsplanung, um TL;DR-Effekte zu vermeiden.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Einspaltige Lesespalte mit optionalen Karten für Teaser und verwandte Artikel.
+- **Accessibility:** Prose-Stile mit ausreichend Zeilenabstand und semantische Überschriften.
+- **SEO:** Schema.org Article, OG-/Twitter-Tags und sprechende URLs.
+- **Design-Guidelines:** Lesefreundliche Typografie, klare Trennung von Metadaten und Inhalt.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Reduziert Nebenelemente und fokussiert auf den Artikelinhalt.
+- **Accessibility:** Inhaltsverzeichnis als Navigationshilfe implementieren.
+- **SEO:** Meta-Daten, strukturierte Daten und interne Verlinkung pflegen.
+- **Best Practices:** Bildlazyloading, Lesefortschrittsanzeige optional, Semantische <article>-Elemente nutzen
+
+## Checkliste
+- [ ] Inhaltsverzeichnis verlinkt korrekt zu Abschnitten.
+- [ ] Bilder besitzen Alt-Texte und Bildunterschriften.
+- [ ] Lesefluss bleibt auch auf mobilen Geräten erhalten.
+- [ ] SEO- und Accessibility-Prüfung bestanden.
+
+## Abhängigkeiten / Überschneidungen
+- Card- und Prosa-Komponenten
+- Markdown/Content-Pipeline
+
+## Akzeptanzkriterien
+- Artikel lädt performant trotz langer Inhalte.
+- Screenreader navigieren problemlos durch Überschriften.
+- Verwandte Artikel werden semantisch korrekt ausgezeichnet.
+
+## Beispiel / Code
+```html
+<main class="prose max-w-3xl mx-auto">
+  <article>
+    <h1>Titel</h1>
+    <p>…</p>
+  </article>
+</main>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Standard für Content-Marketing und Wissensvermittlung.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Blog Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Blog Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Blog Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Blog Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Blog Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-card-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-card-layout.md
@@ -1,0 +1,78 @@
+---
+title: "Card Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Card Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-card-layout
+original_path: layouts/relevant/card-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Card Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Card Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Card Layout
+
+## Beschreibung
+Karten bündeln Bild, Titel, Teasertext und CTA in wiederverwendbaren Modulen. Sie eignen sich für Artikelübersichten, Feature-Highlights oder Produktteaser.
+
+## Warum dieses Layout?
+- Skaliert modular über verschiedene Content-Typen.
+- Unterstützt klare Scanbarkeit durch visuelle Blöcke.
+- Kann bei zu vielen Karten überladen wirken.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Karten passen sich in Grid- oder Flexstrukturen an und behalten konsistente Höhen.
+- **Accessibility:** Fokusrahmen sichtbar, Klickflächen ausreichend groß und Alternativtexte gepflegt.
+- **SEO:** Primärer CTA als Link, sprechende Überschriften und strukturierte Daten optional.
+- **Design-Guidelines:** Einheitliche Bildverhältnisse, konsistente Typografie und Abstände.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Beginnt einspaltig und erweitert sich auf mehrere Spalten.
+- **Accessibility:** Arbeitet mit aria-labels oder Überschriftenelementen für Kartentitel.
+- **SEO:** Linkstruktur so anlegen, dass Karten direkt indexiert werden.
+- **Best Practices:** Lazy Loading für Bilder, Hover- und Fokus-States angleichen, Karteninhalte klar priorisieren
+
+## Checkliste
+- [ ] Tab-Reihenfolge der Karten ist logisch.
+- [ ] Teasertexte bleiben kurz und prägnant.
+- [ ] Bilder besitzen Alternativtexte.
+- [ ] Performance- und Accessibility-Metriken dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Card-Komponentenbibliothek
+- Bild-CDN oder Asset-Pipeline
+
+## Akzeptanzkriterien
+- Kartenhöhen skalieren ohne Layoutsprünge.
+- CTA ist sowohl per Maus als auch Tastatur bedienbar.
+- Lazy Loading reduziert initiale Ladezeit spürbar.
+
+## Beispiel / Code
+```html
+<article class="card">
+  <img src="../../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" />
+  <h3>…</h3>
+  <p>…</p>
+</article>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Universeller Baustein für vielfältige Content-Module.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Card Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Card Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Card Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Card Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Card Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-centered-content.md
+++ b/_posts/2025-09-30-layouts-relevant-centered-content.md
@@ -1,0 +1,74 @@
+---
+title: "Centered Content: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Centered Content unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-centered-content
+original_path: layouts/relevant/centered-content.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Centered Content** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Centered Content nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Centered Content
+
+## Beschreibung
+Der Inhalt wird auf eine begrenzte Breite zentriert, um den Fokus auf Texte oder Formulare zu lenken. Besonders nützlich für Storytelling-Seiten, Knowledge-Base-Einträge oder Conversion-Formulare.
+
+## Warum dieses Layout?
+- Steigert Lesbarkeit und Konzentration auf den Kerninhalt.
+- Funktioniert hervorragend mit langen Texten oder wichtigen Interaktionen.
+- Bietet wenig Raum für flankierende Elemente wie Werbung oder Toolbars.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Max-width im Bereich 68–76ch, adaptive Ränder und Padding.
+- **Accessibility:** Ausreichender Zeilenabstand, klare Linkzustände und großzügige Schriftgrößen.
+- **SEO:** Semantische Struktur mit klarer Priorisierung von Überschriften und Abschnitten.
+- **Design-Guidelines:** Konsistentes Spacing, ruhige Farbpalette und typografische Hierarchie.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet vollbreit und begrenzt ab größeren Breakpoints die Breite.
+- **Accessibility:** Sorgt für ausreichende Kontrastwerte und unterstützt dynamische Schriftgrößen.
+- **SEO:** Heading- und Absatzstruktur orientiert sich an inhaltlicher Priorität.
+- **Best Practices:** max-width über clamp(), Padding per Spacing-Token, line-height von mindestens 1.5
+
+## Checkliste
+- [ ] Max-width zwischen 68–76 Zeichenbreite gesetzt.
+- [ ] Kontraste für Text und Links geprüft.
+- [ ] Content bleibt bei größerer Schriftgröße nutzbar.
+- [ ] Core Web Vitals erreichen Zielwerte.
+
+## Abhängigkeiten / Überschneidungen
+- Typografie-Token
+- Formular- und Content-Komponenten
+
+## Akzeptanzkriterien
+- Inhalte bleiben zentriert ohne horizontale Scrollleisten.
+- Screenreader geben die Struktur logisch wieder.
+- Responsives Verhalten für Formulare und Medien verifiziert.
+
+## Beispiel / Code
+```html
+<main class="mx-auto max-w-prose p-4">…</main>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Bewährtes Setup für fokussierte Inhalte und Formulare.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Centered Content gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Centered Content tastatur- und screenreader-freundlich gestalten.
+- Performance: Centered Content nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Centered Content direkt neben dem Code dokumentieren.
+
+## Fazit
+Centered Content bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-chat-interface.md
+++ b/_posts/2025-09-30-layouts-relevant-chat-interface.md
@@ -1,0 +1,82 @@
+---
+title: "Chat Interface: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Chat Interface unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-chat-interface
+original_path: layouts/relevant/chat-interface.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Chat Interface** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Chat Interface nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Chat Interface
+
+## Beschreibung
+Ein Chat-Layout kombiniert Nachrichtenverlauf, Eingabefeld und Statusanzeigen für Echtzeitkommunikation.
+
+## Warum dieses Layout?
+- Schafft vertraute Interaktionsmuster für Support und Messaging.
+- Unterstützt Live-Feedback durch Typing- und Online-Indikatoren.
+- Erfordert DSGVO-konforme Speicherung und Logging-Konzepte.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Nachrichtenblasen passen sich an Breite an und erlauben Scrollen in der Historie.
+- **Accessibility:** Live-Regionen für neue Nachrichten, klare Fokusführung und Tastaturkürzel.
+- **SEO:** Für öffentliche Chats irrelevant, bei Chat-Logs optional strukturierte Daten.
+- **Design-Guidelines:** Konsistente Bubble-Styles, Abstände und Statusfarben.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Chat-Verlauf füllt Bildschirmhöhe, Eingabe bleibt fixiert.
+- **Accessibility:** Role=log oder aria-live verwenden, Eingabefeld mit Label versehen.
+- **SEO:** Server-Side-Rendering für Chat-Transkripte nur falls indexiert.
+- **Best Practices:** Virtuelles Scrolling für lange Verläufe, Upload-Komponenten klar kennzeichnen, Shortcuts dokumentieren
+
+## Checkliste
+- [ ] Neue Nachrichten werden angekündigt ohne Fokus zu stehlen.
+- [ ] Scroll-Position bei History-Load stabil.
+- [ ] Eingabefeld funktioniert mit Tastaturkürzeln.
+- [ ] Security/Privacy-Checks (Logging, Masking) abgeschlossen.
+
+## Abhängigkeiten / Überschneidungen
+- Realtime-/Websocket-Layer
+- UI-Komponenten für Bubbles und Status
+
+## Akzeptanzkriterien
+- Chat bleibt auch bei hohem Nachrichtenaufkommen performant.
+- Screenreader erhalten Updates über neue Nachrichten.
+- Eingabefeld erfüllt Barrierefreiheitsanforderungen.
+
+## Beispiel / Code
+```html
+<section class="chat">
+  <div class="messages" role="log" aria-live="polite">
+    <div class="message">Hallo</div>
+  </div>
+  <form class="composer">
+    <input type="text" aria-label="Nachricht schreiben" />
+    <button>Senden</button>
+  </form>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Wesentlich für Service- und Collaboration-Produkte.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Chat Interface gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Chat Interface tastatur- und screenreader-freundlich gestalten.
+- Performance: Chat Interface nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Chat Interface direkt neben dem Code dokumentieren.
+
+## Fazit
+Chat Interface bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-cover-page.md
+++ b/_posts/2025-09-30-layouts-relevant-cover-page.md
@@ -1,0 +1,77 @@
+---
+title: "Cover Page: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Cover Page unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-cover-page
+original_path: layouts/relevant/cover-page.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Cover Page** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Cover Page nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Cover Page
+
+## Beschreibung
+Ein Deckblatt mit großem Titel, Untertitel und optionaler Illustration eröffnet Dossiers, Reports oder Präsentationen im Web.
+
+## Warum dieses Layout?
+- Setzt einen starken ersten Eindruck und Rahmen.
+- Fokussiert auf Kernbotschaft ohne Ablenkung.
+- Kann Inhalte verstecken, wenn Scroll-Hinweise fehlen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Titel und Visuals skalieren fließend, ausreichend Padding für verschiedene Geräte.
+- **Accessibility:** Klarer Kontrast, semantische Überschriften und Skip-Link zum Hauptinhalt.
+- **SEO:** Deckblatt enthält relevante Keywords und Meta-Informationen.
+- **Design-Guidelines:** Große Typografie, definierte Weißräume und stimmige Farbflächen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Stackt Elemente vertikal, Bild ggf. unter Titel platzieren.
+- **Accessibility:** Scroll-Hinweis einblenden und Fokus auf nächste Sektion ermöglichen.
+- **SEO:** Open-Graph/Twitter-Cards auf Cover-Inhalte abstimmen.
+- **Best Practices:** Hero-ähnliche Struktur nutzen, Kontrastreiches Farbschema, Animationspräferenzen respektieren
+
+## Checkliste
+- [ ] Titel ist prominent und responsiv.
+- [ ] Scroll-Hinweis vorhanden.
+- [ ] Kontraste und Typografie geprüft.
+- [ ] A11y- und Performance-Test bestanden.
+
+## Abhängigkeiten / Überschneidungen
+- Hero-/Typography-Komponenten
+- Branding-Guidelines
+
+## Akzeptanzkriterien
+- Cover leitet klar zum folgenden Inhalt über.
+- Screenreader finden direkten Zugang zum Hauptinhalt.
+- Darstellung bleibt auf allen Viewports stabil.
+
+## Beispiel / Code
+```html
+<header class="cover">
+  <h1>Titel</h1>
+  <p>Untertitel</p>
+</header>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Ideal für Reports, Whitepaper und thematische Einstiege.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Cover Page gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Cover Page tastatur- und screenreader-freundlich gestalten.
+- Performance: Cover Page nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Cover Page direkt neben dem Code dokumentieren.
+
+## Fazit
+Cover Page bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-dashboard-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-dashboard-layout.md
@@ -1,0 +1,74 @@
+---
+title: "Dashboard Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Dashboard Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-dashboard-layout
+original_path: layouts/relevant/dashboard-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Dashboard Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Dashboard Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Dashboard Layout
+
+## Beschreibung
+Dashboards bündeln Karten, Tabellen und Diagramme in einer übersichtlichen Oberfläche. Sie kommen in Admin-Tools, Analytics-Lösungen oder SaaS-Plattformen zum Einsatz.
+
+## Warum dieses Layout?
+- Ermöglicht dichte Darstellung von Kennzahlen.
+- Unterstützt modulare Widgets mit unterschiedlichen Größen.
+- Benötigt durchdachtes Responsive-Verhalten und Priorisierung.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Grid-Areas passen sich an verfügbare Fläche an und erlauben Reordering.
+- **Accessibility:** Tabellen, Charts und Widgets benötigen ARIA-Unterstützung und verständliche Labels.
+- **SEO:** Bei öffentlichen Dashboards strukturierte Daten und semantische Überschriften verwenden.
+- **Design-Guidelines:** Konsistente Spacing- und Farbskalen, klare Kartentitel und Statusindikatoren.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Widgets stapeln und priorisieren, kritische Kennzahlen zuerst.
+- **Accessibility:** Keyboard-Navigation für Widgets sicherstellen und Live-Regionen sparsam einsetzen.
+- **SEO:** SSR oder statische Ausspielung für indexierbare Inhalte berücksichtigen.
+- **Best Practices:** Grid-Areas definieren, Charts mit Textäquivalenten versehen, Skeleton-Loading für Datenabfragen
+
+## Checkliste
+- [ ] Widgets bleiben auch mobil lesbar.
+- [ ] Fokuspfade für interaktive Module getestet.
+- [ ] Charts haben beschreibende Alternativen.
+- [ ] Performance-Monitoring implementiert.
+
+## Abhängigkeiten / Überschneidungen
+- Charting-Library
+- Grid-System
+
+## Akzeptanzkriterien
+- Layout unterstützt individuelles Rearrangement ohne Layoutbruch.
+- Screenreader können Kennzahlen interpretieren.
+- Loading-States vermitteln klaren Status.
+
+## Beispiel / Code
+```html
+<section class="grid lg:grid-cols-3 gap-4">…</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Bewährte Grundlage für datengetriebene Anwendungen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Dashboard Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Dashboard Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Dashboard Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Dashboard Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Dashboard Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-ecommerce-product-grid.md
+++ b/_posts/2025-09-30-layouts-relevant-ecommerce-product-grid.md
@@ -1,0 +1,76 @@
+---
+title: "Ecommerce Product Grid: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Ecommerce Product Grid unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-ecommerce-product-grid
+original_path: layouts/relevant/ecommerce-product-grid.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Ecommerce Product Grid** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Ecommerce Product Grid nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: E-Commerce Product Grid
+
+## Beschreibung
+Produktkacheln mit Bild, Preis, Bewertung und CTA bilden den Kern vieler Shop-Übersichten. Das Layout ermöglicht Sortierung, Filterung und Batch-Aktionen.
+
+## Warum dieses Layout?
+- Präsentiert viele Produkte strukturiert und vergleichbar.
+- Unterstützt Facetten- und Filterlogik für schnelle Auswahl.
+- Braucht sorgfältiges Management von Datenqualität und Performance.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Grid reagiert auf Breakpoints und unterstützt unterschiedliche Kartenbreiten.
+- **Accessibility:** Komplette Karte als Link oder Button mit sichtbarem Fokus und ARIA-Labels.
+- **SEO:** Jede Karte verlinkt auf kanonische Produktseiten mit strukturierten Daten.
+- **Design-Guidelines:** Konsistente Bildverhältnisse, Preisformatierung und Label-Hierarchie.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet einspaltig, priorisiert Produktbild und Preis.
+- **Accessibility:** Beschriftet Aktionen wie Merkliste oder Warenkorb klar und fokussierbar.
+- **SEO:** Vermeidet Duplicate Content durch Filterparameter und setzt rel="canonical".
+- **Best Practices:** Lazy Loading + LQIP für Bilder, Sichtbare Rabatt-Badges, Skeleton-Loading bei Filtersuche
+
+## Checkliste
+- [ ] Bildgrößen und Ratio sind vereinheitlicht.
+- [ ] Preisangaben entsprechen regulatorischen Vorgaben.
+- [ ] Filter/Sortierung funktionieren mit Tastatur.
+- [ ] Performance- und Tracking-Messung vorhanden.
+
+## Abhängigkeiten / Überschneidungen
+- Produktdaten-API
+- Filter- und Sortiermodule
+
+## Akzeptanzkriterien
+- Produktgrid bleibt bei Filterwechsel performant.
+- Screenreader können Karteninhalt vollständig erfassen.
+- CWV bleiben trotz vieler Bilder im Zielbereich.
+
+## Beispiel / Code
+```html
+<section class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+  <article class="product-card">…</article>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Zentral für digitale Handelsflächen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Ecommerce Product Grid gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Ecommerce Product Grid tastatur- und screenreader-freundlich gestalten.
+- Performance: Ecommerce Product Grid nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Ecommerce Product Grid direkt neben dem Code dokumentieren.
+
+## Fazit
+Ecommerce Product Grid bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-full-height-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-full-height-layout.md
@@ -1,0 +1,76 @@
+---
+title: "Full Height Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Full Height Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-full-height-layout
+original_path: layouts/relevant/full-height-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Full Height Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Full Height Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Full Height Layout
+
+## Beschreibung
+Das Layout streckt Container auf die volle Höhe des Viewports, um Inhalte mittig zu platzieren. Typisch für Login-Seiten, Splash-Screens oder Deckblätter.
+
+## Warum dieses Layout?
+- Erzeugt eine konzentrierte Bühne für einzelne Inhalte.
+- Hilft, kurze Inhalte visuell zu zentrieren.
+- Muss Browserleisten und kleine Displays berücksichtigen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** min-height: 100dvh mit sicherem Fallback für iOS/Android, Padding für kleinere Screens.
+- **Accessibility:** Zentrierte Inhalte müssen bei Zoom und größeren Schriftgrößen funktionieren.
+- **SEO:** Wichtige Botschaften im sichtbaren Bereich platzieren.
+- **Design-Guidelines:** Kontrastreiche Hintergründe, klare Typografie und ausreichend Weißraum.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Flexible Höhen nutzen und erst ab größeren Breakpoints strikte Full-Height-Anmutung einsetzen.
+- **Accessibility:** Focus-Traps vermeiden und Skip-Links bereitstellen, falls weiterer Content folgt.
+- **SEO:** Meta-Daten auf Kernbotschaften abstimmen.
+- **Best Practices:** 100dvh statt 100vh, Content vertikal via flexbox zentrieren, Fallback bei Tastaturfokus testen
+
+## Checkliste
+- [ ] Viewport-Variationen getestet (iOS Safari, Android Chrome).
+- [ ] Zentrierter Inhalt bleibt bei Zoom erreichbar.
+- [ ] Kontrast und Lesbarkeit geprüft.
+- [ ] A11y- und Performance-Check durchgeführt.
+
+## Abhängigkeiten / Überschneidungen
+- Hero- oder Auth-Komponenten
+- Design-Tokens für Abstände
+
+## Akzeptanzkriterien
+- Layout bleibt ohne Scroll-Fallen nutzbar.
+- Screenreader erreichen weitere Inhalte nach dem Full-Height-Block.
+- Darstellung kollabiert nicht auf kleinen Displays.
+
+## Beispiel / Code
+```html
+<section class="min-h-[100dvh] flex items-center justify-center p-8">
+  <div>Inhalt</div>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Ideal für fokussierte Einstiegs- oder Login-Screens.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Full Height Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Full Height Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Full Height Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Full Height Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Full Height Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-full-width-hero.md
+++ b/_posts/2025-09-30-layouts-relevant-full-width-hero.md
@@ -1,0 +1,77 @@
+---
+title: "Full Width Hero: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Full Width Hero unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-full-width-hero
+original_path: layouts/relevant/full-width-hero.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Full Width Hero** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Full Width Hero nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Full Width Hero
+
+## Beschreibung
+Der Hero-Bereich nutzt die gesamte Seitenbreite für starke Botschaften, Visuals und Calls-to-Action. Eingesetzt auf Landingpages, Produktseiten oder Kampagnenstarts.
+
+## Warum dieses Layout?
+- Sichert maximale Aufmerksamkeit direkt beim Einstieg.
+- Bietet viel Raum für Bildsprache und zentrale Call-to-Actions.
+- Kann bei schlechter Optimierung LCP und Fokus beeinträchtigen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Fluides Skalieren von Bildern, Texten und CTA-Elementen.
+- **Accessibility:** Kontraste zwischen Text und Hintergrund sowie aussagekräftige Alt-Texte gewährleisten.
+- **SEO:** Hero enthält die Hauptüberschrift und relevante Keywords.
+- **Design-Guidelines:** Klare Hierarchie, großzügiges Spacing und ggf. Overlays zur Textlesbarkeit.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Hero-Text und CTA priorisieren, Hintergrundbild adaptiv laden.
+- **Accessibility:** Sichtbare Fokuszustände und tastaturfreundliche CTAs sicherstellen.
+- **SEO:** H1 im Hero platzieren und strukturierte Daten bei Kampagnen ergänzen.
+- **Best Practices:** <picture> für responsive Images, LCP-Optimierung durch Preload, CTA oberhalb des Folds positionieren
+
+## Checkliste
+- [ ] CTA ist sofort sichtbar und fokussierbar.
+- [ ] Hintergrundbilder sind komprimiert und responsive.
+- [ ] Hero erfüllt Kontrastanforderungen.
+- [ ] Lighthouse-LCP und A11y-Checks bestanden.
+
+## Abhängigkeiten / Überschneidungen
+- CTA-Komponenten
+- Bildoptimierungs-Stack
+
+## Akzeptanzkriterien
+- Hero lädt performant mit optimiertem LCP.
+- Texte bleiben auf allen Breakpoints gut lesbar.
+- CTA ist mit Tastatur und Screenreader erreichbar.
+
+## Beispiel / Code
+```html
+<section class="hero">
+  <h1>Headline</h1>
+  <a class="btn" href="#">CTA</a>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Kernbaustein für aufmerksamkeitsstarke Landingpages.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Full Width Hero gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Full Width Hero tastatur- und screenreader-freundlich gestalten.
+- Performance: Full Width Hero nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Full Width Hero direkt neben dem Code dokumentieren.
+
+## Fazit
+Full Width Hero bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-fullscreen-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-fullscreen-layout.md
@@ -1,0 +1,76 @@
+---
+title: "Fullscreen Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Fullscreen Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-fullscreen-layout
+original_path: layouts/relevant/fullscreen-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Fullscreen Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Fullscreen Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Fullscreen Layout
+
+## Beschreibung
+Sektionen nutzen die komplette Viewport-Höhe, um Inhalte immersiv zu inszenieren. Geeignet für Storytelling, Produkt-Highlights oder Scroll-Snapping-Erfahrungen.
+
+## Warum dieses Layout?
+- Erzeugt starke visuelle Präsenz und Fokus.
+- Unterstützt Schritt-für-Schritt-Inszenierungen.
+- Kann die Wahrnehmung des "Folds" beeinträchtigen und Nutzer zum Scrollen motivieren müssen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** min-height: 100dvh mit Fallbacks für mobile Browserleisten, Scroll-Hinweis ergänzen.
+- **Accessibility:** Keine Scroll-Fallen erzeugen, Tastatur- und Screenreader-Steuerung sicherstellen.
+- **SEO:** Wichtige Inhalte nicht ausschließlich in späteren Panels verstecken.
+- **Design-Guidelines:** Klare Kontraste, großzügige Typografie und visuelle Balance zwischen Panels.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet mit flexiblen Höhen und erweitert sich zu Fullscreen erst ab größeren Breakpoints.
+- **Accessibility:** Scroll-Hinweise und Skip-Links bereitstellen, Animationspräferenzen respektieren.
+- **SEO:** Meta-Beschreibungen auf Kernbotschaften der ersten Sektion abstimmen.
+- **Best Practices:** 100dvh statt 100vh verwenden, Scroll-Snap nur optional aktivieren, Interaktionen klar kennzeichnen
+
+## Checkliste
+- [ ] Scroll-Hinweis vorhanden und erkennbar.
+- [ ] Inhalt bleibt bei deaktivierten Animationen verständlich.
+- [ ] Kontrast- und Lesbarkeitswerte geprüft.
+- [ ] Performance- und Accessibility-Test durchgeführt.
+
+## Abhängigkeiten / Überschneidungen
+- Hero- oder Storytelling-Komponenten
+- Scroll- und Animationsutilities
+
+## Akzeptanzkriterien
+- Panels passen sich an unterschiedliche Viewport-Höhen an.
+- Screenreader können Sektionen sequentiell durchlaufen.
+- Keine unerwünschten Scroll-Fallen bei Tastatur- oder Touchbedienung.
+
+## Beispiel / Code
+```html
+<section class="min-h-[100dvh] flex items-center justify-center">
+  <div>Inhalt</div>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Wirkt stark, erfordert aber sorgfältige Nutzerführung.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Fullscreen Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Fullscreen Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Fullscreen Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Fullscreen Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Fullscreen Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-gallery-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-gallery-layout.md
@@ -1,0 +1,76 @@
+---
+title: "Gallery Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Gallery Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-gallery-layout
+original_path: layouts/relevant/gallery-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Gallery Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Gallery Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Gallery Layout
+
+## Beschreibung
+Eine Galerie präsentiert Bild- oder Medienkollektionen mit optionaler Lightbox. Sie eignet sich für Pressebereiche, Produktansichten oder Moodboards.
+
+## Warum dieses Layout?
+- Setzt visuelle Inhalte in den Mittelpunkt.
+- Unterstützt verschiedene Medienformate inklusive Video.
+- Kann bei schlechter Optimierung zu Performance-Problemen führen.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Skaliert zwischen einzelnen Spalten und Mehrspalt-Ansichten, unterstützt Swipe-Gesten.
+- **Accessibility:** Lightbox steuerbar per Tastatur, klare Alt-Texte und Beschreibungen.
+- **SEO:** Bilddaten mit beschreibenden Dateinamen, Alt-Texten und optional JSON-LD.
+- **Design-Guidelines:** Konsistente Abstände, Thumbnail-Ratio und Hover-Zustände.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Beginnt mit einspaltiger Darstellung und ermöglicht horizontales Scrollen nur kontextuell.
+- **Accessibility:** Lightbox nutzt Dialog-Pattern mit Fokus-Trap und ESC-Schließen.
+- **SEO:** Strukturierte Daten (ImageGallery) bei öffentlichen Sammlungen ergänzen.
+- **Best Practices:** Lazy Loading, Srcset für responsive Bilder, Keyboard Shortcuts dokumentieren
+
+## Checkliste
+- [ ] Lazy Loading für alle Medien aktiviert.
+- [ ] Lightbox ist vollständig tastaturbedienbar.
+- [ ] Alt-Texte beschreiben Inhalt präzise.
+- [ ] Performance- und Accessibility-Checks bestanden.
+
+## Abhängigkeiten / Überschneidungen
+- Lightbox-Komponente
+- Medien-Asset-Management
+
+## Akzeptanzkriterien
+- Galerie bleibt auch bei vielen Assets performant.
+- Lightbox respektiert Fokusreihenfolge und ESC.
+- Swipe- oder Pfeilnavigation funktioniert zuverlässig.
+
+## Beispiel / Code
+```html
+<section class="gallery grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+  <a class="gallery-item" href="#" aria-label="Bild öffnen">…</a>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Schlüssel-Layout für visuelle Asset-Sammlungen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Gallery Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Gallery Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Gallery Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Gallery Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Gallery Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-grid-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-grid-layout.md
@@ -1,0 +1,76 @@
+---
+title: "Grid Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Grid Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-grid-layout
+original_path: layouts/relevant/grid-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Grid Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Grid Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Responsive Grid
+
+## Beschreibung
+Ein modularer Kartenraster erlaubt flexible Inhalte wie Produktkacheln, Team-Profile oder News. Das Layout nutzt CSS Grid für unterschiedliche Spaltenkonfigurationen.
+
+## Warum dieses Layout?
+- Skalierbar für unterschiedlich viele Karten.
+- Bietet konsistente Darstellung über diverse Viewports.
+- Erfordert sorgfältige Breakpoint-Definitionen und Bildoptimierung.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Grid-Spalten passen sich über auto-fit/minmax() dynamisch an.
+- **Accessibility:** Lesereihenfolge folgt der DOM-Struktur, Karten erhalten eindeutige Überschriften.
+- **SEO:** Jede Karte nutzt semantische Elemente wie <article> und sprechende Links.
+- **Design-Guidelines:** Konsistente Kartenhöhen, klare Abstände und definierte Schatten oder Umrandungen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet einspaltig und erweitert sich schrittweise auf mehr Spalten.
+- **Accessibility:** Fokuszustände klar hervorheben und Karten interaktiv gestalten.
+- **SEO:** Primäre Links in Karten prominent platzieren und strukturierte Daten erwägen.
+- **Best Practices:** minmax() zur Breitensteuerung, Lazy Loading für Medien, Grid-Gaps gemäß Spacing-Scale
+
+## Checkliste
+- [ ] Kartenhöhen bleiben visuell ausgerichtet.
+- [ ] LCP-relevante Bilder optimiert.
+- [ ] Tastaturnavigation durch Karten getestet.
+- [ ] Performance- und Accessibility-Review erfolgt.
+
+## Abhängigkeiten / Überschneidungen
+- Card-Komponenten
+- Design-Tokens für Abstände
+
+## Akzeptanzkriterien
+- Grid passt sich nahtlos an 1–4 Spalten an.
+- Screenreader können jede Karte separat ankündigen.
+- Lazy Loading reduziert Initial-Ladezeit messbar.
+
+## Beispiel / Code
+```html
+<section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+  <article class="card">…</article>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Grundlage für produkt- und contentlastige Übersichten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Grid Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Grid Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Grid Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Grid Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Grid Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-header-content-footer.md
+++ b/_posts/2025-09-30-layouts-relevant-header-content-footer.md
@@ -1,0 +1,76 @@
+---
+title: "Header Content Footer: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Header Content Footer unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-header-content-footer
+original_path: layouts/relevant/header-content-footer.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Header Content Footer** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Header Content Footer nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Header – Content – Footer
+
+## Beschreibung
+Der klassische Aufbau mit Kopfbereich, zentralem Content und abschließendem Footer funktioniert für die meisten Websites. Er eignet sich für Marketingseiten, Unternehmensauftritte oder Informationsangebote.
+
+## Warum dieses Layout?
+- Universelles Muster mit klarer Navigationsstruktur.
+- Lässt sich mit Komponentenbibliotheken schnell zusammensetzen.
+- Kann ohne hochwertige Gestaltung austauschbar wirken.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Alle Bereiche passen sich an Viewportgrößen an und verhindern horizontales Scrollen.
+- **Accessibility:** Nur ein <main>-Element, korrekte Überschriftenhierarchie und sichtbare Skip-Links.
+- **SEO:** Saubere Title-/Meta-Tags und strukturierte Daten für Footer-Informationen.
+- **Design-Guidelines:** Deutliche visuelle Hierarchie zwischen Header, Content und Footer.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Navigation vereinfachen und Content-Abstände auf kleinen Screens optimieren.
+- **Accessibility:** Landmark-Struktur validieren und interaktive Elemente fokussierbar machen.
+- **SEO:** Hero-Bereich mit h1 und relevanten Keywords versehen.
+- **Best Practices:** Core Web Vitals regelmäßig messen, Footer-Links priorisieren, Responsives Typo-Scale via clamp()
+
+## Checkliste
+- [ ] Überschriftenstruktur ist linear und nachvollziehbar.
+- [ ] Footer enthält rechtliche Pflichtlinks und Kontaktinformationen.
+- [ ] Navigation und Content funktionieren ohne JavaScript.
+- [ ] Core Web Vitals erfüllen Zielwerte.
+
+## Abhängigkeiten / Überschneidungen
+- Globaler Header/Footer
+- Content-Komponentenbibliothek
+
+## Akzeptanzkriterien
+- Layout bleibt auf allen Breakpoints stabil.
+- Skip-Link springt zum einzigen <main>-Element.
+- Footer erreicht mindestens AA-Kontrastwerte.
+
+## Beispiel / Code
+```html
+<header>…</header>
+<main>…</main>
+<footer>…</footer>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Universelles Standardskelett für multipage Websites.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Header Content Footer gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Header Content Footer tastatur- und screenreader-freundlich gestalten.
+- Performance: Header Content Footer nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Header Content Footer direkt neben dem Code dokumentieren.
+
+## Fazit
+Header Content Footer bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-header-footer.md
+++ b/_posts/2025-09-30-layouts-relevant-header-footer.md
@@ -1,0 +1,76 @@
+---
+title: "Header Footer: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Header Footer unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-header-footer
+original_path: layouts/relevant/header-footer.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Header Footer** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Header Footer nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Header & Footer Framework
+
+## Beschreibung
+Das Layout bildet die minimale Seitenstruktur aus Kopf- und Fußbereich, die andere Layouts erweitern. Es dient als Ausgangspunkt für Anwendungen, die ihre Inhalte dynamisch in <main> einfügen.
+
+## Warum dieses Layout?
+- Schafft ein konsistentes Grundgerüst für wiederkehrende Seiten.
+- Erleichtert die Wiederverwendung von Navigations- und Footer-Komponenten.
+- Allein nicht ausreichend, da der Hauptinhalt separat gestaltet werden muss.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Header- und Footer-Inhalte passen sich flexiblen Breiten an und bleiben lesbar.
+- **Accessibility:** Landmark-Rollen nutzen, Skip-Link vorsehen und klare Fokusführung etablieren.
+- **SEO:** Semantische Auszeichnung von Navigation, Logo und Pflichtlinks.
+- **Design-Guidelines:** Ausreichende Padding-Werte, konsistente Typografie und klare Trennung zwischen Bereichen.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Navigationsinhalte reduzieren und bei Bedarf als Burger-Menü bereitstellen.
+- **Accessibility:** Skip-Link implementieren und Fokusindikatoren sichtbar halten.
+- **SEO:** Footer für Kontakt- und Organisationsdaten nutzen und korrekt markieren.
+- **Best Practices:** Sticky-Header nur bei Bedarf, Footer-Links gruppieren, Navigation logisch ordnen
+
+## Checkliste
+- [ ] Skip-Link führt zuverlässig zum Hauptinhalt.
+- [ ] Navigation bleibt auch auf kleinen Screens bedienbar.
+- [ ] Footer enthält alle Pflichtinformationen (Impressum, Datenschutz).
+- [ ] Lighthouse-A11y-Check ohne kritische Fehler.
+
+## Abhängigkeiten / Überschneidungen
+- Globale Navigationskomponenten
+- Footer-Link-Module
+
+## Akzeptanzkriterien
+- Header kollabiert responsiv ohne Layoutsprünge.
+- Footer bleibt bei langen Seiten sichtbar und strukturiert.
+- Screenreader erkennen die Landmarken korrekt.
+
+## Beispiel / Code
+```html
+<header>…</header>
+<main>Inhalt</main>
+<footer>…</footer>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Solide Basis für Seiten mit dynamisch eingespeistem Content.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Header Footer gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Header Footer tastatur- und screenreader-freundlich gestalten.
+- Performance: Header Footer nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Header Footer direkt neben dem Code dokumentieren.
+
+## Fazit
+Header Footer bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-header-sticky-navigation.md
+++ b/_posts/2025-09-30-layouts-relevant-header-sticky-navigation.md
@@ -1,0 +1,74 @@
+---
+title: "Header Sticky Navigation: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Header Sticky Navigation unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-header-sticky-navigation
+original_path: layouts/relevant/header-sticky-navigation.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Header Sticky Navigation** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Header Sticky Navigation nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Header mit Sticky Navigation
+
+## Beschreibung
+Die Navigation bleibt beim Scrollen sichtbar und erleichtert schnellen Zugriff auf wichtige Bereiche. Geeignet für lange Seiten, Wissensdatenbanken oder Anwendungen mit häufigen Kontextwechseln.
+
+## Warum dieses Layout?
+- Verbessert Orientierung und Zugänglichkeit bei langen Seiten.
+- Reduziert Interaktionskosten, weil Hauptnavigation immer erreichbar ist.
+- Verbraucht vertikalen Raum, insbesondere auf mobilen Geräten.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Sticky-Verhalten an Breakpoints anpassen, damit auf kleinen Screens genug Inhalt sichtbar bleibt.
+- **Accessibility:** Sichtbare Fokuszustände und sinnvolle Tab-Reihenfolge, keine Überblendung von Inhalten.
+- **SEO:** Navigation bleibt semantisch als <nav> ausgezeichnet, ohne redundante Links.
+- **Design-Guidelines:** Z-Index und Schatten definieren, um Überlagerungen zu vermeiden.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Navigation verschlanken oder als kompakte Bar darstellen.
+- **Accessibility:** Sticky-Header darf keine Inhalte überdecken; Skip-Link nach dem Header anbieten.
+- **SEO:** Relevante Links priorisieren und doppelte Navigation vermeiden.
+- **Best Practices:** CLS durch feste Höhen verhindern, Scroll-Hide/Show vorsichtig einsetzen, Sticky-Offset testen
+
+## Checkliste
+- [ ] Sticky-Header überdeckt keine Inhalte oder Fokusindikatoren.
+- [ ] Tastatur- und Screenreader-Bedienung geprüft.
+- [ ] Scroll-Verhalten auf Touch-Geräten getestet.
+- [ ] Performance- und Accessibility-Audit durchgeführt.
+
+## Abhängigkeiten / Überschneidungen
+- Navigationskomponenten
+- Scroll-Behaviour-Skripte
+
+## Akzeptanzkriterien
+- Header bleibt in allen Breakpoints funktional sticky.
+- Skip-Link führt zum Beginn des Hauptinhalts.
+- Navigation reagiert flüssig auf Scroll-Interaktionen.
+
+## Beispiel / Code
+```html
+<header class="sticky top-0">…</header>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Essentiell für informationsreiche oder lange Seiten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Header Sticky Navigation gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Header Sticky Navigation tastatur- und screenreader-freundlich gestalten.
+- Performance: Header Sticky Navigation nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Header Sticky Navigation direkt neben dem Code dokumentieren.
+
+## Fazit
+Header Sticky Navigation bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-landing-page.md
+++ b/_posts/2025-09-30-layouts-relevant-landing-page.md
@@ -1,0 +1,78 @@
+---
+title: "Landing Page: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Landing Page unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-landing-page
+original_path: layouts/relevant/landing-page.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Landing Page** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Landing Page nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Landing Page
+
+## Beschreibung
+Kampagnen- oder Conversion-Seiten kombinieren Hero, Benefits, Social Proof und CTA in klarer Sequenz. Sie dienen der gezielten Lead- oder Sales-Generierung.
+
+## Warum dieses Layout?
+- Fokussiert Besucher auf ein klares Conversion-Ziel.
+- Lässt sich modular testen und iterativ optimieren.
+- Muss trotz visueller Dichte schnell laden.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Abschnitte passen sich fluid an und halten CTA sichtbar.
+- **Accessibility:** Kontraststarke Buttons, verständliche Formularbeschriftungen und Skip-Links.
+- **SEO:** Meta-/Open-Graph-Daten, strukturierte Daten für Angebote und Trust-Signale.
+- **Design-Guidelines:** Konsistente Benefit-Icons, eindeutige Hierarchie von Überschriften und CTAs.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Hero und Kernargumente zuerst, sekundäre Inhalte nachgelagert.
+- **Accessibility:** Formulare mit aria-describedby und verständlichen Fehlermeldungen versehen.
+- **SEO:** Landing-spezifische Keywords und Tracking sauber integrieren.
+- **Best Practices:** Above-the-fold-CTA testen, A/B-Testing vorbereiten, Consent- und Tracking-Setup beachten
+
+## Checkliste
+- [ ] CTA ist auf allen Breakpoints prominent.
+- [ ] Social-Proof-Elemente sind glaubwürdig und aktuell.
+- [ ] Formular funktioniert mit Tastatur und Screenreader.
+- [ ] Performance- und Tracking-Checks abgeschlossen.
+
+## Abhängigkeiten / Überschneidungen
+- Hero-, Benefit- und Trust-Komponenten
+- Analytics- und Consent-Implementierung
+
+## Akzeptanzkriterien
+- Landing Page erreicht definierte Performance-Budgets.
+- Conversion-Pfade sind ohne Hindernisse nutzbar.
+- Tracking-Events werden korrekt ausgelöst.
+
+## Beispiel / Code
+```html
+<main>
+  <section class="hero">…</section>
+  <section class="benefits">…</section>
+  <section class="cta">…</section>
+</main>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Schlüssel-Layout für Kampagnen und Conversion-Ziele.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Landing Page gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Landing Page tastatur- und screenreader-freundlich gestalten.
+- Performance: Landing Page nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Landing Page direkt neben dem Code dokumentieren.
+
+## Fazit
+Landing Page bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-magazine-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-magazine-layout.md
@@ -1,0 +1,77 @@
+---
+title: "Magazine Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Magazine Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-magazine-layout
+original_path: layouts/relevant/magazine-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Magazine Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Magazine Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Magazine Layout
+
+## Beschreibung
+Magazinartige Seiten nutzen abwechslungsreiche Sektionen, um Stories zu erzählen. Ideal für Editorials, Content-Hubs oder Markenwelten.
+
+## Warum dieses Layout?
+- Erlaubt kuratiertes Storytelling mit wechselnden Modulen.
+- Bietet hohe Flexibilität für redaktionelle Inhalte.
+- Erfordert intensives Redaktions- und Design-Management.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Sektionen passen sich via Grid- und Flex-Patterns an Viewports an.
+- **Accessibility:** Jede Sektion erhält semantische Struktur und klare Überschriften.
+- **SEO:** Rich Snippets für Artikel und Sammlungen berücksichtigen.
+- **Design-Guidelines:** Visuelle Hierarchie pro Abschnitt, konsistente Farb- und Typo-Systeme.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Sektionen stapeln sich vertikal mit klarer Reihenfolge.
+- **Accessibility:** Vermeidet Layoutsprünge, die Lesefluss stören, und nutzt ausreichend Kontrast.
+- **SEO:** Sektionen über interne Verlinkung und strukturierte Daten verknüpfen.
+- **Best Practices:** Container Queries nutzen, Sections mit klaren IDs versehen, Visuelle Vielfalt ohne übermäßige Effekte
+
+## Checkliste
+- [ ] Sektionen haben eindeutige Überschriften.
+- [ ] Bild- und Medienelemente sind optimiert.
+- [ ] Storyline bleibt auf mobilen Geräten nachvollziehbar.
+- [ ] Accessibility- und Performance-Checks dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Section-Komponentenbibliothek
+- Content-Management-System
+
+## Akzeptanzkriterien
+- Layout unterstützt mindestens drei unterschiedliche Section-Varianten.
+- Screenreader erkennen Abschnittsstruktur klar.
+- Redaktion kann Module ohne Entwickler anordnen.
+
+## Beispiel / Code
+```html
+<article>
+  <section class="feature">…</section>
+  <section class="story-grid">…</section>
+</article>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Stark für editorial geprägte Content-Erlebnisse.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Magazine Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Magazine Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Magazine Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Magazine Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Magazine Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-masonry-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-masonry-layout.md
@@ -1,0 +1,74 @@
+---
+title: "Masonry Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Masonry Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-masonry-layout
+original_path: layouts/relevant/masonry-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Masonry Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Masonry Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Masonry Layout
+
+## Beschreibung
+Ein unregelmäßiges Raster ordnet Karten wie Mauerwerk an und erzeugt eine dynamische Bildfläche. Häufig für Galerien, Moodboards oder Inspirationsseiten genutzt.
+
+## Warum dieses Layout?
+- Schafft visuelle Abwechslung bei heterogenen Inhalten.
+- Kann große Mengen visueller Elemente effizient darstellen.
+- A11y und Reflow müssen genau kontrolliert werden.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Fällt auf mobilen Geräten auf ein- bis zweispaltige Darstellung zurück.
+- **Accessibility:** Lesereihenfolge bleibt trotz visueller Versetzung nachvollziehbar.
+- **SEO:** Karten bleiben semantisch sauber ausgezeichnet, Links klar benannt.
+- **Design-Guidelines:** Konsistente Spacing-Scale und definierte Bildbeschnitte.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet als klassischer Grid-Stack und erweitert sich per Masonry.
+- **Accessibility:** Fallback auf reguläre Spalten sicherstellen, wenn Masonry nicht unterstützt wird.
+- **SEO:** Sprechende Bild-Alt-Texte und korrekte Linkziele pflegen.
+- **Best Practices:** CSS Masonry oder Column-Layout nutzen, Lazy Loading für Bilder, DOM-Reihenfolge unverändert lassen
+
+## Checkliste
+- [ ] Lesereihenfolge bleibt nachvollziehbar.
+- [ ] LCP- und CLS-Metriken geprüft.
+- [ ] Bildgrößen sind optimiert.
+- [ ] Accessibility-Audit dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Bild- oder Card-Komponenten
+- Optionaler Masonry-Polyfill
+
+## Akzeptanzkriterien
+- Fallback-Layout funktioniert ohne Masonry-Unterstützung.
+- Screenreader lesen Inhalte in logischer Reihenfolge vor.
+- Performance bleibt trotz vieler Bilder stabil.
+
+## Beispiel / Code
+```html
+<section class="masonry">…</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Ideal für visuelle Galerien mit dynamischer Anmutung.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Masonry Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Masonry Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Masonry Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Masonry Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Masonry Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-navigation-overlay.md
+++ b/_posts/2025-09-30-layouts-relevant-navigation-overlay.md
@@ -1,0 +1,79 @@
+---
+title: "Navigation Overlay: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Navigation Overlay unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-navigation-overlay
+original_path: layouts/relevant/navigation-overlay.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Navigation Overlay** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Navigation Overlay nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Navigation Overlay
+
+## Beschreibung
+Eine Vollbild-Navigation blendet sich über den Inhalt und eignet sich für minimalistische Seiten oder mobile Menüs.
+
+## Warum dieses Layout?
+- Lenkt volle Aufmerksamkeit auf Navigationsziele.
+- Schafft klare, fokussierte Nutzerführung.
+- Kann tiefe Hierarchien oder viele Links überfrachten.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Overlay deckt gesamte Viewports ab, Übergang von Burger-Icon zu Overlay.
+- **Accessibility:** Dialog- oder Drawer-Pattern mit Fokus-Trap, aria-modal und ESC-Schließen.
+- **SEO:** Navigation bleibt im DOM vorhanden, auch wenn sie überlagert.
+- **Design-Guidelines:** Kontrastreiche Links, animierte Übergänge nur subtil.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Overlay ist Standard, Desktop optional als sekundärer Einstieg.
+- **Accessibility:** Fokus beim Öffnen auf erstes Element setzen, beim Schließen zurückführen.
+- **SEO:** Wichtige Links bleiben crawlbar, Hidden-Attribute korrekt einsetzen.
+- **Best Practices:** aria-modal verwenden, ESC- und Klick-Outside-Handling, Animationen mit prefers-reduced-motion abstimmen
+
+## Checkliste
+- [ ] Overlay öffnet und schließt mit Tastatur.
+- [ ] Fokus bleibt innerhalb des Overlays gefangen.
+- [ ] Links sind klar lesbar und kontrastreich.
+- [ ] A11y- und Performance-Tests abgeschlossen.
+
+## Abhängigkeiten / Überschneidungen
+- Navigation-/Dialog-Komponente
+- State-Management
+
+## Akzeptanzkriterien
+- Overlay erfüllt Dialog-Pattern-Anforderungen.
+- Screenreader erhalten Ankündigung des Overlays.
+- Interaktion funktioniert auch ohne Animationen.
+
+## Beispiel / Code
+```html
+<nav class="overlay" aria-modal="true" hidden>
+  <button class="close" aria-label="Menü schließen">×</button>
+  <ul>
+    <li><a href="#">Link</a></li>
+  </ul>
+</nav>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Starkes Pattern für fokussierte mobile Navigation.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Navigation Overlay gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Navigation Overlay tastatur- und screenreader-freundlich gestalten.
+- Performance: Navigation Overlay nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Navigation Overlay direkt neben dem Code dokumentieren.
+
+## Fazit
+Navigation Overlay bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-one-column.md
+++ b/_posts/2025-09-30-layouts-relevant-one-column.md
@@ -1,0 +1,79 @@
+---
+title: "One Column: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum One Column unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-one-column
+original_path: layouts/relevant/one-column.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **One Column** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt One Column nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: One Column
+
+## Beschreibung
+Ein einspaltiges Layout lenkt den Blick auf den Hauptinhalt und reduziert Ablenkungen. Typischerweise wird es für Artikel, Dokumentationen oder fokussierte Landingpages eingesetzt.
+
+## Warum dieses Layout?
+- Maximiert Lesbarkeit und Flow für längere Texte.
+- Einfach zu pflegen und mit modularen Komponenten zu erweitern.
+- Bietet wenig Fläche für sekundäre Navigation oder Promotions.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Flexible max-width zwischen 68–76ch und adaptive Seitenränder auf allen Breakpoints.
+- **Accessibility:** Saubere Überschriftenhierarchie, ausreichend Zeilenabstand und lesbare Schriftgrößen.
+- **SEO:** Semantische Struktur mit <header>, <main>, <footer> und klarer h1–h3-Reihenfolge.
+- **Design-Guidelines:** Großzügige Weißräume, konsistente Typografie-Skala und ruhige Farbpalette.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Beginnt als vollbreite Spalte mit progressiver Begrenzung über max-width.
+- **Accessibility:** Nutzt Landmark-Rollen und Skip-Links für schnelle Navigation.
+- **SEO:** Verwendet strukturierte Überschriften und relevante Meta-Daten.
+- **Best Practices:** max-width clamp(), line-height ≥ 1.5, font-size über clamp() skalieren
+
+## Checkliste
+- [ ] Maximale Inhaltsbreite und Seitenabstände definiert.
+- [ ] Heading-Skala konsistent angewendet.
+- [ ] Kontrastwerte für Text und Links geprüft.
+- [ ] Core Web Vitals im grünen Bereich.
+
+## Abhängigkeiten / Überschneidungen
+- Globaler Header/Footer
+- Typografie-Token und Lesbarkeitsrichtlinien
+
+## Akzeptanzkriterien
+- Inhalte bleiben auf allen Breakpoints ohne horizontales Scrollen lesbar.
+- H1–H3-Struktur validiert und screenreaderfreundlich.
+- Layout reagiert flüssig auf Schriftgrößenänderungen.
+
+## Beispiel / Code
+```html
+<main class="container">
+  <article class="prose">
+    <h1>Titel</h1>
+    <p>Absatz…</p>
+  </article>
+</main>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Zeitloses Standard-Layout für leselastige Seiten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um One Column gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: One Column tastatur- und screenreader-freundlich gestalten.
+- Performance: One Column nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu One Column direkt neben dem Code dokumentieren.
+
+## Fazit
+One Column bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-portfolio-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-portfolio-layout.md
@@ -1,0 +1,76 @@
+---
+title: "Portfolio Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Portfolio Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-portfolio-layout
+original_path: layouts/relevant/portfolio-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Portfolio Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Portfolio Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Portfolio Layout
+
+## Beschreibung
+Projekte oder Referenzen werden als visuelle Kacheln und Fallstudien präsentiert. Ideal für Kreativschaffende, Agenturen oder Produktteams.
+
+## Warum dieses Layout?
+- Hebt Projekte visuell hervor und erlaubt kuratiertes Storytelling.
+- Unterstützt Filter und Tags für zielgerichtete Navigation.
+- Erfordert konsequente Bildpflege und aktuelle Inhalte.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Flexible Grids, die je nach Viewport von einer auf mehrere Spalten wechseln.
+- **Accessibility:** Karten als klickbare Elemente mit klaren Alternativtexten und Fokuszuständen.
+- **SEO:** Jede Referenz nutzt sprechende Titel, Metadaten und strukturierte Daten (CreativeWork).
+- **Design-Guidelines:** Konsistente Bildformate, Abstände und typografische Gewichtung für Projektinfos.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet einspaltig mit priorisiertem Projekt-Highlight.
+- **Accessibility:** Verwendet <figure>/<figcaption> für Medien und sichtbare Fokusrahmen.
+- **SEO:** Filteroptionen ohne Duplicate-Content-Fallen implementieren.
+- **Best Practices:** Lazy Loading von Bildern, Tag-basierte Filter klar kennzeichnen, Hover-Effekte mit Fokus synchronisieren
+
+## Checkliste
+- [ ] Bilder entsprechen vereinbarten Formaten.
+- [ ] Filter funktionieren mit Tastatur und Screenreadern.
+- [ ] Projekttexte sind aktuell und konsistent.
+- [ ] Performance- und Accessibility-Audit durchgeführt.
+
+## Abhängigkeiten / Überschneidungen
+- Filter-/Tagging-System
+- Card-Komponenten
+
+## Akzeptanzkriterien
+- Portfolio skaliert ohne Layout-Brüche.
+- Filterbare Listen aktualisieren Inhalte barrierefrei.
+- Jede Karte führt zu detaillierter Projektbeschreibung.
+
+## Beispiel / Code
+```html
+<section class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+  <article class="project-card">…</article>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Bewährtes Muster zur Präsentation kreativer Arbeiten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Portfolio Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Portfolio Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Portfolio Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Portfolio Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Portfolio Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-responsive-flexbox.md
+++ b/_posts/2025-09-30-layouts-relevant-responsive-flexbox.md
@@ -1,0 +1,77 @@
+---
+title: "Responsive Flexbox: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Responsive Flexbox unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-responsive-flexbox
+original_path: layouts/relevant/responsive-flexbox.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Responsive Flexbox** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Responsive Flexbox nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Responsive Flexbox
+
+## Beschreibung
+Ein flexbasiertes Grundlayout nutzt Flexbox für Zeilen- und Spaltenanordnungen. Geeignet für einfache Dashboards, Formularlayouts oder Utility-Bereiche.
+
+## Warum dieses Layout?
+- Schnell einzurichten und vielseitig für kleinere Module.
+- Erlaubt flexible Umsortierung und Ausrichtung ohne komplexes Grid.
+- Bei komplexen Layouts stößt Flexbox an Grenzen gegenüber CSS Grid.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Flex-Container nutzen wrap, gap und order, um Breakpoints abzudecken.
+- **Accessibility:** DOM-Reihenfolge bleibt logisch, auch wenn die visuelle Reihenfolge angepasst wird.
+- **SEO:** Semantische Container (<section>, <article>) innerhalb der Flexstruktur verwenden.
+- **Design-Guidelines:** Konsistente Gaps, Padding und Alignment-Regeln definieren.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Flexrichtung zunächst Spalte, erweitert sich zu Reihen erst bei größeren Viewports.
+- **Accessibility:** Visuelle Order-Änderungen nur einsetzen, wenn Fokusreihenfolge erhalten bleibt.
+- **SEO:** Inhalte klar strukturieren, da Flexbox keine semantische Bedeutung liefert.
+- **Best Practices:** flex-wrap aktivieren, Gap statt margin nutzen, Container Queries für Ausrichtung erwägen
+
+## Checkliste
+- [ ] Flex-Items brechen sauber um.
+- [ ] Order-Manipulation beeinflusst Fokus nicht.
+- [ ] Spacing entspricht Design-System.
+- [ ] Performance- und Accessibility-Check erledigt.
+
+## Abhängigkeiten / Überschneidungen
+- Utility-Klassen oder Design-Tokens
+- Layout-Komponenten
+
+## Akzeptanzkriterien
+- Layout verhält sich auf allen Breakpoints erwartungsgemäß.
+- Screenreader erleben logische Reihenfolge.
+- Flex-Gaps entsprechen definierten Abständen.
+
+## Beispiel / Code
+```html
+<section class="flex flex-col md:flex-row gap-4 flex-wrap">
+  <div class="flex-1">Block A</div>
+  <div class="flex-1">Block B</div>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Basispattern für viele responsive Komponenten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Responsive Flexbox gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Responsive Flexbox tastatur- und screenreader-freundlich gestalten.
+- Performance: Responsive Flexbox nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Responsive Flexbox direkt neben dem Code dokumentieren.
+
+## Fazit
+Responsive Flexbox bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-sidebar-dropdown-menu.md
+++ b/_posts/2025-09-30-layouts-relevant-sidebar-dropdown-menu.md
@@ -1,0 +1,79 @@
+---
+title: "Sidebar Dropdown Menu: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Sidebar Dropdown Menu unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-sidebar-dropdown-menu
+original_path: layouts/relevant/sidebar-dropdown-menu.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Sidebar Dropdown Menu** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Sidebar Dropdown Menu nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Sidebar Dropdown Menu
+
+## Beschreibung
+Eine vertikale Navigation mit ausklappbaren Unterpunkten strukturiert tiefe Inhaltsarchitekturen. Geeignet für Dokumentationen, Intranets oder komplexe Applikationen.
+
+## Warum dieses Layout?
+- Bietet schnellen Zugriff auf tiefe Hierarchien.
+- Lässt sich mit Such- und Filterfunktionen kombinieren.
+- Auf mobilen Geräten ist oft ein Off-Canvas-Pattern sinnvoller.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Sidebar kann zu Off-Canvas, Drawer oder Dropdown zusammenfallen.
+- **Accessibility:** Menü folgt WAI-ARIA-Menü- oder Treeview-Pattern, Fokusmanagement klar geregelt.
+- **SEO:** Interne Verlinkung stärkt Informationsarchitektur, aber Priorität liegt auf Hauptinhalten.
+- **Design-Guidelines:** Indentation, Icons und aktive Zustände klar definieren.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Navigation als Drawer oder Akkordeon ausspielen.
+- **Accessibility:** Tab- und Pfeiltastensteuerung implementieren, sichtbare Fokusrahmen.
+- **SEO:** Linktexte beschreibend formulieren und Hierarchie reflektieren.
+- **Best Practices:** Maximal zwei Ebenen expandierbar, Suchfeld optional integrieren, Aktiven Pfad hervorheben
+
+## Checkliste
+- [ ] Dropdowns lassen sich Tastatur-gesteuert öffnen und schließen.
+- [ ] Aktiver Navigationspfad ist visuell markiert.
+- [ ] Mobile Darstellung ist getestet.
+- [ ] A11y- und Performance-Checks dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Navigation-/Tree-Komponente
+- Suche oder Filtermodul
+
+## Akzeptanzkriterien
+- Alle Ebenen sind mit Screenreader zugänglich.
+- Fokus kehrt beim Schließen zum auslösenden Element zurück.
+- Navigation kollidiert nicht mit Content-Scroll.
+
+## Beispiel / Code
+```html
+<nav class="sidebar" aria-label="Hauptnavigation">
+  <button aria-expanded="false" aria-controls="nav-1">Bereich</button>
+  <ul id="nav-1" hidden>
+    <li><a href="#">Unterpunkt</a></li>
+  </ul>
+</nav>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Wichtig für umfangreiche Inhaltsstrukturen auf Desktop.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Sidebar Dropdown Menu gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Sidebar Dropdown Menu tastatur- und screenreader-freundlich gestalten.
+- Performance: Sidebar Dropdown Menu nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Sidebar Dropdown Menu direkt neben dem Code dokumentieren.
+
+## Fazit
+Sidebar Dropdown Menu bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-spa-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-spa-layout.md
@@ -1,0 +1,77 @@
+---
+title: "Spa Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Spa Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-spa-layout
+original_path: layouts/relevant/spa-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Spa Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Spa Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: SPA Shell Layout
+
+## Beschreibung
+Eine Single-Page-Application-Shell mit persistentem Header, Navigation und dynamischem Content-Bereich. Ideal für Web-Apps mit Client-Routing.
+
+## Warum dieses Layout?
+- Bietet app-ähnliches Nutzererlebnis mit schnellen Übergängen.
+- Ermöglicht Code-Splitting und dynamische Komponentenauslieferung.
+- Erfordert besondere Sorgfalt bei SEO und Initial-Ladezeit.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Shell-Elemente passen sich an mobile und Desktop-Viewports an, Navigation adaptiv.
+- **Accessibility:** Routenwechsel ankündigen, Fokusmanagement und Skip-Links implementieren.
+- **SEO:** SSR/SSG oder Prerendering nutzen, Meta-Handling pro Route.
+- **Design-Guidelines:** Konsistente Shell-Komponenten, Spacing und Zustände für Ladeindikatoren.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Navigation und Panels zuerst für Touch optimieren, Desktop mit erweiterten Flächen.
+- **Accessibility:** Fokus nach Navigationswechsel auf Hauptbereich setzen, Live-Region optional.
+- **SEO:** Sitemap und strukturierte Daten serverseitig bereitstellen.
+- **Best Practices:** Code-Splitting per Route, Skeleton- oder Spinner-States, Service Worker für Assets
+
+## Checkliste
+- [ ] Routing funktioniert mit Browser-Historie und Deep Links.
+- [ ] Fokus springt nach Route zum Hauptinhalt.
+- [ ] Loading-States kommunizieren Status klar.
+- [ ] Performance- und Accessibility-Audits durchgeführt.
+
+## Abhängigkeiten / Überschneidungen
+- Client-Router
+- State- und Data-Layer
+
+## Akzeptanzkriterien
+- Shell bleibt persistent, Content tauscht ohne Full Reload.
+- Screenreader werden über Routenwechsel informiert.
+- CWV-Ziele trotz Client-Routing erreichbar.
+
+## Beispiel / Code
+```html
+<div class="app-shell">
+  <header>Navigation</header>
+  <main id="app">Route-Content</main>
+</div>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Grundlage moderner Web-Applikationen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Spa Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Spa Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Spa Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Spa Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Spa Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-split-screen.md
+++ b/_posts/2025-09-30-layouts-relevant-split-screen.md
@@ -1,0 +1,77 @@
+---
+title: "Split Screen: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Split Screen unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-split-screen
+original_path: layouts/relevant/split-screen.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Split Screen** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Split Screen nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Split Screen
+
+## Beschreibung
+Zwei Bereiche teilen sich die Breite, häufig Text und Bild oder ein Formular neben einer Vorschau. Ideal für Produktvorstellungen, Kampagnen oder Vergleichsdarstellungen.
+
+## Warum dieses Layout?
+- Erzeugt einen starken visuellen Kontrast zwischen Inhalt und Medien.
+- Eignet sich für Storytelling mit parallelen Informationssträngen.
+- Erfordert auf kleinen Screens sauberes Stapeln, damit nichts verloren geht.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Bricht auf mobilen Geräten in eine vertikale Reihenfolge um.
+- **Accessibility:** DOM-Reihenfolge folgt der gewünschten Leselogik, Bilder mit aussagekräftigen Alternativtexten.
+- **SEO:** Klare Überschriftenstruktur und relevante Meta-Texte für beide Bereiche.
+- **Design-Guidelines:** Ausreichende Abstände, harmonische Typografie und abgestimmte Bildkomposition.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet gestapelt und erweitert sich ab mittleren Breakpoints auf zwei Spalten.
+- **Accessibility:** Sorgt für erkennbare Fokuszustände und sinnvolle Reihenfolge bei Tastaturbedienung.
+- **SEO:** Betont wichtige Botschaften im Textbereich und nutzt beschreibende Alt-Texte.
+- **Best Practices:** grid md:grid-cols-2 einsetzen, Bilder responsive laden, Scroll-Hinweise optional ergänzen
+
+## Checkliste
+- [ ] Bilder sind in passenden Größen optimiert.
+- [ ] Text bleibt auch bei Reduktion der Breite lesbar.
+- [ ] Tastaturnavigation folgt der inhaltlichen Reihenfolge.
+- [ ] Performance- und Accessibility-Check dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Medien- und CTA-Komponenten
+- Responsive Grid-Utilities
+
+## Akzeptanzkriterien
+- Split-Layout skaliert von mobil bis Desktop ohne Überlappungen.
+- Bild und Text erhalten ausreichenden Kontrast.
+- Screenreader greifen auf eine logische Reihenfolge zu.
+
+## Beispiel / Code
+```html
+<section class="grid md:grid-cols-2">
+  <div>Text</div>
+  <div><img src="../../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" /></div>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Starkes Muster für bildstarke Kampagnen und Vergleiche.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Split Screen gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Split Screen tastatur- und screenreader-freundlich gestalten.
+- Performance: Split Screen nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Split Screen direkt neben dem Code dokumentieren.
+
+## Fazit
+Split Screen bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-sticky-sidebar.md
+++ b/_posts/2025-09-30-layouts-relevant-sticky-sidebar.md
@@ -1,0 +1,76 @@
+---
+title: "Sticky Sidebar: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Sticky Sidebar unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-sticky-sidebar
+original_path: layouts/relevant/sticky-sidebar.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Sticky Sidebar** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Sticky Sidebar nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Sticky Sidebar
+
+## Beschreibung
+Eine Seitenleiste bleibt beim Scrollen sichtbar, während der Hauptinhalt weiterläuft. Sie eignet sich für Inhaltsverzeichnisse, Call-to-Actions oder sekundäre Navigation.
+
+## Warum dieses Layout?
+- Ermöglicht schnellen Zugriff auf Sprungziele oder CTAs.
+- Verbessert Orientierung bei langen Inhalten.
+- Kann auf kleinen Screens wertvollen Platz blockieren.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Sticky-Funktion nur auf großen Breakpoints aktiv, mobil alternative Platzierung.
+- **Accessibility:** Fokusreihenfolge bewahren, Sticky-Element darf Inhalt nicht überdecken.
+- **SEO:** Sidebar-Inhalte bleiben ergänzend und lenken nicht vom Hauptcontent ab.
+- **Design-Guidelines:** Ausreichend Abstand zwischen Sidebar und Content, klare Abgrenzung.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Sidebar zunächst unter Content platzieren, Sticky erst ab Desktop aktivieren.
+- **Accessibility:** Skip-Link zu Sidebar anbieten und Fokusindikatoren sichtbar halten.
+- **SEO:** Wichtige Links priorisieren und Redundanzen vermeiden.
+- **Best Practices:** position: sticky mit top-Offset, Scrollbereich begrenzen, Sticky auf Touch testen
+
+## Checkliste
+- [ ] Sticky-Offset verhindert Überdeckung durch Header.
+- [ ] Sidebar lässt sich mit Tastatur erreichen.
+- [ ] Mobil existiert eine sinnvolle Alternative.
+- [ ] Accessibility- und Performance-Prüfung erfolgt.
+
+## Abhängigkeiten / Überschneidungen
+- Table of Contents oder CTA-Module
+- Layout-Utilities
+
+## Akzeptanzkriterien
+- Sidebar bleibt auf Desktop sichtbar ohne zu flackern.
+- Mobil wird Sidebar sinnvoll eingereiht oder ausgeblendet.
+- Screenreader erkennen Sidebar als ergänzenden Bereich.
+
+## Beispiel / Code
+```html
+<aside class="sticky top-16">
+  <nav>…</nav>
+</aside>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Hilfreich für lange Artikel oder Dokumentationen.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Sticky Sidebar gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Sticky Sidebar tastatur- und screenreader-freundlich gestalten.
+- Performance: Sticky Sidebar nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Sticky Sidebar direkt neben dem Code dokumentieren.
+
+## Fazit
+Sticky Sidebar bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-tabbed-interface.md
+++ b/_posts/2025-09-30-layouts-relevant-tabbed-interface.md
@@ -1,0 +1,79 @@
+---
+title: "Tabbed Interface: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Tabbed Interface unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-tabbed-interface
+original_path: layouts/relevant/tabbed-interface.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Tabbed Interface** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Tabbed Interface nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Tabbed Interface
+
+## Beschreibung
+Inhalte werden in Reitern organisiert und lassen sich per Tabs wechseln. Ideal für vergleichbare Inhalte, Produktdetails oder komprimierte Informationsbereiche.
+
+## Warum dieses Layout?
+- Strukturiert komplexe Inhalte übersichtlich.
+- Reduziert Scrollwege und zeigt relevante Informationen kontextuell.
+- Versteckt Inhalte hinter Interaktion, daher gute Kommunikation nötig.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Tabs sind horizontal oder in Dropdowns/Accordions überführbar.
+- **Accessibility:** WAI-ARIA Tabs-Pattern mit role=tablist, tab und aria-controls nutzen.
+- **SEO:** Wichtige Inhalte bleiben crawlbar und werden nicht verzögert nachgeladen.
+- **Design-Guidelines:** Aktiver Tab klar markiert, konsistente Abstände und Hover/Fokus-Zustände.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Tabs stapeln oder in ein horizontales Scroll-Menü wechseln.
+- **Accessibility:** Keyboard-Steuerung mit Pfeiltasten, Home/End und Fokus-Management implementieren.
+- **SEO:** Tab-Inhalte im DOM belassen, optional lazy load sekundärer Ressourcen.
+- **Best Practices:** ARIA-Attribute korrekt setzen, Fokus sichtbar halten, State in URL optional spiegeln
+
+## Checkliste
+- [ ] Tab-Reihenfolge ist logisch und beschriftet.
+- [ ] Fokus springt beim Wechsel zum aktiven Panel.
+- [ ] Mobile Darstellung bleibt bedienbar.
+- [ ] Accessibility- und Performance-Tests abgeschlossen.
+
+## Abhängigkeiten / Überschneidungen
+- Tabs-Komponente
+- State-Management oder Router
+
+## Akzeptanzkriterien
+- Tabs erfüllen WAI-ARIA-Authoring-Practices.
+- Aktives Panel wird beim Wechsel sofort sichtbar.
+- Screenreader kündigen Tab-Status korrekt an.
+
+## Beispiel / Code
+```html
+<div class="tabs" role="tablist">
+  <button role="tab" aria-controls="panel-1" aria-selected="true">Tab 1</button>
+  <button role="tab" aria-controls="panel-2">Tab 2</button>
+</div>
+<section id="panel-1" role="tabpanel">Inhalt 1</section>
+<section id="panel-2" role="tabpanel" hidden>Inhalt 2</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Beliebtes Muster zur Verdichtung thematisch verwandter Inhalte.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Tabbed Interface gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Tabbed Interface tastatur- und screenreader-freundlich gestalten.
+- Performance: Tabbed Interface nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Tabbed Interface direkt neben dem Code dokumentieren.
+
+## Fazit
+Tabbed Interface bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-timeline-layout.md
+++ b/_posts/2025-09-30-layouts-relevant-timeline-layout.md
@@ -1,0 +1,79 @@
+---
+title: "Timeline Layout: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Timeline Layout unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-timeline-layout
+original_path: layouts/relevant/timeline-layout.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Timeline Layout** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Timeline Layout nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Timeline Layout
+
+## Beschreibung
+Ein Zeitstrahl stellt Meilensteine, Prozesse oder Historien in chronologischer Reihenfolge dar.
+
+## Warum dieses Layout?
+- Visualisiert Abläufe und Entwicklungen klar.
+- Unterstützt Storytelling mit Zeitbezug.
+- Kann bei zu viel Text unübersichtlich werden.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Timeline wechselt von horizontaler/zweispaltiger Darstellung zu vertikal gestapelten Events.
+- **Accessibility:** Semantisch als Liste oder geordnete Sektionen markieren, beschreibende Labels verwenden.
+- **SEO:** Events mit Datum, Überschrift und optionalen strukturierten Daten (Event/HowTo).
+- **Design-Guidelines:** Klare Marker, konsistente Abstände und ausreichender Kontrast zwischen Linien und Hintergrund.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Beginnt als vertikale Liste mit deutlich gekennzeichneten Zeitpunkten.
+- **Accessibility:** Fokusreihenfolge entlang des zeitlichen Verlaufs, Screenreader-Labels für Zeitangaben.
+- **SEO:** Zeiteinträge mit <time>-Elementen versehen.
+- **Best Practices:** Icons sparsam einsetzen, Tooltips für Details nur ergänzend, Scroll-Spy optional
+
+## Checkliste
+- [ ] Zeitpunkte sind chronologisch korrekt sortiert.
+- [ ] Lesbarkeit auf kleinen Screens gewährleistet.
+- [ ] Kontrastwerte der Marker geprüft.
+- [ ] Accessibility- und Performance-Test erledigt.
+
+## Abhängigkeiten / Überschneidungen
+- Timeline-Komponente
+- Icon- und Typografie-Tokens
+
+## Akzeptanzkriterien
+- Timeline lässt sich sowohl mit Maus als auch Tastatur durchlaufen.
+- Screenreader geben Datum und Beschreibung verständlich wieder.
+- Layout bricht auf mobilen Geräten nicht um.
+
+## Beispiel / Code
+```html
+<ol class="timeline">
+  <li>
+    <time datetime="2024-01-01">Jan 2024</time>
+    <p>Meilenstein</p>
+  </li>
+</ol>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Perfekt für Prozessdarstellungen und Unternehmenshistorien.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Timeline Layout gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Timeline Layout tastatur- und screenreader-freundlich gestalten.
+- Performance: Timeline Layout nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Timeline Layout direkt neben dem Code dokumentieren.
+
+## Fazit
+Timeline Layout bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-two-column-equal-width.md
+++ b/_posts/2025-09-30-layouts-relevant-two-column-equal-width.md
@@ -1,0 +1,77 @@
+---
+title: "Two Column Equal Width: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Two Column Equal Width unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-two-column-equal-width
+original_path: layouts/relevant/two-column-equal-width.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Two Column Equal Width** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Two Column Equal Width nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Two Column – Equal Width
+
+## Beschreibung
+Zwei gleich breite Spalten stellen Inhalt und begleitende Medien ausgewogen dar. Geeignet für Feature-Übersichten, Vergleiche oder Bild-Text-Kombinationen.
+
+## Warum dieses Layout?
+- Sorgt für visuelles Gleichgewicht zwischen Text und Medien.
+- Lässt sich modular mit Komponenten befüllen.
+- Kann bei langen Texten fragmentiert wirken und die Leseführung stören.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Spalten stapeln auf kleinen Screens und richten sich an Containergrößen aus.
+- **Accessibility:** DOM-Reihenfolge folgt der gewünschten Lesereihenfolge, unabhängig vom visuellen Layout.
+- **SEO:** Überschriften und Absätze klar strukturieren, damit beide Spalten verständlich bleiben.
+- **Design-Guidelines:** Gleichmäßige Spaltenabstände, ausreichend Luft für Medieninhalte.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Beginnt als einspaltiges Layout und erweitert sich ab definiertem Breakpoint auf zwei Spalten.
+- **Accessibility:** Verzichtet auf rein optische Reihenfolge-Manipulation zugunsten logischer Lesbarkeit.
+- **SEO:** Sichert konsistente h2/h3-Struktur auch bei geteilten Inhalten.
+- **Best Practices:** Container Queries nutzen, Bildgrößen responsiv skalieren, Spaltenhöhe flexibel halten
+
+## Checkliste
+- [ ] Leselänge der Textspalte geprüft.
+- [ ] Fokusreihenfolge entspricht inhaltlicher Priorität.
+- [ ] Medien sind responsiv und performant eingebunden.
+- [ ] Accessibility- und Performance-Metriken dokumentiert.
+
+## Abhängigkeiten / Überschneidungen
+- Medienkomponenten
+- Grid-System
+
+## Akzeptanzkriterien
+- Auf mobilen Geräten werden Spalten ohne Layout-Brüche gestapelt.
+- Content bleibt auch bei reduzierter Breite verständlich.
+- Screenreader geben die Inhalte in korrekter Reihenfolge wieder.
+
+## Beispiel / Code
+```html
+<section class="grid md:grid-cols-2 gap-6">
+  <div>Spalte A</div>
+  <div>Spalte B</div>
+</section>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Ausgewogenes Layout für kombinierte Text- und Medienblöcke.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Two Column Equal Width gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Two Column Equal Width tastatur- und screenreader-freundlich gestalten.
+- Performance: Two Column Equal Width nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Two Column Equal Width direkt neben dem Code dokumentieren.
+
+## Fazit
+Two Column Equal Width bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-two-column-left-sidebar.md
+++ b/_posts/2025-09-30-layouts-relevant-two-column-left-sidebar.md
@@ -1,0 +1,77 @@
+---
+title: "Two Column Left Sidebar: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Two Column Left Sidebar unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-two-column-left-sidebar
+original_path: layouts/relevant/two-column-left-sidebar.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Two Column Left Sidebar** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Two Column Left Sidebar nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Two Column – Left Sidebar
+
+## Beschreibung
+Dieses Layout kombiniert eine linke Sidebar für Navigation oder Filter mit einem rechten Inhaltsbereich. Es eignet sich für Shops, Wissensdatenbanken oder umfangreiche Kategorie-Seiten.
+
+## Warum dieses Layout?
+- Ermöglicht eine prominente Platzierung sekundärer Navigation.
+- Unterstützt schnelle Kontextwechsel zwischen Kategorien oder Filtern.
+- Erfordert auf mobilen Geräten ein sinnvolles Umsortieren der Spalten.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** CSS Grid oder Flex mit klar definierter Spaltenaufteilung und Umschaltung der Reihenfolge.
+- **Accessibility:** Sidebar als <aside> mit aria-labelledby und Fokusmanagement auszeichnen.
+- **SEO:** Sicherstellen, dass der Hauptinhalt im DOM vor der Sidebar kommt.
+- **Design-Guidelines:** Konsistente Spaltenabstände und visuelle Abgrenzung zwischen Navigation und Content.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Startet als gestapelte Ansicht, in der der Content vor der Sidebar steht.
+- **Accessibility:** Steuert die DOM-Reihenfolge per CSS order, nicht über inhaltliche Umstellungen.
+- **SEO:** Kennzeichnet Navigation mit strukturierten Listen und sprechenden Linktexten.
+- **Best Practices:** CSS order sparsam einsetzen, aria-labelledby für Sidebar-Titel, Off-Canvas-Alternative evaluieren
+
+## Checkliste
+- [ ] Spaltenreihenfolge auf mobilen Breakpoints geprüft.
+- [ ] Off-Canvas-Lösung für enge Viewports bewertet.
+- [ ] Fokusreihenfolge und Skip-Link getestet.
+- [ ] Performance- und Accessibility-Audit durchgeführt.
+
+## Abhängigkeiten / Überschneidungen
+- Filter- oder Navigationsmodule
+- Layout-Grid-Token
+
+## Akzeptanzkriterien
+- Auf mobilen Geräten erscheint der Hauptinhalt vor der Sidebar.
+- Desktop-Version hält stabile Spaltenbreiten bei unterschiedlichen Content-Längen.
+- Tastaturnavigation erreicht Sidebar-Elemente in logischer Reihenfolge.
+
+## Beispiel / Code
+```html
+<main class="grid grid-cols-12 gap-4">
+  <article class="col-span-12 md:col-span-8 order-1">Inhalt</article>
+  <aside class="col-span-12 md:col-span-4 order-0 md:order-2">Sidebar</aside>
+</main>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐⭐ Häufiger Standard in Shops und wissenslastigen Seiten.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Two Column Left Sidebar gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Two Column Left Sidebar tastatur- und screenreader-freundlich gestalten.
+- Performance: Two Column Left Sidebar nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Two Column Left Sidebar direkt neben dem Code dokumentieren.
+
+## Fazit
+Two Column Left Sidebar bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/_posts/2025-09-30-layouts-relevant-two-column-right-sidebar.md
+++ b/_posts/2025-09-30-layouts-relevant-two-column-right-sidebar.md
@@ -1,0 +1,77 @@
+---
+title: "Two Column Right Sidebar: Randnotiz"
+date: 2025-09-30
+tags: [UI, Komponente, Webentwicklung]
+excerpt: "Warum Two Column Right Sidebar unsere Layouts-Notizen inspiriert."
+layout: post
+categories: [layouts]
+slug: layouts-relevant-two-column-right-sidebar
+original_path: layouts/relevant/two-column-right-sidebar.md
+---
+
+## Einleitung
+Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **Two Column Right Sidebar** passte heute perfekt in unsere Layouts-Gedanken, und plötzlich roch der Raum nach Whiteboard-Markern und frisch gebrühtem Kaffee.
+
+## Technischer Kern
+Technisch betrachtet verlangt Two Column Right Sidebar nach klaren Leitplanken. Ich habe die ursprüngliche Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog sichtbar bleibt.
+
+### Originalnotizen
+# Layout: Two Column – Right Sidebar
+
+## Beschreibung
+Das Layout spiegelt die linke Sidebar-Variante und platziert zusätzliche Informationen rechts vom Content. Ideal für Produktseiten, Blogartikel mit Meta-Infos oder Supportbereiche.
+
+## Warum dieses Layout?
+- Bietet Platz für kontextuelle Hinweise oder CTAs neben dem Inhalt.
+- Unterstützt vertraute Leseführung mit Hauptfokus auf der linken Spalte.
+- Mobil müssen beide Spalten in sinnvoller Reihenfolge gestapelt werden.
+
+## Anforderungen & Besonderheiten
+- **Responsiveness:** Grid- oder Flex-Setup mit klaren Breakpoints für den Spaltenwechsel.
+- **Accessibility:** DOM-Reihenfolge belässt den Hauptinhalt zuerst; Sidebar erhält <aside>-Landmarke.
+- **SEO:** Sicherstellen, dass Search-Bots den Main-Content als primär erkennen.
+- **Design-Guidelines:** Konsistente Spaltenbreiten und ausreichende Abstände zwischen Content und Sidebar.
+
+## Umsetzung – Technische Leitplanken
+- **Mobile First:** Stackt Content und Sidebar vertikal, Content bleibt zuerst.
+- **Accessibility:** Tab-Reihenfolge überprüfen, insbesondere bei interaktiven Widgets in der Sidebar.
+- **SEO:** Semantische Struktur mit klarer Kennzeichnung von Haupt- und Nebeninhalten.
+- **Best Practices:** Spaltenbreiten per clamp(), Responsive Gaps für bessere Lesbarkeit, Sidebar-Inhalte priorisieren
+
+## Checkliste
+- [ ] Tab-Reihenfolge und Fokuszustände getestet.
+- [ ] Visuelle Priorisierung zwischen Content und Sidebar abgestimmt.
+- [ ] Mobile Stack wirkt nicht überladen.
+- [ ] Performance- und Accessibility-Prüfung bestanden.
+
+## Abhängigkeiten / Überschneidungen
+- Promo- oder Widget-Module
+- Globale Navigationsstruktur
+
+## Akzeptanzkriterien
+- Desktop-Spalten bleiben bei unterschiedlicher Höhe optisch ausbalanciert.
+- Mobil wird der Hauptinhalt vor der Sidebar dargestellt.
+- Screenreader erkennen die Sidebar als ergänzenden Bereich.
+
+## Beispiel / Code
+```html
+<main class="grid grid-cols-12 gap-4">
+  <article class="col-span-12 md:col-span-8">Inhalt</article>
+  <aside class="col-span-12 md:col-span-4">Sidebar</aside>
+</main>
+```
+
+Bewertung der Relevanz 2025
+
+⭐⭐⭐⭐☆ Bewährtes Muster für produktnahe Inhalte mit Zusatzinfos.
+
+## Anekdoten & Nerd-Zitate
+Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um Two Column Right Sidebar gestrickt, nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC dazu, weil die Nerd-Fakten selten stillstehen.
+
+## Best Practices
+- A11y: Two Column Right Sidebar tastatur- und screenreader-freundlich gestalten.
+- Performance: Two Column Right Sidebar nur laden, wenn der Kontext es wirklich braucht.
+- Wartbarkeit: Entscheidungen zu Two Column Right Sidebar direkt neben dem Code dokumentieren.
+
+## Fazit
+Two Column Right Sidebar bleibt ein schönes Beispiel dafür, wie Layouts-Elemente Geschichten erzählen können, wenn man sie ernst nimmt und trotzdem mit Humor betrachtet.

--- a/blog/categories.md
+++ b/blog/categories.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Kategorien
+permalink: /blog/categories/
+---
+<section class="blog-categories">
+  <h2>Kategorien</h2>
+  <ul class="blog-categories__list">
+    {% assign grouped = site.posts | group_by_exp: 'post', 'post.categories | join: ","' %}
+    {% for group in grouped %}
+      {% assign categories = group.name | split: ',' %}
+      <li class="blog-categories__item" id="{{ categories | join: '-' }}">
+        <h3 class="blog-categories__title">{{ categories | join: ', ' }}</h3>
+        <ul class="blog-categories__posts">
+          {% for post in group.items %}
+            <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a> · {{ post.date | date: '%d.%m.%Y' }}</li>
+          {% endfor %}
+        </ul>
+      </li>
+    {% endfor %}
+  </ul>
+</section>

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Blog
+permalink: /blog/
+---
+<section class="blog-index">
+  <h2>Neueste Beiträge</h2>
+  <ul class="blog-index__list">
+    {% for post in site.posts %}
+      <li class="blog-index__item">
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        <span class="blog-index__meta">{{ post.date | date: '%d.%m.%Y' }}</span>
+        <p class="blog-index__excerpt">{{ post.excerpt | strip_html | truncate: 200 }}</p>
+      </li>
+    {% endfor %}
+  </ul>
+</section>

--- a/scripts/generate_posts.py
+++ b/scripts/generate_posts.py
@@ -1,0 +1,108 @@
+import datetime
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+POSTS_DIR = ROOT / "_posts"
+POSTS_DIR.mkdir(exist_ok=True)
+
+SOURCE_DIRS = [
+    ROOT / "layouts",
+    ROOT / "content-elements",
+    ROOT / "frontend",
+]
+
+def slugify_path(path: Path) -> str:
+    relative = path.relative_to(ROOT)
+    without_suffix = relative.with_suffix("")
+    return "-".join(without_suffix.parts)
+
+def human_title(segment: str) -> str:
+    words = segment.replace("-", " ").replace("_", " ")
+    return " ".join(word.capitalize() if word.islower() else word for word in words.split())
+
+def build_text(name: str, category_title: str, original_path: Path, slug: str) -> str:
+    today = datetime.date.today().isoformat()
+    excerpt = f"Warum {name} unsere {category_title}-Notizen inspiriert.".replace('"', '\\"')
+
+    intro = (
+        f"Es fühlt sich an wie ein Fund in einer verstaubten Prototyp-Schublade: **{name}** "
+        f"passte heute perfekt in unsere {category_title}-Gedanken, und plötzlich roch der Raum "
+        "nach Whiteboard-Markern und frisch gebrühtem Kaffee."
+    )
+    technical = (
+        f"Technisch betrachtet verlangt {name} nach klaren Leitplanken. Ich habe die ursprüngliche "
+        f"Beschreibung unten angeheftet und mit Kommentaren versehen, damit der Transfer in das neue Blog "
+        "sichtbar bleibt."
+    )
+    anecdotes = (
+        f"Michael Crichton hätte wahrscheinlich eine komplette Katastrophensimulation um {name} gestrickt, "
+        f"nur um zu zeigen, wie viele Dinge gleichzeitig schiefgehen können. Douglas Coupland würde dagegen "
+        f"eine Slack-Konversation voller Insider-Gags daraus machen. Und irgendwo zwinkert eine alte RFC "
+        "dazu, weil die Nerd-Fakten selten stillstehen."
+    )
+    best_practices = [
+        f"A11y: {name} tastatur- und screenreader-freundlich gestalten.",
+        f"Performance: {name} nur laden, wenn der Kontext es wirklich braucht.",
+        f"Wartbarkeit: Entscheidungen zu {name} direkt neben dem Code dokumentieren."
+    ]
+    fazit = (
+        f"{name} bleibt ein schönes Beispiel dafür, wie {category_title}-Elemente Geschichten erzählen können, "
+        "wenn man sie ernst nimmt und trotzdem mit Humor betrachtet."
+    )
+
+    best_practices_md = "\n".join(f"- {line}" for line in best_practices)
+    original_content = original_path.read_text(encoding="utf-8").strip()
+
+    lines = [
+        "---",
+        f"title: \"{name}: Randnotiz\"",
+        f"date: {today}",
+        "tags: [UI, Komponente, Webentwicklung]",
+        "excerpt: \"" + excerpt + "\"",
+        "layout: post",
+        f"categories: [{category_title.lower().replace(' ', '-')}]",
+        f"slug: {slug}",
+        f"original_path: {original_path.relative_to(ROOT).as_posix()}",
+        "---",
+        "",
+        "## Einleitung",
+        intro,
+        "",
+        "## Technischer Kern",
+        technical,
+        "",
+        "### Originalnotizen",
+        original_content,
+        "",
+        "## Anekdoten & Nerd-Zitate",
+        anecdotes,
+        "",
+        "## Best Practices",
+        best_practices_md,
+        "",
+        "## Fazit",
+        fazit,
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    today = datetime.date.today().isoformat()
+    for source_dir in SOURCE_DIRS:
+        for path in sorted(source_dir.rglob("*.md")):
+            slug = slugify_path(path)
+            category = path.relative_to(ROOT).parts[0]
+            category_title = category.replace("-", " ").title()
+            name_segment = path.stem
+            name = human_title(name_segment)
+            content = build_text(name, category_title, path, slug)
+            target_name = f"{today}-{slug}.md"
+            target_path = POSTS_DIR / target_name
+            if target_path.exists():
+                continue
+            target_path.write_text(content, encoding="utf-8")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- configure a Jekyll-powered blog with site defaults, layouts, includes, and navigation while preserving the existing root index
- convert the existing markdown notes into posts that embed the original content alongside new editorial framing
- add a dedicated Jekyll build workflow and streamline the legacy examples workflow to stop regenerating the static index

## Testing
- bundle install *(fails: rubygems.org returns 403 in container)*