### PR TITLE
Refresh content element journals for six components

### DIFF
--- a/_posts/2025-09-30-content-elements-date-picker.md
+++ b/_posts/2025-09-30-content-elements-date-picker.md
@@ -1,87 +1,35 @@
 ---
-title: "Date Picker: Randnotiz"
+title: "Kalenderkollisionen und Kaffee: Mein Date-Picker-Feldbericht"
 date: 2025-09-30
-tags: [UI, Komponente, Webentwicklung]
-excerpt: "Warum Date Picker unsere Content Elements-Notizen inspiriert."
 layout: post
-categories: [content-elements]
+categories:
+  - content-elements
+tags:
+  - Content Element
+  - UX Engineering
+  - Accessibility
+excerpt: "Wie unser Date Picker zwischen Buchungskalendern, Filterlogs und Gesetzesblättern jongliert, ohne dass mir der Espresso kalt wird."
 slug: content-elements-date-picker
 original_path: content-elements/date-picker.md
 ---
 
-## Einleitung
-Als ich heute Morgen die Kaffeemaschine anwarf, vibrierte das Handy wie ein Pager aus den Neunzigern. Im Editor blinkte Date Picker und ich hörte innerlich die Titelmusik von ‚Akte X‘. Irgendwo zwischen dem Duft von frisch gemahlenen Bohnen und dem leisen Summen des Lüfters entschied ich: Diese Notiz wird eine Liebeserklärung an Date Picker im Rahmen unserer Content Elements-Expedition.
+## Szene: Morgenmeeting mit Zeitzonenzauber
+Der Tag begann mit einem Stand-up, bei dem niemand merkte, dass mein virtueller Hintergrund der eigene Debugger war. Während der Product Owner euphorisch über Paket-Tracking sprach, flüsterte mir der Date Picker eine andere Wahrheit: In sechs Ländern gelten andere Feiertage, und unser Hotelkunde möchte trotzdem fehlerfreie Slots. Ich grinste, nippte an Kaffee Nummer zwei und versprach dem Team, dass der Kalender auch dann nicht implodiert, wenn jemand um Mitternacht zwischen Berlin und São Paulo bucht.
 
-## Technischer Kern
-Technisch gesehen sitzt Date Picker genau an der Schnittstelle zwischen Ordnung und Emotion. Ich erinnere mich noch, wie wir im letzten Quartal eine Variante shippten, die auf dem Testgerät butterweich wirkte, auf einem alten Android aber ruckelte wie ein VHS-Band. Seitdem ist Mobile First mein Morgenritual; ich starte immer mit dem kleinsten Screen. Accessibility hält mich ehrlich: Ohne klare Fokuszustände oder Transkripte wird aus Eleganz sofort Chaos, und genau dann ruft jemand aus dem Support an. Die Originalnotizen unten dienen mir als Checkliste, doch meine heimliche Regel lautet: Wir alle tüfteln in unseren Kellern an der Zukunft. In diesem Keller sorge ich dafür, dass Date Picker stabil bleibt, selbst wenn ein Sturm aus Edge Cases tobt.
+## Feldnotizen aus dem Bau
+Die Komponente lebt davon, dass sie Buchungen, Terminplanungen und Reporting-Filter ohne Stolpern abwickelt. Wir halten aktive, deaktivierte und ausgewählte Tage visuell klar getrennt, markieren Monatswechsel dezent und lassen Range-Auswahlen logisch einrasten. Die Verantwortung endet nicht beim Pixel: Lokalisierung, Zeitbibliotheken und rechtliche Aufbewahrungspflichten hängen dran wie Anhang B in einem Vertrag – unromantisch, aber unverzichtbar. Wer unsaubere Kalenderlogik shippt, sorgt für Support-Drama, also prüfen wir jede State-Transition doppelt.
 
-### Originalnotizen
-Bevor wir uns im Meme-Verhau verlieren, bleiben die originalen Notizen unbeschnitten erhalten:
-# Content-Element: Date Picker
+## Mobile-First-Fahrplan
+Ich starte konsequent auf dem kleinsten Viewport und nutze native Picker, wenn das Gerät sie hergibt. Fällt das weg, rendern wir eine Vollbild- oder Listenansicht, die mit Daumen-Gesten funktioniert, ohne dass man das Display umarmen muss. Range-Auswahlen unterstützen Drag-Gesten, und auf Geräten mit schwacher GPU vermeiden wir Transition-Overkill, damit der Kalender nicht wie ein VHS-Remix ruckelt. Größere Viewports bekommen erst später Monatsübersicht, Shortcut-Leiste und Quick-Jump.
 
-## Beschreibung
-Komponente zur Auswahl einzelner Daten oder Zeitspannen.
+## Accessibility & Fürsorge
+Der Screenreader erzählt die Monatsreise via `aria-live`, jeder Tag pflegt sein `aria-selected`, und Fokusindikatoren sind so deutlich wie eine Stadionanzeige. Tastaturnavigation folgt den Pfeiltasten, `Home` und `End` springen an den Anfang oder das Ende der Woche – keine versteckten Moves. Fehlerstates beschreiben wir in Klartext, inklusive Tipp zu erlaubten Formaten, damit Formularvalidierung nicht zum Escape Room wird. Selbst Hinweise aus Transkripten der Voice-Sessions landen wieder im Backlog.
 
-## Warum dieses Element?
-- Buchungen oder Terminplanungen ermöglichen.
-- Filter nach Zeitraum in Reports oder Dashboards anbieten.
-- Trade-off: Komplexe Kalenderlogik kann Fehler hervorrufen und ist schwer barrierefrei umzusetzen.
+## Technik, Validierung & Betrieb
+Min- und Max-Daten schützen uns vor Reisebuchungen für 1997, während serverseitige Validierung Doppelbuchungen einfängt. Datumsformate passen sich pro Locale an – ISO für API, lesbar für Menschen – und wir synchronisieren alles mit Zeitzonen-Services. Range-Picker speichern Zwischenstände, falls jemand den Browser schließt, und Logs helfen uns, Grenzfälle wie Schaltjahre und Sommerzeit zu enttarnen. Rechtlich dokumentieren wir, wann welche Eingabe gespeichert wurde; TLS und Audit-Trails sind gesetzt.
 
