### PR TITLE
Add Shopify content element sections

### DIFF
--- a/content-elements-shopify/audio-embed.liquid
+++ b/content-elements-shopify/audio-embed.liquid
@@ -1,0 +1,34 @@
+<figure class="audio">
+  {% if section.settings.caption != blank %}
+  <figcaption>{{ section.settings.caption }}</figcaption>
+  {% endif %}
+  <audio controls preload="none">
+    {% if section.settings.audio != blank %}
+    <source src="{{ section.settings.audio }}" type="audio/mpeg">
+    {% endif %}
+    {{ section.settings.fallback_text }}
+  </audio>
+</figure>
+{% schema %}
+{
+  "name": "Audio Embed",
+  "settings": [
+    {
+      "type": "url",
+      "id": "audio",
+      "label": "Audio-URL"
+    },
+    {
+      "type": "text",
+      "id": "caption",
+      "label": "Beschriftung"
+    },
+    {
+      "type": "text",
+      "id": "fallback_text",
+      "label": "Fallback-Text",
+      "default": "Ihr Browser unterstützt das Audio-Element nicht."
+    }
+  ]
+}
+{% endschema %}

--- a/content-elements-shopify/callout-box.liquid
+++ b/content-elements-shopify/callout-box.liquid
@@ -1,0 +1,46 @@
+{% assign callout_style = section.settings.style | default: 'info' %}
+<aside class="callout callout--{{ callout_style }}">
+  {% if section.settings.title != blank %}
+  <h3 class="callout__title">{{ section.settings.title }}</h3>
+  {% endif %}
+  {% if section.settings.text != blank %}
+  <div class="callout__content">{{ section.settings.text }}</div>
+  {% endif %}
+</aside>
+{% schema %}
+{
+  "name": "Callout Box",
+  "settings": [
+    {
+      "type": "select",
+      "id": "style",
+      "label": "Stil",
+      "default": "info",
+      "options": [
+        {
+          "value": "info",
+          "label": "Info"
+        },
+        {
+          "value": "warning",
+          "label": "Warnung"
+        },
+        {
+          "value": "success",
+          "label": "Erfolg"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "title",
+      "label": "Titel"
+    },
+    {
+      "type": "richtext",
+      "id": "text",
+      "label": "Text"
+    }
+  ]
+}
+{% endschema %}

--- a/content-elements-shopify/image-with-caption.liquid
+++ b/content-elements-shopify/image-with-caption.liquid
@@ -1,0 +1,30 @@
+{% if section.settings.image != blank %}
+<figure class="image">
+  <img src="{{ section.settings.image | image_url }}" alt="{{ section.settings.alt | escape }}" loading="lazy">
+  {% if section.settings.caption != blank %}
+  <figcaption>{{ section.settings.caption }}</figcaption>
+  {% endif %}
+</figure>
+{% endif %}
+{% schema %}
+{
+  "name": "Image with Caption",
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "image",
+      "label": "Bild"
+    },
+    {
+      "type": "text",
+      "id": "alt",
+      "label": "Alt-Text"
+    },
+    {
+      "type": "text",
+      "id": "caption",
+      "label": "Beschriftung"
+    }
+  ]
+}
+{% endschema %}

--- a/content-elements-shopify/trust-badges.liquid
+++ b/content-elements-shopify/trust-badges.liquid
@@ -1,0 +1,36 @@
+{% if section.blocks.size > 0 %}
+<ul class="trust-badges">
+  {% for block in section.blocks %}
+  <li {{ block.shopify_attributes }}>
+    {% if block.settings.image != blank %}
+    <img src="{{ block.settings.image | image_url }}" alt="{{ block.settings.alt | escape }}">
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% schema %}
+{
+  "name": "Trust Badges",
+  "settings": [],
+  "blocks": [
+    {
+      "type": "badge",
+      "name": "Abzeichen",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Bild"
+        },
+        {
+          "type": "text",
+          "id": "alt",
+          "label": "Alt-Text"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 5
+}
+{% endschema %}

--- a/content-elements-shopify/video-embed.liquid
+++ b/content-elements-shopify/video-embed.liquid
@@ -1,0 +1,35 @@
+{% if section.settings.video != blank %}
+<figure class="video">
+  <video controls preload="none"{% if section.settings.poster != blank %} poster="{{ section.settings.poster | image_url }}"{% endif %}>
+    {% for source in section.settings.video.sources %}
+    <source src="{{ source.url }}" type="{{ source.mime_type }}">
+    {% endfor %}
+    Ihr Browser unterstützt das Video-Element nicht.
+  </video>
+  {% if section.settings.caption != blank %}
+  <figcaption>{{ section.settings.caption }}</figcaption>
+  {% endif %}
+</figure>
+{% endif %}
+{% schema %}
+{
+  "name": "Video Embed",
+  "settings": [
+    {
+      "type": "video",
+      "id": "video",
+      "label": "Video"
+    },
+    {
+      "type": "image_picker",
+      "id": "poster",
+      "label": "Posterbild"
+    },
+    {
+      "type": "text",
+      "id": "caption",
+      "label": "Beschriftung"
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- add audio embed section for Shopify content elements
- add video, image with caption, trust badges, and callout box sections for Shopify

## Testing
- not run