-## Anforderungen & Besonderheiten
-- **Responsiveness:** Kalender auf Mobile als Vollbild oder Listenansicht.
-- **Accessibility:** Tastaturbedienung (Pfeiltasten), Screenreader-Beschriftungen, Ansagen der Auswahl.
-- **SEO:** Keine direkte Relevanz.
-- **Design-Guidelines:** Hervorhebung von aktiven, ausgewählten und deaktivierten Tagen, klare Navigation.
-- **Rechtliches:** Bei Buchungen gesetzliche Aufbewahrung von Daten beachten.
-
-## Umsetzung – Technische Leitplanken
-- **Mobile First:** Native Picker nutzen, wenn verfügbar, oder optimierte Touch-Gesten.
-- **Accessibility:** `aria-live` für Monatswechsel, `aria-selected` für Tage pflegen.
-- **SEO:** Nicht relevant.
-- **Best Practices:**
-  - Min-/Max-Daten definieren.
-  - Datumsformat klar kommunizieren.
-  - Range-Auswahl mit Drag oder zwei Feldern ermöglichen.
-
-## Checkliste
-- [ ] Darstellung auf allen Breakpoints geprüft
-- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
-- [ ] Semantik korrekt (HTML)
-- [ ] Performance optimiert (Lazyload/Kompression)
-
-## Abhängigkeiten / Überschneidungen
-- Lokalisierung, Zeitbibliothek
-
-## Akzeptanzkriterien
-- Technische Funktion OK
-- Konsistenz zum Designsystem
-- A11y & rechtliche Vorgaben erfüllt
-
-## Beispiel / Code
-[content-elements-examples/date-picker.html](../content-elements-examples/date-picker.html)
-
-```html
-<!-- Minimales, valides HTML-Beispiel -->
-<label for="date">Datum</label>
-<input id="date" name="date" type="date">
-```
-
-Bewertung der Relevanz 2025
-
-⭐⭐⭐⭐ Datumsauswahl bleibt komplex, aber unverzichtbar für Transaktionen.
-
-## Anekdoten & Nerd-Zitate
-- Im Retro-Meeting tippte jemand: „Date Picker war mein Bosslevel.“ – Ich antwortete: „Nur weil du den Accessibility-Check nach Mitternacht gemacht hast.“
-- In meinem inneren Katastrophenskript gibt es immer eine Szene, in der Date Picker ausfällt und der Shop nervös wird. In der Realität helfen uns Logs und Gelassenheit.
-- Beim Debuggen flüstert mir eher das Bauchgefühl zu: „Wir leben zwischen Bugfixes, also mach sie hübsch.“ Das gilt besonders, wenn der Mobile-Test im Bus stattfindet.
-- O-Ton eines Kunden: „Seit Date Picker sauber läuft, fühlt sich unser Interface an wie eine gute Playlist.“ Besseres Lob gibt es nicht.
-
-## Best Practices
-- **Altgeräte-Test:** Wenn Date Picker auf dem alten iPhone aus der Agentur-Schublade gut läuft, kannst du halbwegs ruhig schlafen.
-- **Semantik rockt:** HTML-Struktur ernst nehmen, ARIA nur ergänzen. Alles andere ist wie ein Special-Effect ohne Plot.
-- **Content-Strategie:** Besprich früh, welche Texte, Bilder oder Daten hier landen. Überraschungen mag höchstens der Cliffhanger im Serienfinale.
-- **Fallbacks vorbereiten:** Offline, Low-Bandwidth, reduzierte Animation – Mobile First bedeutet, mit wenig auszukommen.
-- **QA-Checklisten:** Hack dir eine Checkliste ins Repo, damit niemand vergisst, warum Date Picker existiert.
-
-## Fazit
-Wenn ich den Tag Revue passieren lasse, sehe ich Date Picker wie eine verlässliche Nebenfigur, die dem Plot erst Sinn gibt. Wir haben gelernt, dass Resilienz aus Routine entsteht: frühe Tests, offene Kommunikation, echte Devices. Beim nächsten Sprint will ich die Kopplung zu Datenquellen sauberer aufsetzen und weiter beweisen, dass Barrierefreiheit kein Extra ist, sondern Haltung.
+## Takeaways
+- Buchungs- und Reporting-Szenarien bleiben die Hauptbühne – mit klar getrennten States lässt sich beides gleichzeitig bedienen.
+- Mobile-First heißt hier: Vollbild-Flow zuerst perfektionieren, Desktop-Extras später einklappen.
+- Ohne `aria-live`, Tastaturpfad und sprechende Fehlermeldungen kippt die Formularvalidierung schneller als ein Espresso-shot.
+- Lokalisierung, Zeitbibliothek und Audit-Trail bilden das Sicherheitsnetz für rechtliche und technische Ausrutscher.

--- a/_posts/2025-09-30-content-elements-dropdown-select.md
+++ b/_posts/2025-09-30-content-elements-dropdown-select.md
@@ -1,90 +1,35 @@
 ---
-title: "Dropdown Select: Randnotiz"
+title: "Dropdown-Detektivarbeit im Formular-Labyrinth"
 date: 2025-09-30
-tags: [UI, Komponente, Webentwicklung]
-excerpt: "Warum Dropdown Select unsere Content Elements-Notizen inspiriert."
 layout: post
-categories: [content-elements]
+categories:
+  - content-elements
+tags:
+  - Content Element
+  - Form UX
+  - Interaction Design
+excerpt: "Weshalb ein simples Dropdown zwischen Filterträumen, Validierung und Tastatur-Hitze besteht – und ich trotzdem lache."
 slug: content-elements-dropdown-select
 original_path: content-elements/dropdown-select.md
 ---
 
-## Einleitung
-Zwischen Straßenbahn, Supermarktkasse und Handy-Display schrieb ich die ersten Zeilen auf dem Smartphone, während in Bremen der Duft von frisch gemahlenem Kaffee durch die Luft zog. Dropdown Select blinkte mir entgegen wie ein Mixtape aus einer vergessenen Schublade, und klar war: Heute bekommt Dropdown Select die große Bühne in unserem Content Elements-Tagebuch.
+## Szene: Abendshift im QA-Zentrum
+Gegen 22 Uhr saß ich im abgedunkelten Büro, nur begleitet vom Surren des Luftfilters und einer Playlist mit 90er-Radiojingles. Auf dem Testgerät blinkte das Filtermenü, während eine Slack-Nachricht fragte, ob wir die Sortierung noch ändern können. Ich schwor, die letzte Checkbox richtig zu beschriften, legte mir das Headset zurecht und machte mich bereit für eine Nacht voller Tabulator-Slalom.
 
-## Technischer Kern
-Dropdown Select klingt harmlos, doch in Wahrheit ist es das Klebeband zwischen Layout und Vertrauen. Damals, als wir eine spontane Nachtmigration fahren mussten, zeigte sich, wie sensibel die Details sind: Ein falsch gesetzter Breakpoint, und das mobile Layout fühlte sich an wie Nokia Snake auf einem faltbaren Display. Seitdem teste ich Mobile First auf dem ältesten Gerät im Büro. Accessibility ist keine Checkbox, sondern der Moment, in dem mir eine Screenreader-Nutzerin dankte, weil sie den Flow ohne Frust durchlaufen konnte. Wir sagen intern gern: Der wirkliche Wahnsinn im Code beginnt erst nach Mitternacht – und genau da merkten wir, wie Dropdown Select mit sauberen `aria`-Labels plötzlich Orientierung stiftete. Statt Zitaten gab es Fäuste in der Luft und einen stillen High-Five übers Debug-Log.
+## Feldnotizen aus dem Bau
+Dropdown Select bedient gleich zwei Welten: Es strukturiert Formulare mit festen Werten und verfeinert Produkt- oder Suchlisten. Damit das funktioniert, gruppieren wir Optionen sinnvoll via `optgroup`, begrenzen die Trefferliste und bieten ab zehn Einträgen eine Suche an. Standardzustände kennzeichnen wir deutlich – niemand soll glauben, dass „Bitte wählen“ eine echte Auswahl ist. Custom-Varianten bekommen das Pfeil-Icon im Designsystem und denselben Höhenrhythmus wie Buttons und Inputs.
 
-### Originalnotizen
-Bevor wir uns im Meme-Verhau verlieren, bleiben die originalen Notizen unbeschnitten erhalten:
-# Content-Element: Dropdown Select
+## Mobile-First-Fahrplan
+Auf kleinen Screens bleibt die native Komponente König, weil sie von Natur aus eine Touch-optimierte Liste liefert und sogar Einhand-Bedienung zulässt. Wenn das Projekt zwingend ein Custom-Control will, kapseln wir das Menü im Vollbild, damit sich niemand durch Mini-Scrollleisten quälen muss. Nur auf größeren Viewports tauchen wir in Multi-Spalten-Varianten oder platzierte Inline-Facetten ein. Scrollhöhe bleibt gedeckelt, damit kein Finger Marathon laufen muss.
 
-## Beschreibung
-Auswahlliste als Native-Select oder erweiterte Combobox.
+## Accessibility & Fürsorge
+Jedes Dropdown hat eine klare `label`-Zuordnung, `aria-expanded` signalisiert Offenheit, und `aria-describedby` verweist auf Hilfetexte. Tastatur-Nutzer navigieren mit Pfeilen oder tippen Buchstaben, um zur richtigen Option zu springen. Fehlertexte erscheinen unmittelbar nach dem Feld, inklusive Hinweisen zu Pflichtfeldern oder ungültigen Kombinationen – Formularvalidierung ohne Ratespiel. Für Comboboxen stellen wir sicher, dass Screenreader den aktiven Vorschlag ansagen und die Liste nach ESC sauber schließt.
 
-## Warum dieses Element?
-- Filter- oder Sortieroptionen bereitstellen.
-- Formulareingaben mit vorgegebenen Werten strukturieren.
-- Trade-off: Custom Selects können A11y-Probleme verursachen, wenn native Funktionen ersetzt werden.
+## Technik, Validierung & Betrieb
+Serverseitig prüfen wir Werte gegen Whitelists und schneiden Sonderzeichen weg, bevor sie in die API rutschen. Edge-Cases wie dynamische Option-Listen speichern wir im State-Management und schreiben den aktiven Filter in die URL, damit Analytics und SEO-Teams wissen, was passiert. Fallback auf native Select geschieht automatisch, wenn JavaScript ausfällt. Performance bleibt entspannt, weil wir Optionen lazy nachladen, sobald Filter-Facets mitspielen, und weil keine Liste mehr als 200 Einträge schluckt.
 
-## Anforderungen & Besonderheiten
-- **Responsiveness:** Volle Breite auf kleinen Screens, Listenhöhe begrenzen.
-- **Accessibility:** `label`-Zuordnung, `aria-expanded`, Tastaturnavigation.
-- **SEO:** Kein direkter Einfluss.
-- **Design-Guidelines:** Pfeil-Icon, States (hover/focus/disabled), konsistente Höhe.
-- **Rechtliches:** Keine speziellen Anforderungen.
-
-## Umsetzung – Technische Leitplanken
-- **Mobile First:** Native Select bevorzugen, da optimierte Mobile UI vorhanden.
-- **Accessibility:** Combobox-Rollen nur verwenden, wenn Funktionalität vollständig unterstützt.
-- **SEO:** Nicht relevant.
-- **Best Practices:**
-  - Optionen logisch gruppieren (`optgroup`).
-  - Leeren Default-State klar kennzeichnen.
-  - Maximale Optionsanzahl begrenzen oder Suche anbieten.
-
-## Checkliste
-- [ ] Darstellung auf allen Breakpoints geprüft
-- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
-- [ ] Semantik korrekt (HTML)
-- [ ] Performance optimiert (Lazyload/Kompression)
-
-## Abhängigkeiten / Überschneidungen
-- Form-Controller, Such-API (optional)
-
-## Akzeptanzkriterien
-- Technische Funktion OK
-- Konsistenz zum Designsystem
-- A11y & rechtliche Vorgaben erfüllt
-
-## Beispiel / Code
-[content-elements-examples/dropdown-select.html](../content-elements-examples/dropdown-select.html)
-
-```html
-<!-- Minimales, valides HTML-Beispiel -->
-<label for="country">Land</label>
-<select id="country" name="country">
-  <option value="">Bitte wählen</option>
-  <option value="de">Deutschland</option>
-</select>
-```
-
-Bewertung der Relevanz 2025
-
-⭐⭐⭐⭐ Dropdowns bleiben häufig, doch Usability hängt von sauberer Umsetzung ab.
-
-## Anekdoten & Nerd-Zitate
-- In meinen Notizen steht noch der Satz: „Dropdown Select riecht nach Filterkaffee und Ticket-Alarm.“ Das war der Abend vor dem Launch.
-- Wir haben uns selbst beobachtet, wie wir mit Taschenlampen (a.k.a. Gerätepark) durch die QA-Nacht stapfen.
-- Niemand von außen textet für uns, aber unsere Slack-Emojis halten uns wach, wenn wir wieder Mobile-Bugs jagen.
-- Eine Kollegin sagte: „Accessibility fühlt sich an wie barfuß laufen – du merkst jeden Stein.“ Seitdem prüfe ich Dropdown Select ohne Maus.
-
-## Best Practices
-- **Accessibility lebt von Ritualen:** Prüfe Dropdown Select mit Tastatur und Screenreader, bevor du überhaupt an Pixel-Politur denkst. Deine künftige Selbstachtung wird es dir danken.
-- **Mobile First aus Überzeugung:** Beginne mit dem kleinsten Viewport und frage dich ernsthaft, ob du das Element auch im U-Bahn-Gedränge bedienen könntest.
-- **Performance mit Hausverstand:** Lade nur, was wirklich gebraucht wird, sonst fühlt sich Dropdown Select an wie ein Buffering-Screen aus der Modem-Ära.
-- **Dokumentation neben dem Code:** Schreib dir dazu, warum Entscheidungen gefallen sind; sonst fragst du dich in drei Monaten selbst, was du damit meintest.
-- **Team-Sync:** Stell sicher, dass Design, Content und Dev dieselben Erwartungen haben – sonst erzählt jeder eine andere Story über Dropdown Select.
-
-## Fazit
-Dropdown Select bleibt ein stiller Held, der uns daran erinnert, warum wir Interfaces mit Herzblut bauen. Ich nehme mir vor, künftig noch radikaler auf echte Nutzungsszenarien zu hören – besonders, wenn das Monitoring ruhig ist. Accessibility, Mobile First, Humor: Diese drei Dinge halten den Laden zusammen.
+## Takeaways
+- Dropdowns tragen Filter und Formulare zugleich – klare Gruppen und Limits halten sie verständlich.
+- Mobile-First bedeutet hier: native Controls nutzen und Custom-Layouts erst ab Tablet einblenden.
+- Barrierefreiheit gewinnt, wenn `aria`-Zustände, Tastatur-Shortcuts und direkte Fehlermeldungen zusammenspielen.
+- Edge-Cases landen in URL-State, Servervalidierung und Logging – so bleibt kein Schattenwert unbemerkt.

--- a/_posts/2025-09-30-content-elements-empty-state.md
+++ b/_posts/2025-09-30-content-elements-empty-state.md
@@ -1,91 +1,35 @@
 ---
-title: "Empty State: Randnotiz"
+title: "Wenn der Screen leer bleibt: Empty-State-Feldnotizen"
 date: 2025-09-30
-tags: [UI, Komponente, Webentwicklung]
-excerpt: "Warum Empty State unsere Content Elements-Notizen inspiriert."
 layout: post
-categories: [content-elements]
+categories:
+  - content-elements
+tags:
+  - Content Element
+  - UX Writing
+  - Service Design
+excerpt: "Wie ein gut erzählter Empty State Suchmasken rettet, Dashboards erklärt und mich trotz Kaffeeentzug lachen lässt."
 slug: content-elements-empty-state
 original_path: content-elements/empty-state.md
 ---
 
-## Einleitung
-Zwischen Straßenbahn, Supermarktkasse und Handy-Display schrieb ich die ersten Zeilen auf dem Smartphone, während in Bremen der Duft von frisch gemahlenem Kaffee durch die Luft zog. Empty State blinkte mir entgegen wie ein Mixtape aus einer vergessenen Schublade, und klar war: Heute bekommt Empty State die große Bühne in unserem Content Elements-Tagebuch.
+## Szene: Support-Call zwischen zwei Straßenbahnhaltestellen
+Ich stand im Regen, AirPods im Ohr, und hörte zu, wie ein Kunde erklärte, dass neue Nutzer in seinem Dashboard verloren gingen. Während die Bahn Verspätung hatte, skizzierte ich auf dem Handy-Screen einen neuen Empty State – Headline, Text, Button, fertig? Nicht ganz. Wir lachten kurz über die Wetterlage, dann versprach ich, dass niemand mehr ratlos auf eine blanke Fläche starren muss.
 
-## Technischer Kern
-Empty State ist einer dieser Bausteine, die niemand beachtet, bis sie fehlen. Wir haben das schmerzhaft gelernt, als ein Kunde das Feature ohne ARIA ausgeliefert hat und ein Feedback-Call zur Selbsthilfegruppe wurde. Seitdem legen wir das Mobile-Layout zuerst fest, tasten uns mit echten Fingern durch Buttons und Links und feiern jeden Moment, in dem der Screenreader flüssig vorliest. Ich halte mich an die Spezifikationen, aber ich erzähle sie wie Lagerfeuergeschichten: mit klaren HTML-Strukturen, sauberen States und einer Prise Humor. Und während ich daran denke, dass wir alle an halb fertigen Interfaces arbeiten, mahnt mich eine innere Stimme, jede Abhängigkeit dreimal zu prüfen.
+## Feldnotizen aus dem Bau
+Empty States sind unsere freundlichen Platzhalter, wenn eine Suche keine Ergebnisse liefert oder ein frischer Account noch keine Daten hat. Wir kombinieren Headline, Bodytext und optionalen CTA, abgestimmt auf das Illustration-Set aus dem Designsystem. Zu schrille Visuals lenken ab, also bleiben wir bei klaren Linien und Farben. Hilfelinks stehen bereit, damit Support nicht zum Flaschenhals wird, und der Ton bleibt empathisch – schließlich sind Nutzer ohnehin schon in einer Null-Daten-Situation.
 
-### Originalnotizen
-Unterhalb dieser Zeile wohnt das Rohmaterial – nach wie vor mein Truthahnthermometer für saubere Implementierung:
-# Content-Element: Empty State
+## Mobile-First-Fahrplan
+Auf kleinen Screens stapeln wir Elemente vertikal, Buttons laufen full-width, und Texte bleiben knackig, damit niemand scrollen muss, um die Aktion zu finden. Illustrationen werden responsive skaliert oder bei sehr schmalen Viewports ausgeblendet, damit die Botschaft nicht untergeht. Erst ab Tablet-Größe gönnen wir uns mehr Weißraum oder zusätzliche Tipps.
 
-## Beschreibung
-Darstellung, wenn keine Daten oder Ergebnisse vorliegen.
+## Accessibility & Fürsorge
+Auch wenn kein Bild angezeigt wird, liefern wir Screenreader-freundliche Texte, die die Situation beschreiben und eine klare Handlungsoption anbieten. Fokusreihenfolge startet beim erklärenden Absatz, gefolgt vom primären Button, damit niemand durch dekorative Elemente tabben muss. Tooltips oder Inline-Hilfe stehen in Textform bereit – keine ikonografischen Rätsel. Für internationale Teams übersetzen wir die Botschaften früh, weil Humor im Deutschen selten genauso im Französischen funktioniert.
 
-## Warum dieses Element?
-- Suche ohne Treffer informativ gestalten.
-- Neue Nutzer in Dashboards an Funktionen heranführen.
-- Trade-off: Unpassende Illustrationen oder Texte können Nutzer verwirren.
+## Technik, Validierung & Betrieb
+Empty States hängen am gleichen Rendering-Pfad wie die Datenlisten: Wir prüfen Serverantworten und zeigen nur dann den leeren Zustand, wenn wirklich keine Items vorliegen. Feature-Flags erlauben uns, CTA-Experimente zu fahren, ohne alle Nutzer zu überraschen. Performance behalten wir im Blick, indem Illustrationen lazy geladen werden und Monitoring mitloggt, wie oft Nutzer direkt in Hilfelinks abbiegen.
 
-## Anforderungen & Besonderheiten
-- **Responsiveness:** Illustrationen und Text skalieren, Buttons darunter anordnen.
-- **Accessibility:** Alternativtexte für Illustrationen, klare Anweisungen auch in Text.
-- **SEO:** Keine direkte Relevanz.
-- **Design-Guidelines:** Illustration, Headline, Body-Text, CTA optional, konsistente Farben.
-- **Rechtliches:** Keine speziellen Anforderungen.
-
-## Umsetzung – Technische Leitplanken
-- **Mobile First:** Kurze Texte, klare Handlungsoptionen, Buttons full-width.
-- **Accessibility:** Keine rein ikonografischen Aussagen; Text beschreibt Situation.
-- **SEO:** Nicht relevant.
-- **Best Practices:**
-  - Konkrete nächste Schritte anbieten.
-  - Optional Hilfelinks einblenden.
-  - Tonfall empathisch wählen.
-
-## Checkliste
-- [ ] Darstellung auf allen Breakpoints geprüft
-- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
-- [ ] Semantik korrekt (HTML)
-- [ ] Performance optimiert (Lazyload/Kompression)
-
-## Abhängigkeiten / Überschneidungen
-- Illustrationen, CTA-Komponenten
-
-## Akzeptanzkriterien
-- Technische Funktion OK
-- Konsistenz zum Designsystem
-- A11y & rechtliche Vorgaben erfüllt
-
-## Beispiel / Code
-[content-elements-examples/empty-state.html](../content-elements-examples/empty-state.html)
-
-```html
-<!-- Minimales, valides HTML-Beispiel -->
-<section class="empty-state">
-  <img src="../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy">
-  <h2>Keine Ergebnisse</h2>
-  <p>Passen Sie Ihre Filter an oder starten Sie eine neue Suche.</p>
-  <button type="button">Filter zurücksetzen</button>
-</section>
-```
-
-Bewertung der Relevanz 2025
-
-⭐⭐⭐⭐ Gute Empty States steigern Engagement und helfen bei der Orientierung.
-
-## Anekdoten & Nerd-Zitate
-- Wir haben einmal eine interne Nostalgie-Matrix gebaut, um Empty State gegen Erinnerungsglitzer zu testen. Ergebnis: 42 Prozent erinnern an MP3-Player aus 2003.
-- Mein Lieblings-Feedback kam aus dem Support: „Endlich muss ich niemandem mehr erklären, wo Empty State versteckt ist.“
-- Wenn das Monitoring blinkt, fühlt es sich kurz wie im Katastrophenfilm an – diesmal blieb der Alarm still.
-- Altundwillig.de hätte es so zusammengefasst: „Mach es benutzbar oder lass es bleiben.“
-
-## Best Practices
-- **Design Tokens nutzen:** Lass Empty State aus dem Designsystem atmen, nicht aus spontanen HEX-Codes.
-- **Keyboard-Liebe:** Jede Interaktion muss per Tab erreichbar sein – ein Modal ohne Escape ist ein Support-Ticket in spe.
-- **Performance messen:** Lighthouse, WebPageTest, was immer du hast – Hauptsache du kennst deine Zahlen.
-- **Copy & Microcopy:** Stimme dich mit Content ab, damit die Sprache genauso flüssig ist wie das Interface.
-- **Post-Launch-Retros:** Plane von Anfang an ein, die Komponente nach den ersten echten Nutzerkontakten anzupassen.
-
-## Fazit
-Zum Schluss fühlt sich Empty State an wie ein gut geölter Plattenspieler: nicht prahlerisch, aber unverzichtbar. Wir haben wieder gelernt, dass Disziplin bei Breakpoints und `aria`-Attributen genau der Unterschied zwischen Frust und Flow ist. Beim nächsten Rollout gönne ich mir mehr Zeit für User-Feedback, bevor der nächste Sturm aus Edge Cases anklopft.
+## Takeaways
+- Empty States erklären Suche und Dashboards, bevor Frust entsteht – klare Texte plus optionale Hilfelinks sind Pflicht.
+- Mobile-First bedeutet kurze Botschaften, Full-Width-Buttons und nur so viel Illustration, wie der Screen verträgt.
+- Barrierefreiheit funktioniert, wenn Fokus, Sprache und Hilfen ohne dekorative Umwege auskommen.
+- Datenpfad, Feature-Flags und Monitoring halten den Zustand ehrlich und geben Support-Team und Produkt klare Signale.

--- a/_posts/2025-09-30-content-elements-file-uploader.md
+++ b/_posts/2025-09-30-content-elements-file-uploader.md
@@ -1,90 +1,35 @@
 ---
-title: "File Uploader: Randnotiz"
+title: "Upload im Gegenlicht: Feldbericht aus der Dateizone"
 date: 2025-09-30
-tags: [UI, Komponente, Webentwicklung]
-excerpt: "Warum File Uploader unsere Content Elements-Notizen inspiriert."
 layout: post
-categories: [content-elements]
+categories:
+  - content-elements
+tags:
+  - Content Element
+  - File Handling
+  - Security
+excerpt: "Warum unser File Uploader Bewerbungen, Support-Tickets und DSGVO mit einem Augenzwinkern balanciert."
 slug: content-elements-file-uploader
 original_path: content-elements/file-uploader.md
 ---
 
-## Einleitung
-Noch bevor Slack das erste Ping losließ, balancierte ich zwischen Straßenbahn und improvisiertem Stehtisch und schrieb die ersten Stichworte ins Smartphone. Auf dem Screen wartete File Uploader; kein Thriller, sondern das nächste Kapitel für C.ntent Elements.
+## Szene: Videocall mit Katzenfilter
+Kurz vor Feierabend schaltete sich ein Kunde in den Call – inklusive aktivierter Katzenohren. Wir redeten über chunked Uploads für hochauflösende Produktfotos, während ich versuchte, nicht über das Schnurren im Mikrofon zu lachen. Das Deployment stand bereit, die Logs warteten, und ich versprach, dass keine Bewerbung im Upload-Limbo stecken bleibt.
 
-## Technischer Kern
-Jede Roadmap hat ihren heimlichen Bossfight, und bei uns hieß der im letzten Sprint File Uploader. Die Doku unten ist die nüchterne Wahrheit, aber die eigentliche Arbeit passierte zwischen Koffeinflash und Pixel-Poesie. Ich habe die Komponente auf einem ausgeleierten iPhone 8 getestet, während ein Kollege Accessibility-Checks über VoiceOver machte. Mobile First bedeutet hier, das Layout zusammenzufalten, bis es auch mit einer Hand bedienbar bleibt. Accessibility heißt, dass niemand fragen muss: „Wo bin ich hier?“ Genau dann ploppte eine Slack-Nachricht auf, die mich daran erinnerte, dass wir alle Prototypen unserer eigenen Ideen sind – und im Kopf jubelte das innere Regieteam, als wir den letzten Bug fixen konnten.
+## Feldnotizen aus dem Bau
+Der File Uploader hält Support-Formulare, Bewerbungsstrecken und Medienbibliotheken am Laufen. Drop-Zonen, Buttons und Fortschrittsbalken folgen den Token aus dem Designsystem, damit jede Variante vertraut wirkt. Große Dateien bedeuten Sicherheits- und Storage-Kosten, also planen wir Serverkapazitäten, CDN-Strategien und Retention-Regeln gemeinsam mit dem Betriebsteam. Die rechtliche Seite achtet auf TLS, Auftragsverarbeitungsverträge und Dateityp-Policies.
 
-### Originalnotizen
-Ich lasse hier den historischen Steckbrief unangetastet; er ist mein Sicherheitsnetz, wenn das Storytelling überkocht:
-# Content-Element: File Uploader
+## Mobile-First-Fahrplan
+Auf Smartphones ist Drag-and-Drop selten praktikabel, deshalb starten wir mit nativen Picker-Dialogen und kurzen Hinweisen zur erlaubten Maximalgröße. Kommt jemand über Tablet oder Desktop, schalten wir die Drop-Zone frei und zeigen zusätzliche Optionen wie Mehrfachauswahl. Fortschrittsanzeigen bleiben groß genug, um auch bei Sonnenlicht lesbar zu sein – dank Tests im Innenhof.
 
-## Beschreibung
-Komponente zum Hochladen von Dateien inklusive Fortschritt und Validierung.
+## Accessibility & Fürsorge
+Statuswechsel landen in einem `aria-live`-Region, damit Screenreader Hochladen, Pausieren oder Fehler sofort melden können. Fokus wandert logisch vom Input zum Fortschrittsbalken und zurück zum Ergebnis. Fehlermeldungen erklären präzise, ob Dateityp, Größe oder Netzwerk schuld sind, inklusive Hinweis auf alternative Einreichungswege. Tastaturnavigation deckt Auswahldialog, Retry-Button und Abbrechen ab.
 
-## Warum dieses Element?
-- Bewerbungs- oder Support-Uploads ermöglichen.
-- Medienverwaltung in CMS oder Kundenportalen.
-- Trade-off: Große Dateien erfordern Chunking, Sicherheit und Storage-Kosten.
+## Technik, Validierung & Betrieb
+Clientseitig prüfen wir Dateitypen und Größenlimits, aber die eigentliche Autorität bleibt die Servervalidierung. Uploads laufen chunkweise, mit Wiederaufsetzen nach Netzabbrüchen und Virenscan in der Warteschlange. Wir protokollieren jede Datei-ID, damit Audit-Logs und Support-Tickets zusammenfinden. Ein Storage-Service übernimmt Versionierung, während das Frontend bei deaktiviertem JavaScript auf eine klassische Formularübermittlung zurückfällt.
 
-## Anforderungen & Besonderheiten
-- **Responsiveness:** Drag-and-Drop-Bereich skalierbar, Fortschrittsanzeigen gut lesbar.
-- **Accessibility:** Klare Statusmeldungen, Tastaturbedienung, Screenreader-freundliche Feedbacks.
-- **SEO:** Keine direkte Relevanz.
-- **Design-Guidelines:** Drop-Zonen, Buttons, Fortschrittsbalken konsistent gestalten.
-- **Rechtliches:** Datenschutz und sichere Übertragung (TLS), Dateitypen-Policy, ggf. AV-Verträge.
-
-## Umsetzung – Technische Leitplanken
-- **Mobile First:** Dateiauswahl über native Picker, klare Hinweise zur Maximalgröße.
-- **Accessibility:** Statusupdates via `aria-live`, Fehler klar beschreiben.
-- **SEO:** Nicht relevant.
-- **Best Practices:**
-  - Serverseitige Validierung ergänzen.
-  - Uploads pausieren/fortsetzen ermöglichen.
-  - Virenscan oder Sicherheitschecks einplanen.
-
-## Checkliste
-- [ ] Darstellung auf allen Breakpoints geprüft
-- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
-- [ ] Semantik korrekt (HTML)
-- [ ] Performance optimiert (Lazyload/Kompression)
-
-## Abhängigkeiten / Überschneidungen
-- Storage-Service, Validation, Progress-API
-
-## Akzeptanzkriterien
-- Technische Funktion OK
-- Konsistenz zum Designsystem
-- A11y & rechtliche Vorgaben erfüllt
-
-## Beispiel / Code
-[content-elements-examples/file-uploader.html](../content-elements-examples/file-uploader.html)
-
-```html
-<!-- Minimales, valides HTML-Beispiel -->
-<form class="uploader">
-  <label for="file" class="uploader__dropzone">Datei hier ablegen oder klicken</label>
-  <input id="file" name="file" type="file" hidden>
-  <progress value="0" max="100" aria-live="polite"></progress>
-</form>
-```
-
-Bewertung der Relevanz 2025
-
-⭐⭐⭐⭐ Datei-Uploads sind häufig und erfordern hohe UX- und Sicherheitsstandards.
-
-## Anekdoten & Nerd-Zitate
-- Im Retro-Meeting tippte jemand: „File Uploader war mein Bosslevel.“ – Ich antwortete: „Nur weil du den Accessibility-Check nach Mitternacht gemacht hast.“
-- In meinem inneren Katastrophenskript gibt es immer eine Szene, in der File Uploader ausfällt und der Shop nervös wird. In der Realität helfen uns Logs und Gelassenheit.
-- Beim Debuggen flüstert mir eher das Bauchgefühl zu: „Wir leben zwischen Bugfixes, also mach sie hübsch.“ Das gilt besonders, wenn der Mobile-Test im Bus stattfindet.
-- O-Ton eines Kunden: „Seit File Uploader sauber läuft, fühlt sich unser Interface an wie eine gute Playlist.“ Besseres Lob gibt es nicht.
-
-## Best Practices
-- **Accessibility lebt von Ritualen:** Prüfe File Uploader mit Tastatur und Screenreader, bevor du überhaupt an Pixel-Politur denkst. Deine künftige Selbstachtung wird es dir danken.
-- **Mobile First aus Überzeugung:** Beginne mit dem kleinsten Viewport und frage dich ernsthaft, ob du das Element auch im U-Bahn-Gedränge bedienen könntest.
-- **Performance mit Hausverstand:** Lade nur, was wirklich gebraucht wird, sonst fühlt sich File Uploader an wie ein Buffering-Screen aus der Modem-Ära.
-- **Dokumentation neben dem Code:** Schreib dir dazu, warum Entscheidungen gefallen sind; sonst fragst du dich in drei Monaten selbst, was du damit meintest.
-- **Team-Sync:** Stell sicher, dass Design, Content und Dev dieselben Erwartungen haben – sonst erzählt jeder eine andere Story über File Uploader.
-
-## Fazit
-File Uploader ist am Ende wie eine Reihe kleiner Laternen im Tunnel: unscheinbar, aber ohne sie stolpern wir. Ich nehme aus diesem Durchgang mit, dass Mobile First und Accessibility keine Kapitelüberschriften sind, sondern Bauchentscheidungen für Menschen. Beim nächsten Mal baue ich noch früher Tests in den Workflow ein – und trinke meinen Kaffee vermutlich etwas langsamer.
+## Takeaways
+- Dateiuploads versorgen Support, HR und Medienverwaltung – konsistente UI-Komponenten schaffen Vertrauen.
+- Mobile-First bedeutet native Picker, klare Größenhinweise und erst später Drag-and-Drop-Luxus.
+- Barrierefreiheit entsteht durch `aria-live`, nachvollziehbare Fehlermeldungen und vollständige Tastaturpfade.
+- Chunking, Servervalidierung, Virenscan und Audit-Logs sichern die Pipeline gegen Datenverlust und Compliance-Stress.

--- a/_posts/2025-09-30-content-elements-filter-facets.md
+++ b/_posts/2025-09-30-content-elements-filter-facets.md
@@ -1,89 +1,35 @@
 ---
-title: "Filter Facets: Randnotiz"
+title: "Filter-Facetten und der nächtliche Warenkorb-Alarm"
 date: 2025-09-30
-tags: [UI, Komponente, Webentwicklung]
-excerpt: "Warum Filter Facets unsere Content Elements-Notizen inspiriert."
 layout: post
-categories: [content-elements]
+categories:
+  - content-elements
+tags:
+  - Content Element
+  - Search UX
+  - Data Strategy
+excerpt: "Wie facettierte Filter Kataloge retten, URLs aufräumen und mir trotz Pager-Alarm den Humor lassen."
 slug: content-elements-filter-facets
 original_path: content-elements/filter-facets.md
 ---
 
-## Einleitung
-Noch bevor Slack das erste Ping losließ, balancierte ich zwischen Straßenbahn und improvisiertem Stehtisch und schrieb die ersten Stichworte ins Smartphone. Auf dem Screen wartete Filter Facets; kein Thriller, sondern das nächste Kapitel für C.ntent Elements.
+## Szene: Pager-Alarm im Lagerraum
+Um halb eins nachts meldete das Monitoring fehlerhafte Filter-Parameter. Ich stand im Lagerraum zwischen Post-its und leeren Kartons, während mein Pager piepte wie ein Retro-Tamagotchi. Laptop aufgeklappt, VPN an, Filter Facets geöffnet. Das Ziel: Den Nutzern ihre Lieblingsprodukte zurückgeben, bevor das Marketing-Team aufwacht.
 
-## Technischer Kern
-Filter Facets klingt harmlos, doch in Wahrheit ist es das Klebeband zwischen Layout und Vertrauen. Damals, als wir eine spontane Nachtmigration fahren mussten, zeigte sich, wie sensibel die Details sind: Ein falsch gesetzter Breakpoint, und das mobile Layout fühlte sich an wie Nokia Snake auf einem faltbaren Display. Seitdem teste ich Mobile First auf dem ältesten Gerät im Büro. Accessibility ist keine Checkbox, sondern der Moment, in dem mir eine Screenreader-Nutzerin dankte, weil sie den Flow ohne Frust durchlaufen konnte. Wir sagen intern gern: Der wirkliche Wahnsinn im Code beginnt erst nach Mitternacht – und genau da merkten wir, wie Filter Facets mit sauberen `aria`-Labels plötzlich Orientierung stiftete. Statt Zitaten gab es Fäuste in der Luft und einen stillen High-Five übers Debug-Log.
+## Feldnotizen aus dem Bau
+Filter Facets zähmen Produktkataloge, Suchergebnisse und Tag-Listen. Wir priorisieren Kategorien, Preise und Lieferoptionen, markieren aktive Filter prominent und legen einen Reset-Button an jedes Modul. Zu viele Optionen überfordern, also testen wir regelmäßig, welche Facetten wirklich Umsatz bringen. Alle Varianten – Chips, Checkbox-Listen, Slider – teilen denselben Design-Rhythmus und interagieren sauber mit den restlichen Komponenten.
 
-### Originalnotizen
-Bevor wir uns im Meme-Verhau verlieren, bleiben die originalen Notizen unbeschnitten erhalten:
-# Content-Element: Filter Facets
+## Mobile-First-Fahrplan
+Auf Smartphones verstecken wir die Filter hinter einem klar beschrifteten Button und öffnen ein Vollbild-Akkordeon. Die wichtigsten Optionen stehen oben, sekundäre landen hinter Disclosure-Elementen. Erst auf Desktop verteilen wir Spalten nebeneinander oder zeigen Inline-Chips unterhalb der Headline. Animationsdauer bleibt kurz, damit sich Off-Canvas-Überlagerungen nicht träge anfühlen.
 
-## Beschreibung
-Facettierte Filtersteuerung mit Chips, Listen oder Slidern.
+## Accessibility & Fürsorge
+Jedes Steuer-Element besitzt sprechende Labels, Checkboxen und Radios sind auch mit großen Fingern treffbar, und Filter-Chips setzen ihr `aria-pressed` konsequent. Nach dem Anwenden springt der Fokus zum Ergebnis-Heading, während `aria-live` leise die neue Trefferzahl vermeldet. Keyboard-User entfernen Filter über Enter oder Space; niemand muss zur Maus greifen. Für Screenreader vermeiden wir kryptische Abkürzungen und sprechen statt „24h“ lieber von „Lieferung innerhalb von 24 Stunden“.
 
-## Warum dieses Element?
-- Produkt- oder Artikellisten zielgerichtet einschränken.
-- Suchergebnisse nach Kategorien, Preisen oder Tags verfeinern.
-- Trade-off: Zu viele Filteroptionen überfordern Nutzer und erhöhen Komplexität.
+## Technik, Validierung & Betrieb
+Wir schreiben Filterzustände in die URL, whitelisten nur erlaubte Parameter und setzen Canonical-Links, damit SEO nicht im Duplikat-Dschungel landet. Client- und Serverseite bleiben synchron, egal ob jemand den Browser-Back-Button drückt oder direkt einen Link teilt. Analytics protokolliert jede Facette DSGVO-konform, während Feature-Flags neue Optionen geschützt ausrollen. Edge-Cases wie leere Resultate triggern den passenden Empty State statt einer stummen Liste.
 
-## Anforderungen & Besonderheiten
-- **Responsiveness:** Auf Mobile als Akkordeon oder Off-Canvas, auf Desktop nebeneinander.
-- **Accessibility:** Checkbox-/Radio-Labels klar benennen, `aria-pressed` für Chips.
-- **SEO:** Filter-URLs sauber handhaben, Duplicate Content vermeiden.
-- **Design-Guidelines:** Visuelle Hierarchie, aktive Filter hervorheben, Reset-Option.
-- **Rechtliches:** Tracking von Filterinteraktionen DSGVO-konform behandeln.
-
-## Umsetzung – Technische Leitplanken
-- **Mobile First:** Filter über Button einblenden, Prioritäten setzen.
-- **Accessibility:** Statusänderungen per `aria-live` ankündigen, Fokus nach Anwendung sinnvoll setzen.
-- **SEO:** Kanonsiche URLs definieren, Parameter whitelisten.
-- **Best Practices:**
-  - Aktive Filter deutlich anzeigen und entfernen lassen.
-  - Filterzustand in URL speichern.
-  - Serverseitige und clientseitige Filter synchron halten.
-
-## Checkliste
-- [ ] Darstellung auf allen Breakpoints geprüft
-- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
-- [ ] Semantik korrekt (HTML)
-- [ ] Performance optimiert (Lazyload/Kompression)
-
-## Abhängigkeiten / Überschneidungen
-- Such-API, State-Management, Analytics
-
-## Akzeptanzkriterien
-- Technische Funktion OK
-- Konsistenz zum Designsystem
-- A11y & rechtliche Vorgaben erfüllt
-
-## Beispiel / Code
-[content-elements-examples/filter-facets.html](../content-elements-examples/filter-facets.html)
-
-```html
-<!-- Minimales, valides HTML-Beispiel -->
-<section class="filters">
-  <button type="button" class="filter-chip" aria-pressed="true">Sofort lieferbar</button>
-  <label><input type="checkbox" name="brand" value="acme"> ACME</label>
-</section>
-```
-
-Bewertung der Relevanz 2025
-
-⭐⭐⭐⭐ Komplexe Kataloge brauchen weiterhin leistungsfähige Filtersteuerungen.
-
-## Anekdoten & Nerd-Zitate
-- Wir haben einmal eine interne Nostalgie-Matrix gebaut, um Filter Facets gegen Erinnerungsglitzer zu testen. Ergebnis: 42 Prozent erinnern an MP3-Player aus 2003.
-- Mein Lieblings-Feedback kam aus dem Support: „Endlich muss ich niemandem mehr erklären, wo Filter Facets versteckt ist.“
-- Wenn das Monitoring blinkt, fühlt es sich kurz wie im Katastrophenfilm an – diesmal blieb der Alarm still.
-- Altundwillig.de hätte es so zusammengefasst: „Mach es benutzbar oder lass es bleiben.“
-
-## Best Practices
-- **A11y first:** Gib Filter Facets klare Rollen, Zustände und `aria`-Labels. Wer jemals ein Feedback von Screenreader-Profi bekommen hat, weiß, warum.
-- **Responsive by default:** Gestalte Breakpoints so, dass das Element nicht wie ein Möbelstück in einer viel zu kleinen Wohnung wirkt.
-- **State-Management:** Dokumentiere, wie Hover, Focus, Error und Success klingen und aussehen; Mobile-Geräte haben keine Hover-Liebe.
-- **Content Hooks:** Halte die Schnittstellen zu Datenquellen sauber, sonst verheddert sich Filter Facets schneller als ein Kassettenband.
-- **Monitoring:** Tracke Interaktionen, damit du erkennst, wann Nutzer stranden – und reagiere schneller, als ein Katastrophenfilm es darstellen würde.
-
-## Fazit
-Filter Facets bleibt ein stiller Held, der uns daran erinnert, warum wir Interfaces mit Herzblut bauen. Ich nehme mir vor, künftig noch radikaler auf echte Nutzungsszenarien zu hören – besonders, wenn das Monitoring ruhig ist. Accessibility, Mobile First, Humor: Diese drei Dinge halten den Laden zusammen.
+## Takeaways
+- Facetten filtern Kataloge effizient, wenn Prioritäten klar gesetzt und Reset-Wege sichtbar bleiben.
+- Mobile-First heißt Vollbild-Akkordeon und wenige primäre Optionen, Desktop bekommt erst später Spaltenluxus.
+- Barrierefreiheit gelingt mit sprechenden Labels, Fokussteuerung und sanften `aria-live`-Updates.
+- URL-Management, Parameter-Whitelist und Analytics-Signale sorgen dafür, dass SEO und Datenanalyse freundlich bleiben.

--- a/_posts/2025-09-30-content-elements-image-carousel.md
+++ b/_posts/2025-09-30-content-elements-image-carousel.md
@@ -1,92 +1,35 @@
 ---
-title: "Image Carousel: Randnotiz"
+title: "Karussell zwischen Pixelregen und Produktglanz"
 date: 2025-09-30
-tags: [UI, Komponente, Webentwicklung]
-excerpt: "Warum Image Carousel unsere Content Elements-Notizen inspiriert."
 layout: post
-categories: [content-elements]
+categories:
+  - content-elements
+tags:
+  - Content Element
+  - Media UX
+  - Performance
+excerpt: "Warum unser Image Carousel Produktstories dreht, ohne Nutzer mit Autoplay und Datenlast zu verschrecken."
 slug: content-elements-image-carousel
 original_path: content-elements/image-carousel.md
 ---
 
-## Einleitung
-Zwischen Straßenbahn, Einkaufskorb und kurzen Pausen auf der Parkbank tippte ich die ersten Sätze ins Smartphone. Image Carousel stand noch warm aus dem letzten Deployment im Raum, und klar war: Heute erzählen wir diese Komponente so, wie altundwillig.de über große und kleine Webdramen schreibt – mitten im Alltag unseres Content Elements-Systems.
+## Szene: Fotoshooting im Serverraum
+Mitten zwischen klimatisierten Racks knipste die Fotografin neue Produktshots, während ich nebenan das Staging-Karussell auf dem Tablet testete. Der Geräuschpegel aus Lüftern und Auslösern war absurd – aber perfekt, um über Bildgrößen, Lazy Loading und Lightbox-Zugriff zu sprechen. Niemand wollte, dass das neue Sortiment mit einer Diashow aus den 2000ern verwechselt wird.
 
-## Technischer Kern
-Image Carousel ist einer dieser Bausteine, die niemand beachtet, bis sie fehlen. Wir haben das schmerzhaft gelernt, als ein Kunde das Feature ohne ARIA ausgeliefert hat und ein Feedback-Call zur Selbsthilfegruppe wurde. Seitdem legen wir das Mobile-Layout zuerst fest, tasten uns mit echten Fingern durch Buttons und Links und feiern jeden Moment, in dem der Screenreader flüssig vorliest. Ich halte mich an die Spezifikationen, aber ich erzähle sie wie Lagerfeuergeschichten: mit klaren HTML-Strukturen, sauberen States und einer Prise Humor. Und während ich daran denke, dass wir alle an halb fertigen Interfaces arbeiten, mahnt mich eine innere Stimme, jede Abhängigkeit dreimal zu prüfen.
+## Feldnotizen aus dem Bau
+Image Carousel zeigt Produktgalerien, Event-Rückblicke oder Referenz-Slides. Wir halten die Anzahl der Slides gering, damit Aufmerksamkeit nicht zerfasert, und markieren Navigation über Pfeile, Dots und optional Play/Pause-Controls. Alle Varianten teilen Farben, Abstände und Typografie mit dem restlichen System. Bildrechte checken wir gemeinsam mit dem Marketing, bevor etwas live geht.
 
-### Originalnotizen
-Ich lasse hier den historischen Steckbrief unangetastet; er ist mein Sicherheitsnetz, wenn das Storytelling überkocht:
-# Content-Element: Image Carousel
+## Mobile-First-Fahrplan
+Auf Smartphones zeigen wir einzelne Slides im Vollformat mit sichtbaren Swipe-Hinweisen. Erst ab Tablet stapeln wir zwei Bilder nebeneinander oder blenden Thumbnails ein. Der Download bleibt sparsam: Wir liefern optimierte WebP-Varianten, progressive JPEG-Fallbacks und laden nur das nächste Bild vor, damit das Karussell sich leicht anfühlt.
 
-## Beschreibung
-Slider-Komponente für mehrere Bilder mit optionaler Lightbox.
+## Accessibility & Fürsorge
+Autoplay bleibt deaktiviert, bis eine Nutzerin bewusst startet. Der Fokus folgt einer logischen Reihenfolge – vom Karussell-Heading über die Navigationselemente zum aktuellen Bild. `aria-live="polite"` kündigt Slide-Wechsel an, und Tastaturbefehle greifen sowohl auf Pfeiltasten als auch auf die Enter-Taste auf Buttons. Für Screenreader beschreiben wir jedes Bild mit einer knappen Caption, statt Alt-Textromanen zu servieren.
 
-## Warum dieses Element?
-- Produktgalerien auf E-Commerce-Seiten.
-- Event- oder Referenz-Slideshows auf Landingpages.
-- Trade-off: Zu viele Slides reduzieren Aufmerksamkeit, Interaktion oft gering.
+## Technik, Validierung & Betrieb
+Wir setzen Progressive Enhancement ein: Ohne JavaScript bleibt eine statische Bildliste übrig, die dennoch klickbar ist. Lazy Loading und Intersection Observer halten die Medienlast im Rahmen, während Lightbox-Aufrufe die Tracking-Events respektieren. Caching-Header und ein Bild-CDN verhindern Bandbreiten-Kater. Monitoring registriert, wie oft Nutzer zum letzten Slide blättern – wenn die Quote sinkt, kürzen wir die Reihe.
 
-## Anforderungen & Besonderheiten
-- **Responsiveness:** Touch- und Mausbedienung, Breakpoints für Anzahl sichtbarer Slides.
-- **Accessibility:** Fokusreihenfolge, `aria-live` für Slide-Wechsel, Pause-/Play-Controls.
-- **SEO:** Bilder mit Alt-Text und Lazyload, Lightbox nicht indexrelevant.
-- **Design-Guidelines:** Navigationselemente konsistent, Dot-/Arrow-Styling, Übergänge dezent.
-- **Rechtliches:** Bildrechte beachten, Tracking in Lightbox vermeiden.
-
-## Umsetzung – Technische Leitplanken
-- **Mobile First:** Einzelne Slides, Swipe-Gesten, geringe Dateigrößen.
-- **Accessibility:** Autoplay standardmäßig deaktiviert, klare Fokusindikatoren.
-- **SEO:** `loading="lazy"`, strukturierte Daten für Produktbilder möglich.
-- **Best Practices:**
-  - Slides per Keyboard navigierbar machen.
-  - Progressive Enhancement bei deaktiviertem JS.
-  - Bildvorab-Laden für nächstes Slide optimieren.
-
-## Checkliste
-- [ ] Darstellung auf allen Breakpoints geprüft
-- [ ] Barrierefreiheit (Fokus, ARIA, Kontrast) OK
-- [ ] Semantik korrekt (HTML)
-- [ ] Performance optimiert (Lazyload/Kompression)
-
-## Abhängigkeiten / Überschneidungen
-- Slider-Library, Lightbox, Bild-CDN
-
-## Akzeptanzkriterien
-- Technische Funktion OK
-- Konsistenz zum Designsystem
-- A11y & rechtliche Vorgaben erfüllt
-
-## Beispiel / Code
-[content-elements-examples/image-carousel.html](../content-elements-examples/image-carousel.html)
-
-```html
-<!-- Minimales, valides HTML-Beispiel -->
-<div class="carousel" aria-roledescription="Karussell">
-  <button class="carousel__prev" aria-label="Vorheriges Bild">‹</button>
-  <ul class="carousel__track">
-    <li class="carousel__slide"><img src="../assets/agents-and-robots.png" alt="Agentin und Roboter in einer futuristischen Stadt bei Nacht" loading="lazy"></li>
-  </ul>
-  <button class="carousel__next" aria-label="Nächstes Bild">›</button>
-</div>
-```
-
-Bewertung der Relevanz 2025
-
-⭐⭐⭐⭐ Karussells bleiben gängig, müssen jedoch nutzerzentriert optimiert werden.
-
-## Anekdoten & Nerd-Zitate
-- Ein Chatverlauf von letzter Woche: „Kannst du Image Carousel mal schnell deaktivieren?“ – „Nur wenn du mir einen neuen Kaffee bringst.“ Ergebnis: Kaffee kam, Image Carousel blieb.
-- Merksatz: Technologie wird genau dann knifflig, wenn sie unsichtbar wirkt. Genau deshalb lassen wir Image Carousel nicht aus der Doku verschwinden.
-- Während der Build lief, las ich alte Projekt-Notizen und sah uns alle als Varianten derselben Crew, die versucht, Image Carousel pixelweise in den Griff zu bekommen.
-- In einer altundwillig.de-Sprachnachricht erzählte ich, wie ein Screenreader-User fragte: „Wo bin ich eigentlich?“ – dieser Satz hallt nach wie ein Drum-Solo.
-
-## Best Practices
-- **Accessibility lebt von Ritualen:** Prüfe Image Carousel mit Tastatur und Screenreader, bevor du überhaupt an Pixel-Politur denkst. Deine künftige Selbstachtung wird es dir danken.
-- **Mobile First aus Überzeugung:** Beginne mit dem kleinsten Viewport und frage dich ernsthaft, ob du das Element auch im U-Bahn-Gedränge bedienen könntest.
-- **Performance mit Hausverstand:** Lade nur, was wirklich gebraucht wird, sonst fühlt sich Image Carousel an wie ein Buffering-Screen aus der Modem-Ära.
-- **Dokumentation neben dem Code:** Schreib dir dazu, warum Entscheidungen gefallen sind; sonst fragst du dich in drei Monaten selbst, was du damit meintest.
-- **Team-Sync:** Stell sicher, dass Design, Content und Dev dieselben Erwartungen haben – sonst erzählt jeder eine andere Story über Image Carousel.
-
-## Fazit
-Zum Schluss fühlt sich Image Carousel an wie ein gut geölter Plattenspieler: nicht prahlerisch, aber unverzichtbar. Wir haben wieder gelernt, dass Disziplin bei Breakpoints und `aria`-Attributen genau der Unterschied zwischen Frust und Flow ist. Beim nächsten Rollout gönne ich mir mehr Zeit für User-Feedback, bevor der nächste Sturm aus Edge Cases anklopft.
+## Takeaways
+- Karussells dienen Produkt- und Eventstories, solange Slides kuratiert und Navigation eindeutig bleibt.
+- Mobile-First setzt auf Einzel-Slides mit Swipe-Hinweis; Desktop ergänzt Thumbnails und mehr Sichtfläche.
+- Barrierefreiheit bedeutet bewusstes Autoplay, klare Fokuspfade und sanfte `aria-live`-Ansagen.
+- Lazy Loading, CDN und Progressive Enhancement zähmen Medienlast und sorgen für reibungslose Deployments.


### PR DESCRIPTION
## Summary
- reworked the front matter for six content-element journal posts to match the updated template with new titles, tags, and excerpts
- rewrote each article into a scene-based narrative that surfaces the original technical guidance, including validation, accessibility, and responsive details
- captured concrete takeaways per component covering mobile-first strategy, edge cases, and operational safeguards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc650198dc8329aa5d9ddc842d199e