### PR TITLE
Add reusable Shopify snippets and flexible content blocks

### DIFF
--- a/blocks/hero-banner.liquid
+++ b/blocks/hero-banner.liquid
@@ -1,0 +1,214 @@
+{% schema %}
+{
+  "name": "Hero Banner",
+  "settings": [
+    {
+      "type": "text",
+      "id": "eyebrow",
+      "label": "Eyebrow"
+    },
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Starte stark in die Saison"
+    },
+    {
+      "type": "textarea",
+      "id": "subheading",
+      "label": "Subheading",
+      "default": "Beschreibe kurz dein Alleinstellungsmerkmal und inspiriere Besucher:innen zum Handeln."
+    },
+    {
+      "type": "image_picker",
+      "id": "background_image",
+      "label": "Background image"
+    },
+    {
+      "type": "image_picker",
+      "id": "supporting_image",
+      "label": "Supporting image"
+    },
+    {
+      "type": "select",
+      "id": "alignment",
+      "label": "Content alignment",
+      "default": "left",
+      "options": [
+        { "value": "left", "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "right", "label": "Right" }
+      ]
+    },
+    {
+      "type": "select",
+      "id": "vertical_alignment",
+      "label": "Vertical alignment",
+      "default": "center",
+      "options": [
+        { "value": "top", "label": "Top" },
+        { "value": "center", "label": "Center" },
+        { "value": "bottom", "label": "Bottom" }
+      ]
+    },
+    {
+      "type": "color",
+      "id": "text_color",
+      "label": "Text color",
+      "default": "#ffffff"
+    },
+    {
+      "type": "range",
+      "id": "overlay_opacity",
+      "label": "Overlay opacity",
+      "default": 40,
+      "min": 0,
+      "max": 90,
+      "step": 5
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Button label",
+      "default": "Jetzt entdecken"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "Button link"
+    },
+    {
+      "type": "select",
+      "id": "button_style",
+      "label": "Button style",
+      "default": "primary",
+      "options": [
+        { "value": "primary", "label": "Primary" },
+        { "value": "secondary", "label": "Secondary" },
+        { "value": "tertiary", "label": "Tertiary" }
+      ]
+    },
+    {
+      "type": "checkbox",
+      "id": "show_supporting_image",
+      "label": "Show supporting image",
+      "default": true
+    }
+  ],
+  "presets": [
+    {
+      "name": "Hero Banner"
+    }
+  ]
+}
+{% endschema %}
+
+{%- liquid
+  assign alignment = block.settings.alignment
+  assign v_align = block.settings.vertical_alignment
+  assign overlay_opacity = block.settings.overlay_opacity | default: 40
+  assign bg_image = block.settings.background_image
+  assign supporting_image = block.settings.supporting_image
+
+  assign classes = 'hero-banner hero-banner--align-' | append: alignment | append: ' hero-banner--valign-' | append: v_align
+
+  capture content_html
+    <div class="hero-banner__content">
+      {% if block.settings.eyebrow != blank %}
+        {% render 'badge', text: block.settings.eyebrow, style: 'info' %}
+      {% endif %}
+      {% if block.settings.heading != blank %}
+        {% render 'heading', text: block.settings.heading, size: 'display', align: alignment, color: block.settings.text_color %}
+      {% endif %}
+      {% if block.settings.subheading != blank %}
+        {% render 'paragraph', text: block.settings.subheading, align: alignment, color: block.settings.text_color, is_richtext: true %}
+      {% endif %}
+      {% if block.settings.button_label != blank %}
+        {% render 'button', label: block.settings.button_label, url: block.settings.button_link, style: block.settings.button_style, size: 'lg' %}
+      {% endif %}
+    </div>
+    {% if block.settings.show_supporting_image and supporting_image %}
+      <div class="hero-banner__media">
+        {% render 'image', image: supporting_image, sizes: '(min-width: 64rem) 40vw, 80vw', aspect_ratio: '4/5' %}
+      </div>
+    {% endif %}
+  endcapture
+
+  capture wrapper_html
+    render 'container', width: 'wide', padding: 'lg', align: alignment, content: content_html
+  endcapture
+-%}
+
+<section class="{{ classes }}" style="--hero-text-color: {{ block.settings.text_color }};">
+  <div class="hero-banner__background" aria-hidden="true">
+    {% if bg_image %}
+      {{ bg_image | image_url: width: 2400 | image_tag: class: 'hero-banner__background-image', loading: 'lazy', sizes: '100vw' }}
+    {% endif %}
+    <div class="hero-banner__overlay" style="opacity: {{ overlay_opacity | times: 0.01 }};"></div>
+  </div>
+  {{ wrapper_html }}
+</section>
+
+{% stylesheet %}
+.hero-banner {
+  position: relative;
+  color: var(--hero-text-color);
+  display: grid;
+  min-height: clamp(24rem, 70vh, 36rem);
+}
+
+.hero-banner__background {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.hero-banner__background-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(110%);
+}
+
+.hero-banner__overlay {
+  position: absolute;
+  inset: 0;
+  background: #111827;
+  pointer-events: none;
+}
+
+.hero-banner .container {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero-banner__content {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hero-banner--align-center .hero-banner__content { text-align: center; }
+.hero-banner--align-right .hero-banner__content { text-align: right; justify-items: end; }
+.hero-banner--align-left .hero-banner__content { text-align: left; justify-items: start; }
+
+.hero-banner__media {
+  max-width: min(24rem, 90vw);
+  justify-self: center;
+}
+
+.hero-banner--valign-top .container { align-items: flex-start; }
+.hero-banner--valign-bottom .container { align-items: flex-end; }
+
+@media (min-width: 64rem) {
+  .hero-banner .container {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .hero-banner__media { justify-self: end; }
+  .hero-banner--align-left .hero-banner__media { order: 2; }
+  .hero-banner--align-right .hero-banner__media { order: 0; justify-self: start; }
+}
+{% endstylesheet %}

--- a/blocks/newsletter-signup.liquid
+++ b/blocks/newsletter-signup.liquid
@@ -1,0 +1,127 @@
+{% schema %}
+{
+  "name": "Newsletter Signup",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Bleib auf dem Laufenden"
+    },
+    {
+      "type": "textarea",
+      "id": "subheading",
+      "label": "Subheading",
+      "default": "Erhalte exklusive Angebote und Neuigkeiten direkt in dein Postfach."
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "label": "Button label",
+      "default": "Jetzt anmelden"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_gdpr",
+      "label": "DSGVO-Hinweis anzeigen",
+      "default": true
+    },
+    {
+      "type": "richtext",
+      "id": "gdpr_text",
+      "label": "DSGVO-Text",
+      "default": "<p>Ich stimme zu, den Newsletter per E-Mail zu erhalten und kann mich jederzeit wieder abmelden.</p>"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Newsletter Signup"
+    }
+  ]
+}
+{% endschema %}
+
+<section class="newsletter" aria-labelledby="newsletter-{{ block.id }}-title">
+  {% capture newsletter_content %}
+  <div class="newsletter__inner">
+    {% if block.settings.heading != blank %}
+      {% render 'heading', text: block.settings.heading, size: 'lg', id: 'newsletter-' | append: block.id | append: '-title' %}
+    {% endif %}
+    {% if block.settings.subheading != blank %}
+      {% render 'paragraph', text: block.settings.subheading, max_width: '60ch' %}
+    {% endif %}
+
+    {% form 'customer', id: 'NewsletterForm-' | append: block.id %}
+      {% if form.posted_successfully? %}
+        {% render 'success-message', message: 'Vielen Dank für deine Anmeldung!' %}
+      {% else %}
+        {% if form.errors %}
+          {% render 'error-message', message: form.errors.translated_fields.email | default: form.errors.messages.email %}
+        {% endif %}
+        <div class="newsletter__fields">
+          {% render 'input',
+            name: 'contact[email]',
+            type: 'email',
+            label: 'E-Mail-Adresse',
+            placeholder: 'deinname@example.com',
+            required: true,
+            autocomplete: 'email',
+            id: 'NewsletterEmail-' | append: block.id,
+            helper_text: 'Wir respektieren deine Privatsphäre.'
+          %}
+          {% render 'button', label: block.settings.button_label, type: 'submit', size: 'md' %}
+        </div>
+        {% if block.settings.show_gdpr and block.settings.gdpr_text != blank %}
+          <div class="newsletter__gdpr">
+            {{ block.settings.gdpr_text }}
+          </div>
+        {% endif %}
+      {% endif %}
+      <input type="hidden" name="contact[tags]" value="newsletter">
+    {% endform %}
+  </div>
+  {% endcapture %}
+  {% render 'container', width: 'narrow', padding: 'lg', content: newsletter_content %}
+</section>
+
+{% stylesheet %}
+.newsletter {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(129, 140, 248, 0.08));
+}
+
+.newsletter__inner {
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+  max-width: min(40rem, 100%);
+  margin: 0 auto;
+}
+
+.newsletter__fields {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.newsletter__fields .input,
+.newsletter__fields .button {
+  width: 100%;
+}
+
+.newsletter__gdpr {
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.7);
+}
+
+@media (min-width: 640px) {
+  .newsletter__fields {
+    grid-template-columns: 1fr auto;
+    align-items: end;
+    text-align: left;
+  }
+  .newsletter__fields .input,
+  .newsletter__fields .button {
+    width: auto;
+  }
+}
+{% endstylesheet %}

--- a/blocks/product-card.liquid
+++ b/blocks/product-card.liquid
@@ -1,0 +1,138 @@
+{% schema %}
+{
+  "name": "Produktkarte",
+  "settings": [
+    {
+      "type": "product",
+      "id": "product",
+      "label": "Produkt"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_badges",
+      "label": "Badges anzeigen",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "show_add_to_cart",
+      "label": "Add-to-Cart anzeigen",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "show_price",
+      "label": "Preis anzeigen",
+      "default": true
+    }
+  ],
+  "presets": [
+    {
+      "name": "Produktkarte"
+    }
+  ]
+}
+{% endschema %}
+
+{%- liquid
+  assign product = block.settings.product
+  if product == blank
+    assign product_title = 'Produktname'
+    assign product_url = '#'
+    assign product_image = blank
+  else
+    assign product_title = product.title
+    assign product_url = product.url
+    assign product_image = product.featured_media
+  endif
+  assign variant = nil
+  if product and product.selected_or_first_available_variant
+    assign variant = product.selected_or_first_available_variant
+  endif
+-%}
+
+<article class="product-card" aria-labelledby="product-card-{{ block.id }}-title">
+  <a class="product-card__media" href="{{ product_url }}">
+    {% if product_image %}
+      {% render 'image', image: product_image, aspect_ratio: '4/5', sizes: '(min-width: 64rem) 25vw, 50vw' %}
+    {% else %}
+      <div class="product-card__placeholder" aria-hidden="true">{% render 'icon', name: 'image', decorative: true %}</div>
+    {% endif %}
+    {% if block.settings.show_badges and product %}
+      <div class="product-card__badges">
+        {% render 'product-badge', product: product %}
+      </div>
+    {% endif %}
+  </a>
+  <div class="product-card__info">
+    <h3 id="product-card-{{ block.id }}-title" class="product-card__title">
+      <a href="{{ product_url }}">{{ product_title }}</a>
+    </h3>
+    {% if block.settings.show_price %}
+      <div class="product-card__price">
+        {% render 'price', product: product, variant: variant, show_discount: true %}
+      </div>
+    {% endif %}
+    {% if block.settings.show_add_to_cart %}
+      <div class="product-card__actions">
+        {% if product %}
+          {% form 'product', product, id: 'product-card-form-' | append: block.id %}
+            <input type="hidden" name="id" value="{{ variant.id }}">
+            {% render 'add-to-cart-button', product: product, variant: variant, form_id: 'product-card-form-' | append: block.id, size: 'md' %}
+          {% endform %}
+        {% else %}
+          {% render 'button', label: 'Zum Produkt', url: '#', style: 'secondary' %}
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+</article>
+
+{% stylesheet %}
+.product-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.product-card__media {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border-radius: 0.75rem;
+}
+
+.product-card__media img { transition: transform 0.3s ease; }
+.product-card__media:hover img { transform: scale(1.05); }
+
+.product-card__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 12rem;
+  background: rgba(17, 24, 39, 0.08);
+}
+
+.product-card__badges {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.product-card__title {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.product-card__title a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.product-card__title a:hover,
+.product-card__title a:focus-visible { text-decoration: underline; }
+
+.product-card__actions { margin-top: 0.75rem; }
+{% endstylesheet %}

--- a/blocks/testimonial-slider.liquid
+++ b/blocks/testimonial-slider.liquid
@@ -1,0 +1,252 @@
+{% schema %}
+{
+  "name": "Testimonial Slider",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Das sagen unsere Kund:innen"
+    },
+    {
+      "type": "textarea",
+      "id": "subheading",
+      "label": "Subheading"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "testimonial",
+      "name": "Testimonial",
+      "settings": [
+        {
+          "type": "textarea",
+          "id": "quote",
+          "label": "Zitat",
+          "default": "Dieses Produkt hat meine Erwartungen übertroffen."
+        },
+        {
+          "type": "text",
+          "id": "name",
+          "label": "Name",
+          "default": "Max Mustermann"
+        },
+        {
+          "type": "text",
+          "id": "role",
+          "label": "Rolle"
+        },
+        {
+          "type": "range",
+          "id": "rating",
+          "label": "Bewertung",
+          "default": 5,
+          "min": 0,
+          "max": 5,
+          "step": 1
+        },
+        {
+          "type": "image_picker",
+          "id": "avatar",
+          "label": "Avatar"
+        }
+      ]
+    }
+  ],
+  "max_blocks": 6,
+  "presets": [
+    {
+      "name": "Testimonial Slider",
+      "blocks": [
+        {
+          "type": "testimonial"
+        },
+        {
+          "type": "testimonial"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}
+
+{%- liquid
+  assign testimonials = block.blocks
+  assign has_testimonials = testimonials and testimonials.size > 0
+-%}
+
+<div class="testimonial-slider" data-testimonial-slider>
+  {% if block.settings.heading != blank %}
+    <div class="testimonial-slider__heading">
+      {% render 'heading', text: block.settings.heading, size: 'lg', align: 'center' %}
+      {% if block.settings.subheading != blank %}
+        {% render 'paragraph', text: block.settings.subheading, align: 'center' %}
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% if has_testimonials %}
+    <div class="testimonial-slider__viewport">
+      <div class="testimonial-slider__track">
+        {% for inner_block in testimonials %}
+          {%- assign rating = inner_block.settings.rating | plus: 0 -%}
+          <article class="testimonial-slider__slide" data-index="{{ forloop.index0 }}" aria-hidden="{% if forloop.index0 == 0 %}false{% else %}true{% endif %}">
+            <div class="testimonial-slider__quote">“{{ inner_block.settings.quote | escape }}”</div>
+            <div class="testimonial-slider__meta">
+              {% if inner_block.settings.avatar %}
+                {% render 'image', image: inner_block.settings.avatar, aspect_ratio: '1/1', sizes: '64px', class: 'testimonial-slider__avatar' %}
+              {% endif %}
+              <div>
+                <p class="testimonial-slider__name">{{ inner_block.settings.name }}</p>
+                {% if inner_block.settings.role != blank %}
+                  <p class="testimonial-slider__role">{{ inner_block.settings.role }}</p>
+                {% endif %}
+              </div>
+            </div>
+            {% if rating > 0 %}
+              <div class="testimonial-slider__rating" aria-label="{{ rating }} von 5 Sternen">
+                {% for i in (1..5) %}
+                  {% if i <= rating %}
+                    {% render 'icon', name: 'star', decorative: true %}
+                  {% else %}
+                    <span class="testimonial-slider__star testimonial-slider__star--empty">★</span>
+                  {% endif %}
+                {% endfor %}
+              </div>
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
+    </div>
+    <div class="testimonial-slider__controls">
+      <button type="button" class="testimonial-slider__button" data-action="prev" aria-label="Vorheriges Testimonial">{% render 'icon', name: 'arrow-left', decorative: true %}</button>
+      <button type="button" class="testimonial-slider__button" data-action="next" aria-label="Nächstes Testimonial">{% render 'icon', name: 'arrow-right', decorative: true %}</button>
+    </div>
+  {% else %}
+    <p class="testimonial-slider__empty">Füge Testimonials hinzu, um den Slider zu aktivieren.</p>
+  {% endif %}
+</div>
+
+{% stylesheet %}
+.testimonial-slider {
+  display: grid;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.testimonial-slider__heading {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.testimonial-slider__viewport {
+  position: relative;
+  overflow: hidden;
+}
+
+.testimonial-slider__track {
+  display: flex;
+  transition: transform 0.4s ease;
+}
+
+.testimonial-slider__slide {
+  flex: 0 0 100%;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.testimonial-slider__quote {
+  font-size: 1.125rem;
+  font-style: italic;
+}
+
+.testimonial-slider__meta {
+  display: inline-flex;
+  gap: 0.75rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.testimonial-slider__avatar img {
+  border-radius: 999px;
+}
+
+.testimonial-slider__name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.testimonial-slider__role {
+  margin: 0;
+  font-size: 0.875rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.testimonial-slider__rating {
+  display: inline-flex;
+  gap: 0.25rem;
+  justify-content: center;
+  color: #fbbf24;
+}
+
+.testimonial-slider__star--empty { color: rgba(17, 24, 39, 0.2); }
+
+.testimonial-slider__controls {
+  display: inline-flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.testimonial-slider__button {
+  background: rgba(17, 24, 39, 0.08);
+  border: none;
+  border-radius: 999px;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.testimonial-slider__button:hover,
+.testimonial-slider__button:focus-visible {
+  background: rgba(17, 24, 39, 0.15);
+}
+{% endstylesheet %}
+
+{% javascript %}
+(function () {
+  const script = document.currentScript;
+  if (!script) return;
+  let slider = script.previousElementSibling;
+  while (slider && slider.tagName === 'STYLE') {
+    slider = slider.previousElementSibling;
+  }
+  if (!slider || !slider.matches('[data-testimonial-slider]')) return;
+  const track = slider.querySelector('.testimonial-slider__track');
+  const slides = slider.querySelectorAll('.testimonial-slider__slide');
+  const buttons = slider.querySelectorAll('.testimonial-slider__button');
+  if (!track || slides.length === 0) return;
+  let index = 0;
+  const update = () => {
+    track.style.transform = `translateX(${-100 * index}%)`;
+    slides.forEach((slide, idx) => {
+      slide.setAttribute('aria-hidden', idx === index ? 'false' : 'true');
+    });
+  };
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const action = btn.dataset.action;
+      if (action === 'prev') {
+        index = (index - 1 + slides.length) % slides.length;
+      } else {
+        index = (index + 1) % slides.length;
+      }
+      update();
+    });
+  });
+  update();
+})();
+{% endjavascript %}

--- a/snippets/add-to-cart-button.liquid
+++ b/snippets/add-to-cart-button.liquid
@@ -1,0 +1,67 @@
+{%- comment -%}
+  Snippet: add-to-cart-button
+  Verwendung: {% render 'add-to-cart-button', product: product, form_id: 'product-form-' | append: section.id %}
+  Parameter:
+    - product: Produktobjekt (product, nil)
+    - variant: Variantenobjekt (variant, nil)
+    - form_id: Ziel-Formular (text, nil)
+    - label: Button-Label (text, nil)
+    - style: Button-Style (text, 'primary')
+    - size: Button-Größe sm | md | lg (text, 'lg')
+{%- endcomment -%}
+
+{%- liquid
+  assign product = product | default: nil
+  assign variant = variant | default: nil
+  assign form_id = form_id | default: nil
+  assign style = style | default: 'primary'
+  assign size = size | default: 'lg'
+
+  if variant == nil and product
+    assign variant = product.selected_or_first_available_variant
+  endif
+
+  assign available = true
+  assign price = nil
+  if variant
+    assign available = variant.available
+    assign price = variant.price
+  elsif product
+    assign available = product.available
+    assign price = product.price
+  endif
+
+  assign label = label | default: 'products.product.add_to_cart' | t
+  if available != true
+    assign label = 'products.product.sold_out' | t
+  endif
+-%}
+
+<div class="add-to-cart-button">
+  {% render 'button',
+    label: label,
+    style: style,
+    size: size,
+    type: 'submit',
+    form: form_id,
+    is_disabled: available != true,
+    aria_label: label
+  %}
+  {%- if price -%}
+    <span class="add-to-cart-button__price">{{ price | money_with_currency }}</span>
+  {%- endif -%}
+</div>
+
+<style>
+.add-to-cart-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.add-to-cart-button__price {
+  font-size: 0.875rem;
+  color: rgba(17, 24, 39, 0.7);
+}
+</style>

--- a/snippets/badge.liquid
+++ b/snippets/badge.liquid
@@ -1,0 +1,71 @@
+{%- comment -%}
+  Snippet: badge
+  Verwendung: {% render 'badge', text: 'Neu', style: 'success' %}
+  Parameter:
+    - text: Badge-Text (text, 'Badge')
+    - style: Variante default | success | warning | danger | info (text, 'default')
+    - icon: Icon-Name für {% render 'icon' %} (text, nil)
+    - is_pill: Pillenform aktivieren (boolean, false)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign text = text | default: 'Badge'
+  assign style = style | default: 'default'
+  assign icon = icon | default: nil
+  assign is_pill = is_pill | default: false
+  assign id = id | default: null
+
+  assign badge_classes = 'badge badge--' | append: style
+  if is_pill == true or is_pill == 'true'
+    assign badge_classes = badge_classes | append: ' badge--pill'
+  endif
+  if icon
+    assign badge_classes = badge_classes | append: ' badge--with-icon'
+  endif
+-%}
+
+<span class="{{ badge_classes }}" {% if id %}id="{{ id }}"{% endif %}>
+  {%- if icon -%}
+    <span class="badge__icon" aria-hidden="true">{% render 'icon', name: icon %}</span>
+  {%- endif -%}
+  <span class="badge__text">{{ text }}</span>
+</span>
+
+<style>
+.badge {
+  --badge-bg-default: rgba(17, 24, 39, 0.08);
+  --badge-color-default: #111827;
+  --badge-bg-success: rgba(34, 197, 94, 0.15);
+  --badge-color-success: #047857;
+  --badge-bg-warning: rgba(251, 191, 36, 0.2);
+  --badge-color-warning: #92400e;
+  --badge-bg-danger: rgba(248, 113, 113, 0.25);
+  --badge-color-danger: #b91c1c;
+  --badge-bg-info: rgba(59, 130, 246, 0.2);
+  --badge-color-info: #1d4ed8;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.375rem;
+  color: var(--badge-color-default);
+  background-color: var(--badge-bg-default);
+}
+
+.badge--pill { border-radius: 999px; }
+
+.badge--success { background-color: var(--badge-bg-success); color: var(--badge-color-success); }
+.badge--warning { background-color: var(--badge-bg-warning); color: var(--badge-color-warning); }
+.badge--danger { background-color: var(--badge-bg-danger); color: var(--badge-color-danger); }
+.badge--info { background-color: var(--badge-bg-info); color: var(--badge-color-info); }
+
+.badge__icon {
+  display: inline-flex;
+  width: 1em;
+  height: 1em;
+}
+</style>

--- a/snippets/breadcrumb.liquid
+++ b/snippets/breadcrumb.liquid
@@ -1,0 +1,88 @@
+{%- comment -%}
+  Snippet: breadcrumb
+  Verwendung: {% render 'breadcrumb', items: breadcrumbs_array, current: product.title %}
+  Parameter:
+    - items: Array aus { title, url } (array, nil)
+    - current: Aktueller Seitentitel (text, page_title)
+    - show_home: Home-Link anzeigen (boolean, true)
+    - home_label: Beschriftung Home (text, 'Startseite')
+    - separator: Trennzeichen (text, '/')
+{%- endcomment -%}
+
+{%- liquid
+  assign items = items | default: nil
+  assign current = current | default: page_title
+  assign show_home = show_home | default: true
+  assign home_label = home_label | default: 'Startseite'
+  assign separator = separator | default: '/'
+-%}
+
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <ol class="breadcrumb__list">
+    {%- if show_home == true or show_home == 'true' -%}
+      <li class="breadcrumb__item">
+        <a href="{{ routes.root_url }}" class="breadcrumb__link">{{ home_label }}</a>
+      </li>
+    {%- endif -%}
+    {%- if items and items.size > 0 -%}
+      {%- for item in items -%}
+        <li class="breadcrumb__item">
+          <span class="breadcrumb__separator" aria-hidden="true">{{ separator }}</span>
+          {%- if item.url -%}
+            <a href="{{ item.url }}" class="breadcrumb__link">{{ item.title }}</a>
+          {%- else -%}
+            <span class="breadcrumb__link breadcrumb__link--current" aria-current="page">{{ item.title }}</span>
+          {%- endif -%}
+        </li>
+      {%- endfor -%}
+    {%- endif -%}
+    {%- if current -%}
+      <li class="breadcrumb__item">
+        <span class="breadcrumb__separator" aria-hidden="true">{{ separator }}</span>
+        <span class="breadcrumb__link breadcrumb__link--current" aria-current="page">{{ current }}</span>
+      </li>
+    {%- endif -%}
+  </ol>
+</nav>
+
+<style>
+.breadcrumb {
+  font-size: 0.8125rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.breadcrumb__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.breadcrumb__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.breadcrumb__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.breadcrumb__link:hover,
+.breadcrumb__link:focus-visible {
+  text-decoration: underline;
+}
+
+.breadcrumb__link--current {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.breadcrumb__separator {
+  opacity: 0.5;
+}
+</style>

--- a/snippets/button-group.liquid
+++ b/snippets/button-group.liquid
@@ -1,0 +1,68 @@
+{%- comment -%}
+  Snippet: button-group
+  Verwendung: {% render 'button-group', buttons: buttons_array, align: 'center' %}
+  Parameter:
+    - buttons: Array von Button-Objekten (array, nil)
+    - align: Ausrichtung left | center | right | stretch (text, 'left')
+    - orientation: Layout row | column (text, 'row')
+    - gap: Abstand zwischen Buttons (text, '0.75rem')
+    - stack_mobile: Stapeln auf kleineren Viewports (boolean, true)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign buttons = buttons | default: null
+  assign align = align | default: 'left'
+  assign orientation = orientation | default: 'row'
+  assign gap = gap | default: '0.75rem'
+  assign stack_mobile = stack_mobile | default: true
+  assign id = id | default: null
+
+  assign group_classes = 'button-group button-group--align-' | append: align | append: ' button-group--' | append: orientation
+  if stack_mobile == true or stack_mobile == 'true'
+    assign group_classes = group_classes | append: ' button-group--stack-mobile'
+  endif
+-%}
+
+<div class="{{ group_classes }}" style="--button-group-gap: {{ gap }};" {% if id %}id="{{ id }}"{% endif %}>
+  {%- if buttons and buttons.size > 0 -%}
+    {%- for button_item in buttons -%}
+      {% render 'button',
+        label: button_item.label,
+        url: button_item.url,
+        style: button_item.style,
+        size: button_item.size,
+        icon: button_item.icon,
+        icon_position: button_item.icon_position,
+        is_disabled: button_item.is_disabled,
+        type: button_item.type,
+        aria_label: button_item.aria_label,
+        id: button_item.id
+      %}
+    {%- endfor -%}
+  {%- endif -%}
+</div>
+
+<style>
+.button-group {
+  --button-group-gap: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--button-group-gap);
+}
+
+.button-group--align-left { justify-content: flex-start; }
+.button-group--align-center { justify-content: center; }
+.button-group--align-right { justify-content: flex-end; }
+.button-group--align-stretch { justify-content: stretch; }
+
+.button-group--column { flex-direction: column; }
+.button-group--row { flex-direction: row; }
+
+@media (max-width: 600px) {
+  .button-group--stack-mobile {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>

--- a/snippets/button.liquid
+++ b/snippets/button.liquid
@@ -1,0 +1,167 @@
+{%- comment -%}
+  Snippet: button
+  Verwendung: {% render 'button', label: 'Jetzt kaufen', url: routes.cart_url %}
+  Parameter:
+    - label: Button-Text (text, 'Button')
+    - url: Link-Ziel (url, '#')
+    - style: Button-Variante: primary | secondary | tertiary (text, 'primary')
+    - size: Größenvariante: sm | md | lg (text, 'md')
+    - icon: Icon-Name für {% render 'icon' %} (text, nil)
+    - icon_position: Position des Icons: left | right (text, 'left')
+    - type: Button-Type für <button> (text, 'button')
+    - is_disabled: Deaktiviert den Button (boolean, false)
+    - aria_label: Überschreibt das aria-label (text, nil)
+    - id: HTML-ID (text, nil)
+    - form: Formular-ID für Button-Submit (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign label = label | default: 'Button'
+  assign url = url | default: '#'
+  assign style = style | default: 'primary'
+  assign size = size | default: 'md'
+  assign icon_position = icon_position | default: 'left'
+  assign type = type | default: 'button'
+  assign is_disabled = is_disabled | default: false
+  assign aria_label = aria_label | default: label
+  assign id = id | default: null
+  assign form = form | default: null
+
+  assign has_icon = icon | default: false
+  assign is_link = url and is_disabled != true and is_disabled != 'true'
+
+  assign button_classes = 'button button--' | append: style | append: ' button--' | append: size
+  if has_icon
+    assign button_classes = button_classes | append: ' button--with-icon'
+    assign button_classes = button_classes | append: ' button--icon-' | append: icon_position
+  endif
+  if is_disabled == true or is_disabled == 'true'
+    assign button_classes = button_classes | append: ' is-disabled'
+  endif
+-%}
+
+{%- if is_link -%}
+  <a
+    {% if id %}id="{{ id }}"{% endif %}
+    href="{{ url }}"
+    class="{{ button_classes }}"
+    aria-label="{{ aria_label | escape }}"
+    {% if is_disabled %}aria-disabled="true" tabindex="-1"{% endif %}
+  >
+{%- else -%}
+  <button
+    {% if id %}id="{{ id }}"{% endif %}
+    type="{{ type }}"
+    class="{{ button_classes }}"
+    aria-label="{{ aria_label | escape }}"
+    {% if is_disabled %}disabled aria-disabled="true"{% endif %}
+    {% if form %}form="{{ form }}"{% endif %}
+  >
+{%- endif -%}
+    {%- if has_icon and icon_position == 'left' -%}
+      <span class="button__icon" aria-hidden="true">
+        {% render 'icon', name: icon %}
+      </span>
+    {%- endif -%}
+    <span class="button__label">{{ label }}</span>
+    {%- if has_icon and icon_position == 'right' -%}
+      <span class="button__icon" aria-hidden="true">
+        {% render 'icon', name: icon %}
+      </span>
+    {%- endif -%}
+{%- if is_link -%}
+  </a>
+{%- else -%}
+  </button>
+{%- endif -%}
+
+<style>
+.button {
+  --button-bg-primary: var(--color-button-primary, #111827);
+  --button-bg-secondary: var(--color-button-secondary, transparent);
+  --button-bg-tertiary: var(--color-button-tertiary, transparent);
+  --button-color-primary: var(--color-button-primary-text, #ffffff);
+  --button-color-secondary: var(--color-button-secondary-text, #111827);
+  --button-color-tertiary: var(--color-button-tertiary-text, #111827);
+  --button-border-radius: var(--radius-button, 0.375rem);
+  --button-padding-sm: 0.5rem 1rem;
+  --button-padding-md: 0.75rem 1.5rem;
+  --button-padding-lg: 1rem 2rem;
+  --button-font-size-sm: 0.875rem;
+  --button-font-size-md: 1rem;
+  --button-font-size-lg: 1.125rem;
+  font-family: inherit;
+  font-weight: 600;
+  border: 1px solid transparent;
+  border-radius: var(--button-border-radius);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+}
+
+.button--sm {
+  padding: var(--button-padding-sm);
+  font-size: var(--button-font-size-sm);
+}
+
+.button--md {
+  padding: var(--button-padding-md);
+  font-size: var(--button-font-size-md);
+}
+
+.button--lg {
+  padding: var(--button-padding-lg);
+  font-size: var(--button-font-size-lg);
+}
+
+.button--primary {
+  background-color: var(--button-bg-primary);
+  color: var(--button-color-primary);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgb(17 24 39 / 0.15);
+}
+
+.button--secondary {
+  background-color: var(--button-bg-secondary);
+  color: var(--button-color-secondary);
+  border-color: currentColor;
+}
+
+.button--secondary:hover,
+.button--secondary:focus-visible {
+  background-color: rgba(17, 24, 39, 0.08);
+}
+
+.button--tertiary {
+  background-color: var(--button-bg-tertiary);
+  color: var(--button-color-tertiary);
+  text-decoration: underline;
+}
+
+.button--tertiary:hover,
+.button--tertiary:focus-visible {
+  text-decoration: none;
+}
+
+.button.is-disabled,
+.button[aria-disabled="true"],
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.button__icon {
+  display: inline-flex;
+  width: 1em;
+  height: 1em;
+}
+</style>

--- a/snippets/checkbox.liquid
+++ b/snippets/checkbox.liquid
@@ -1,0 +1,141 @@
+{%- comment -%}
+  Snippet: checkbox
+  Verwendung: {% render 'checkbox', name: 'terms', label: 'AGB akzeptieren', required: true %}
+  Parameter:
+    - name: Feldname (text, 'checkbox-field')
+    - label: Beschriftung (text, 'Checkbox')
+    - value: Wert bei Auswahl (text, 'yes')
+    - checked: Vorbelegung (boolean, false)
+    - helper_text: Hilfetext (text, nil)
+    - error: Fehlermeldung (text, nil)
+    - required: Pflichtfeld (boolean, false)
+    - disabled: Deaktiviert (boolean, false)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign name = name | default: 'checkbox-field'
+  assign label = label | default: 'Checkbox'
+  assign value = value | default: 'yes'
+  assign checked = checked | default: false
+  assign helper_text = helper_text | default: nil
+  assign error = error | default: nil
+  assign required = required | default: false
+  assign disabled = disabled | default: false
+  assign id = id | default: name | handle | prepend: 'checkbox-'
+
+  assign wrapper_classes = 'checkbox'
+  if error
+    assign wrapper_classes = wrapper_classes | append: ' checkbox--error'
+  endif
+
+  assign describedby = ''
+  if helper_text
+    assign describedby = describedby | append: id | append: '-helper'
+  endif
+  if error
+    if describedby != ''
+      assign describedby = describedby | append: ' ' | append: id | append: '-error'
+    else
+      assign describedby = describedby | append: id | append: '-error'
+    endif
+  endif
+-%}
+
+<div class="{{ wrapper_classes }}">
+  <label class="checkbox__label" for="{{ id }}">
+    <input
+      class="checkbox__field"
+      type="checkbox"
+      id="{{ id }}"
+      name="{{ name }}"
+      value="{{ value }}"
+      {% if checked == true or checked == 'true' %}checked{% endif %}
+      {% if required == true or required == 'true' %}required aria-required="true"{% endif %}
+      {% if disabled == true or disabled == 'true' %}disabled aria-disabled="true"{% endif %}
+      {% if describedby != '' %}aria-describedby="{{ describedby }}"{% endif %}
+    >
+    <span class="checkbox__box" aria-hidden="true"></span>
+    <span class="checkbox__text">{{ label }}</span>
+  </label>
+  {%- if helper_text -%}
+    <p class="checkbox__helper" id="{{ id }}-helper">{{ helper_text }}</p>
+  {%- endif -%}
+  {%- if error -%}
+    <p class="checkbox__error" role="alert" id="{{ id }}-error">{{ error }}</p>
+  {%- endif -%}
+</div>
+
+<style>
+.checkbox {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.checkbox__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox__field {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.checkbox__box {
+  width: 1.125rem;
+  height: 1.125rem;
+  border: 1.5px solid rgba(17, 24, 39, 0.6);
+  border-radius: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  position: relative;
+}
+
+.checkbox__box::after {
+  content: '';
+  width: 0.5rem;
+  height: 0.25rem;
+  border-left: 2px solid #ffffff;
+  border-bottom: 2px solid #ffffff;
+  transform: rotate(-45deg) scale(0);
+  transform-origin: center;
+  transition: transform 0.2s ease;
+}
+
+.checkbox__field:checked + .checkbox__box {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.checkbox__field:checked + .checkbox__box::after {
+  transform: rotate(-45deg) scale(1);
+}
+
+.checkbox__text {
+  font-size: 0.875rem;
+  color: inherit;
+}
+
+.checkbox__helper {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.checkbox__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #dc2626;
+}
+
+.checkbox--error .checkbox__box { border-color: #dc2626; }
+.checkbox--error .checkbox__field:checked + .checkbox__box { background: #dc2626; border-color: #dc2626; }
+</style>

--- a/snippets/container.liquid
+++ b/snippets/container.liquid
@@ -1,0 +1,48 @@
+{%- comment -%}
+  Snippet: container
+  Verwendung: {% render 'container', content: section_content, width: 'wide', padding: 'lg' %}
+  Parameter:
+    - content: HTML-Inhalt (text, nil)
+    - width: max-width Variante narrow | default | wide | full (text, 'default')
+    - padding: Innenabstand none | sm | md | lg (text, 'md')
+    - align: Textausrichtung left | center | right (text, 'left')
+    - tag: Wrapper-Tag (text, 'div')
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign content = content | default: ''
+  assign width = width | default: 'default'
+  assign padding = padding | default: 'md'
+  assign align = align | default: 'left'
+  assign tag = tag | default: 'div'
+  assign id = id | default: nil
+
+  assign classes = 'container container--width-' | append: width | append: ' container--pad-' | append: padding | append: ' container--align-' | append: align
+-%}
+
+<{{ tag }} class="{{ classes }}" {% if id %}id="{{ id }}"{% endif %}>
+  {{ content }}
+</{{ tag }}>
+
+<style>
+.container {
+  margin-inline: auto;
+  width: 100%;
+  display: block;
+}
+
+.container--width-narrow { max-width: min(48rem, 92vw); }
+.container--width-default { max-width: min(64rem, 92vw); }
+.container--width-wide { max-width: min(80rem, 96vw); }
+.container--width-full { max-width: none; width: 100%; }
+
+.container--pad-none { padding: 0; }
+.container--pad-sm { padding: clamp(1rem, 3vw, 1.5rem) clamp(1rem, 4vw, 1.5rem); }
+.container--pad-md { padding: clamp(1.5rem, 4vw, 2.5rem) clamp(1.5rem, 5vw, 3rem); }
+.container--pad-lg { padding: clamp(2rem, 5vw, 3.5rem) clamp(2rem, 6vw, 4rem); }
+
+.container--align-left { text-align: left; }
+.container--align-center { text-align: center; }
+.container--align-right { text-align: right; }
+</style>

--- a/snippets/divider.liquid
+++ b/snippets/divider.liquid
@@ -1,0 +1,34 @@
+{%- comment -%}
+  Snippet: divider
+  Verwendung: {% render 'divider', style: 'dashed', margin: '2rem auto' %}
+  Parameter:
+    - style: Linie solid | dashed | dotted (text, 'solid')
+    - thickness: Linienbreite (text, '1px')
+    - width: Breite (text, '100%')
+    - color: Linienfarbe (color, rgba(17,24,39,0.12))
+    - margin: Außenabstand (text, '2rem auto')
+    - aria_hidden: Linie für Screenreader ausblenden (boolean, true)
+{%- endcomment -%}
+
+{%- liquid
+  assign style = style | default: 'solid'
+  assign thickness = thickness | default: '1px'
+  assign width = width | default: '100%'
+  assign color = color | default: 'rgba(17,24,39,0.12)'
+  assign margin = margin | default: '2rem auto'
+  assign aria_hidden = aria_hidden | default: true
+-%}
+
+<hr class="divider divider--{{ style }}" style="--divider-width: {{ width }}; --divider-thickness: {{ thickness }}; --divider-color: {{ color }}; --divider-margin: {{ margin }};" {% if aria_hidden == true or aria_hidden == 'true' %}aria-hidden="true"{% endif %}>
+
+<style>
+.divider {
+  width: var(--divider-width);
+  margin: var(--divider-margin);
+  border: none;
+  border-bottom: var(--divider-thickness) solid var(--divider-color);
+}
+
+.divider--dashed { border-bottom-style: dashed; }
+.divider--dotted { border-bottom-style: dotted; }
+</style>

--- a/snippets/error-message.liquid
+++ b/snippets/error-message.liquid
@@ -1,0 +1,69 @@
+{%- comment -%}
+  Snippet: error-message
+  Verwendung: {% render 'error-message', message: 'Etwas ist schief gelaufen.' %}
+  Parameter:
+    - message: Fehlermeldung (text, 'Es ist ein Fehler aufgetreten.')
+    - icon: Icon-Name (text, 'close')
+    - dismissible: Schließen-Button anzeigen (boolean, false)
+{%- endcomment -%}
+
+{%- liquid
+  assign message = message | default: 'Es ist ein Fehler aufgetreten.'
+  assign icon = icon | default: 'close'
+  assign dismissible = dismissible | default: false
+-%}
+
+<div class="alert alert--error" role="alert">
+  <span class="alert__icon">{% render 'icon', name: icon, decorative: true %}</span>
+  <div class="alert__content">{{ message }}</div>
+  {%- if dismissible == true or dismissible == 'true' -%}
+    <button type="button" class="alert__close" aria-label="{{ 'general.close' | t | default: 'Schließen' }}">{% render 'icon', name: 'close', decorative: true %}</button>
+  {%- endif -%}
+</div>
+
+<style>
+.alert {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: rgba(17, 24, 39, 0.05);
+  color: #111827;
+}
+
+.alert--error {
+  background: rgba(220, 38, 38, 0.1);
+  color: #b91c1c;
+}
+
+.alert__icon { display: inline-flex; }
+.alert__content { font-size: 0.875rem; }
+.alert__close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+</style>
+
+{%- if dismissible == true or dismissible == 'true' -%}
+<script>
+(function () {
+  var script = document.currentScript;
+  if (!script) return;
+  var alertEl = script.previousElementSibling.previousElementSibling;
+  while (alertEl && alertEl.tagName === 'STYLE') {
+    alertEl = alertEl.previousElementSibling;
+  }
+  if (!alertEl || !alertEl.classList.contains('alert')) return;
+  var closeBtn = alertEl.querySelector('.alert__close');
+  if (!closeBtn) return;
+  closeBtn.addEventListener('click', function () {
+    alertEl.remove();
+  });
+})();
+</script>
+{%- endif -%}

--- a/snippets/grid.liquid
+++ b/snippets/grid.liquid
@@ -1,0 +1,47 @@
+{%- comment -%}
+  Snippet: grid
+  Verwendung: {% render 'grid', content: grid_content, columns: 3, gap: '1.5rem' %}
+  Parameter:
+    - content: HTML-Inhalt (text, nil)
+    - columns: Anzahl Spalten Desktop (number, 3)
+    - columns_tablet: Spalten Tablet (number, 2)
+    - columns_mobile: Spalten Mobile (number, 1)
+    - gap: Abstand zwischen Zellen (text, '1.5rem')
+    - align: Justierung stretch | start | center | end (text, 'stretch')
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign content = content | default: ''
+  assign columns = columns | default: 3 | plus: 0
+  assign columns_tablet = columns_tablet | default: 2 | plus: 0
+  assign columns_mobile = columns_mobile | default: 1 | plus: 0
+  assign gap = gap | default: '1.5rem'
+  assign align = align | default: 'stretch'
+  assign id = id | default: nil
+-%}
+
+<div class="grid" style="--grid-gap: {{ gap }}; --grid-columns: {{ columns }}; --grid-columns-tablet: {{ columns_tablet }}; --grid-columns-mobile: {{ columns_mobile }}; --grid-align: {{ align }};" {% if id %}id="{{ id }}"{% endif %}>
+  {{ content }}
+</div>
+
+<style>
+.grid {
+  display: grid;
+  gap: var(--grid-gap);
+  grid-template-columns: repeat(var(--grid-columns-mobile), minmax(0, 1fr));
+  align-items: var(--grid-align);
+}
+
+@media (min-width: 600px) {
+  .grid {
+    grid-template-columns: repeat(var(--grid-columns-tablet), minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .grid {
+    grid-template-columns: repeat(var(--grid-columns), minmax(0, 1fr));
+  }
+}
+</style>

--- a/snippets/heading.liquid
+++ b/snippets/heading.liquid
@@ -1,0 +1,85 @@
+{%- comment -%}
+  Snippet: heading
+  Verwendung: {% render 'heading', text: section.settings.heading, level: 2, size: 'xl' %}
+  Parameter:
+    - text: Überschriftentext (text, 'Überschrift')
+    - level: Heading-Level 1-6 (number, 2)
+    - size: Größenvariante xs | sm | md | lg | xl | display (text, 'md')
+    - align: Textausrichtung left | center | right (text, 'left')
+    - color: Textfarbe (color, 'inherit')
+    - id: HTML-ID (text, nil)
+    - subtitle: Optionaler Untertitel (text, nil)
+    - visually_hidden: Macht den Text nur für Screenreader sichtbar (boolean, false)
+{%- endcomment -%}
+
+{%- liquid
+  assign text = text | default: 'Überschrift'
+  assign level = level | default: 2 | plus: 0
+  if level < 1 or level > 6
+    assign level = 2
+  endif
+  assign size = size | default: 'md'
+  assign align = align | default: 'left'
+  assign color = color | default: 'inherit'
+  assign id = id | default: null
+  assign subtitle = subtitle | default: null
+  assign visually_hidden = visually_hidden | default: false
+
+  assign tag_name = 'h' | append: level
+  assign heading_classes = 'heading heading--' | append: size | append: ' heading--align-' | append: align
+  if visually_hidden == true or visually_hidden == 'true'
+    assign heading_classes = heading_classes | append: ' heading--visually-hidden'
+  endif
+-%}
+
+<{{ tag_name }}
+  class="{{ heading_classes }}"
+  {% if color %}style="--heading-color: {{ color }}"{% endif %}
+  {% if id %}id="{{ id }}"{% endif %}
+>
+  <span class="heading__text">{{ text }}</span>
+  {%- if subtitle -%}
+    <span class="heading__subtitle">{{ subtitle }}</span>
+  {%- endif -%}
+</{{ tag_name }}>
+
+<style>
+.heading {
+  --heading-color: inherit;
+  color: var(--heading-color);
+  margin: 0;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.heading--visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.heading--align-left { text-align: left; }
+.heading--align-center { text-align: center; }
+.heading--align-right { text-align: right; }
+
+.heading--xs { font-size: clamp(0.75rem, 1.5vw, 0.875rem); }
+.heading--sm { font-size: clamp(0.875rem, 2vw, 1.125rem); }
+.heading--md { font-size: clamp(1.125rem, 2.5vw, 1.5rem); }
+.heading--lg { font-size: clamp(1.5rem, 3vw, 2rem); }
+.heading--xl { font-size: clamp(2rem, 4vw, 2.5rem); }
+.heading--display { font-size: clamp(2.5rem, 5vw, 3.5rem); font-weight: 700; }
+
+.heading__subtitle {
+  display: block;
+  margin-top: 0.25em;
+  font-size: 0.6em;
+  font-weight: 400;
+  opacity: 0.7;
+}
+</style>

--- a/snippets/icon-button.liquid
+++ b/snippets/icon-button.liquid
@@ -1,0 +1,102 @@
+{%- comment -%}
+  Snippet: icon-button
+  Verwendung: {% render 'icon-button', icon: 'search', label: 'Suche öffnen', url: '/search' %}
+  Parameter:
+    - icon: Icon-Name für {% render 'icon' %} (text, 'search')
+    - label: Beschriftung/Tooltip (text, 'Button')
+    - url: Link-Ziel (url, nil)
+    - style: Variante solid | ghost | subtle (text, 'solid')
+    - size: Größenvariante sm | md | lg (text, 'md')
+    - is_disabled: Deaktiviert den Button (boolean, false)
+    - aria_label: Überschreibt aria-label (text, nil)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign icon = icon | default: 'search'
+  assign label = label | default: 'Button'
+  assign url = url | default: nil
+  assign style = style | default: 'solid'
+  assign size = size | default: 'md'
+  assign is_disabled = is_disabled | default: false
+  assign aria_label = aria_label | default: label
+  assign id = id | default: null
+
+  assign tag = 'button'
+  if url and is_disabled != true and is_disabled != 'true'
+    assign tag = 'a'
+  endif
+
+  assign classes = 'icon-button icon-button--' | append: style | append: ' icon-button--' | append: size
+  if is_disabled == true or is_disabled == 'true'
+    assign classes = classes | append: ' is-disabled'
+  endif
+
+  assign disabled_attributes = ''
+  if is_disabled == true or is_disabled == 'true'
+    if tag == 'a'
+      assign disabled_attributes = ' aria-disabled="true" tabindex="-1"'
+    else
+      assign disabled_attributes = ' disabled aria-disabled="true"'
+    endif
+  endif
+-%}
+
+<{% if tag == 'a' %}a{% else %}button{% endif %}
+  class="{{ classes }}"
+  {% if tag == 'a' %}href="{{ url }}"{% else %}type="button"{% endif %}
+  aria-label="{{ aria_label | escape }}"{{ disabled_attributes }}
+  {% if id %}id="{{ id }}"{% endif %}
+>
+  <span class="icon-button__icon" aria-hidden="true">{% render 'icon', name: icon %}</span>
+  <span class="icon-button__label">{{ label }}</span>
+</{% if tag == 'a' %}a{% else %}button{% endif %}>
+
+<style>
+.icon-button {
+  --icon-button-size-sm: 2rem;
+  --icon-button-size-md: 2.5rem;
+  --icon-button-size-lg: 3rem;
+  --icon-button-bg: rgba(17, 24, 39, 0.08);
+  --icon-button-color: #111827;
+  --icon-button-bg-solid: #111827;
+  --icon-button-color-solid: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.icon-button__label { display: none; }
+.icon-button--lg .icon-button__label,
+.icon-button--md .icon-button__label { display: inline; }
+
+.icon-button--sm { width: var(--icon-button-size-sm); height: var(--icon-button-size-sm); }
+.icon-button--md { padding: 0 1rem; height: var(--icon-button-size-md); }
+.icon-button--lg { padding: 0 1.25rem; height: var(--icon-button-size-lg); }
+
+.icon-button--solid { background-color: var(--icon-button-bg-solid); color: var(--icon-button-color-solid); }
+.icon-button--solid:hover,
+.icon-button--solid:focus-visible { box-shadow: 0 6px 14px rgb(17 24 39 / 0.2); }
+
+.icon-button--ghost { background-color: transparent; color: var(--icon-button-color); border-color: currentColor; }
+.icon-button--ghost:hover,
+.icon-button--ghost:focus-visible { background-color: rgba(17, 24, 39, 0.08); }
+
+.icon-button--subtle { background-color: var(--icon-button-bg); color: var(--icon-button-color); }
+.icon-button--subtle:hover,
+.icon-button--subtle:focus-visible { background-color: rgba(17, 24, 39, 0.12); }
+
+.icon-button.is-disabled,
+.icon-button[aria-disabled="true"],
+.icon-button:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
+
+.icon-button__icon { display: inline-flex; width: 1.25em; height: 1.25em; }
+</style>

--- a/snippets/icon.liquid
+++ b/snippets/icon.liquid
@@ -1,0 +1,108 @@
+{%- comment -%}
+  Snippet: icon
+  Verwendung: {% render 'icon', name: 'arrow-right', title: 'Weiter' %}
+  Parameter:
+    - name: Icon-Name (text, 'arrow-right')
+    - title: Accessible Titel (text, nil)
+    - size: Kantenlänge in rem/em/px (text, '1em')
+    - stroke_width: Strichstärke für Outline-Icons (number, 1.5)
+    - decorative: Wenn true, aria-hidden (boolean, true)
+    - class: Zusätzliche Klasse (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign name = name | default: 'arrow-right'
+  assign title = title | default: null
+  assign size = size | default: '1em'
+  assign stroke_width = stroke_width | default: 1.5
+  assign decorative = decorative | default: true
+  assign class = class | default: null
+
+  assign aria_hidden = 'false'
+  assign role_attr = 'img'
+  if decorative == true or decorative == 'true'
+    assign aria_hidden = 'true'
+    assign role_attr = 'presentation'
+    assign title = null
+  endif
+
+  assign classes = 'icon icon--' | append: name
+  if class
+    assign classes = classes | append: ' ' | append: class
+  endif
+-%}
+
+{% capture icon_markup %}
+  {% case name %}
+    {% when 'arrow-right' %}
+      <svg class="{{ classes }}" role="{{ role_attr }}" aria-hidden="{{ aria_hidden }}" {% if title %}aria-label="{{ title | escape }}"{% endif %} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke_width }}" stroke-linecap="round" stroke-linejoin="round">
+        {% if title %}<title>{{ title }}</title>{% endif %}
+        <path d="M5 12h14"></path>
+        <path d="m13 6 6 6-6 6"></path>
+      </svg>
+    {% when 'arrow-left' %}
+      <svg class="{{ classes }}" role="{{ role_attr }}" aria-hidden="{{ aria_hidden }}" {% if title %}aria-label="{{ title | escape }}"{% endif %} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke_width }}" stroke-linecap="round" stroke-linejoin="round">
+        {% if title %}<title>{{ title }}</title>{% endif %}
+        <path d="M19 12H5"></path>
+        <path d="m11 18-6-6 6-6"></path>
+      </svg>
+    {% when 'check' %}
+      <svg class="{{ classes }}" role="{{ role_attr }}" aria-hidden="{{ aria_hidden }}" {% if title %}aria-label="{{ title | escape }}"{% endif %} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke_width }}" stroke-linecap="round" stroke-linejoin="round">
+        {% if title %}<title>{{ title }}</title>{% endif %}
+        <path d="m5 13 4 4L19 7"></path>
+      </svg>
+    {% when 'close' %}
+      <svg class="{{ classes }}" role="{{ role_attr }}" aria-hidden="{{ aria_hidden }}" {% if title %}aria-label="{{ title | escape }}"{% endif %} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke_width }}" stroke-linecap="round" stroke-linejoin="round">
+        {% if title %}<title>{{ title }}</title>{% endif %}
+        <path d="M18 6 6 18"></path>
+        <path d="m6 6 12 12"></path>
+      </svg>
+    {% when 'search' %}
+      <svg class="{{ classes }}" role="{{ role_attr }}" aria-hidden="{{ aria_hidden }}" {% if title %}aria-label="{{ title | escape }}"{% endif %} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke_width }}" stroke-linecap="round" stroke-linejoin="round">
+        {% if title %}<title>{{ title }}</title>{% endif %}
+        <circle cx="11" cy="11" r="7"></circle>
+        <path d="m20 20-3.5-3.5"></path>
+      </svg>
+    {% when 'image' %}
+      <svg class="{{ classes }}" role="{{ role_attr }}" aria-hidden="{{ aria_hidden }}" {% if title %}aria-label="{{ title | escape }}"{% endif %} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke_width }}" stroke-linecap="round" stroke-linejoin="round">
+        {% if title %}<title>{{ title }}</title>{% endif %}
+        <rect x="3" y="5" width="18" height="14" rx="2" ry="2"></rect>
+        <circle cx="8" cy="10" r="1.5"></circle>
+        <path d="M21 15.5 16 11l-5 5"></path>
+      </svg>
+    {% when 'star' %}
+      <svg class="{{ classes }}" role="{{ role_attr }}" aria-hidden="{{ aria_hidden }}" {% if title %}aria-label="{{ title | escape }}"{% endif %} viewBox="0 0 24 24" fill="currentColor" stroke="none">
+        {% if title %}<title>{{ title }}</title>{% endif %}
+        <path d="M12 2.5 14.9 9l6.6.5-5 4.3 1.6 6.5-6.1-3.7-6.1 3.7 1.6-6.5-5-4.3 6.6-.5L12 2.5Z"></path>
+      </svg>
+    {% when 'cart' %}
+      <svg class="{{ classes }}" role="{{ role_attr }}" aria-hidden="{{ aria_hidden }}" {% if title %}aria-label="{{ title | escape }}"{% endif %} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke_width }}" stroke-linecap="round" stroke-linejoin="round">
+        {% if title %}<title>{{ title }}</title>{% endif %}
+        <circle cx="9" cy="20" r="1"></circle>
+        <circle cx="17" cy="20" r="1"></circle>
+        <path d="M3 4h2l2.4 12.2a1 1 0 0 0 1 .8H19"></path>
+        <path d="m7 8 13-.5-1 6H8"></path>
+      </svg>
+    {% else %}
+      <span class="{{ classes }}" aria-hidden="true">&#9632;</span>
+    {% endcase %}
+{% endcapture %}
+
+<div class="icon-wrapper" style="--icon-size: {{ size }};">
+  {{ icon_markup | strip }}
+</div>
+
+<style>
+.icon-wrapper {
+  display: inline-flex;
+  width: var(--icon-size);
+  height: var(--icon-size);
+  align-items: center;
+  justify-content: center;
+}
+
+.icon {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/snippets/image.liquid
+++ b/snippets/image.liquid
@@ -1,0 +1,103 @@
+{%- comment -%}
+  Snippet: image
+  Verwendung: {% render 'image', image: section.settings.image, alt: section.settings.alt_text, aspect_ratio: '16/9' %}
+  Parameter:
+    - image: Shopify Image-Objekt (image, nil)
+    - alt: Alternativtext (text, Bild-Alt oder '')
+    - sizes: sizes-Attribut (text, '100vw')
+    - widths: Responsive Widths CSV (text, '320,480,768,1024,1440,2048')
+    - aspect_ratio: Erzwingt Ratio (text, nil)
+    - object_fit: object-fit Wert (text, 'cover')
+    - loading: Ladeverhalten auto | lazy | eager (text, 'lazy')
+    - id: HTML-ID (text, nil)
+    - class: Zusätzliche Klasse (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign image = image | default: nil
+  assign alt = alt | default: ''
+  if image and image.alt and alt == ''
+    assign alt = image.alt
+  endif
+  assign sizes = sizes | default: '100vw'
+  assign widths = widths | default: '320,480,768,1024,1440,2048'
+  assign aspect_ratio = aspect_ratio | default: null
+  assign object_fit = object_fit | default: 'cover'
+  assign loading = loading | default: 'lazy'
+  assign id = id | default: null
+  assign class = class | default: null
+
+  assign wrapper_classes = 'image'
+  if class
+    assign wrapper_classes = wrapper_classes | append: ' ' | append: class
+  endif
+  if aspect_ratio
+    assign wrapper_classes = wrapper_classes | append: ' image--ratio'
+  endif
+
+  assign style_attributes = ''
+  assign style_attributes = style_attributes | append: '--image-object-fit: ' | append: object_fit | append: ';'
+  if aspect_ratio
+    assign style_attributes = style_attributes | append: ' --image-aspect-ratio: ' | append: aspect_ratio | append: ';'
+  endif
+-%}
+
+<div class="{{ wrapper_classes }}" {% if id %}id="{{ id }}"{% endif %} style="{{ style_attributes | strip }}">
+  {%- if image -%}
+    {%- assign image_class = 'image__media' -%}
+    {{ image | image_url: width: image.width | image_tag:
+      loading: loading,
+      class: image_class,
+      sizes: sizes,
+      widths: widths,
+      alt: alt | escape
+    }}
+  {%- else -%}
+    <div class="image__placeholder" role="img" aria-label="{{ alt | default: 'Platzhalterbild' | escape }}">
+      <span class="image__placeholder-icon" aria-hidden="true">☐</span>
+    </div>
+  {%- endif -%}
+</div>
+
+<style>
+.image {
+  position: relative;
+  display: block;
+  width: 100%;
+  overflow: hidden;
+}
+
+.image--ratio::before {
+  content: '';
+  display: block;
+  padding-bottom: calc(100% / (var(--image-aspect-ratio)));
+}
+
+.image--ratio > * {
+  position: absolute;
+  inset: 0;
+}
+
+.image__media {
+  width: 100%;
+  height: 100%;
+  object-fit: var(--image-object-fit, cover);
+  display: block;
+}
+
+.image[style*='--image-aspect-ratio'] {
+  --image-object-fit: {{ object_fit }};
+}
+
+.image__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: repeating-linear-gradient(45deg, rgba(17, 24, 39, 0.08), rgba(17, 24, 39, 0.08) 10px, transparent 10px, transparent 20px);
+  color: rgba(17, 24, 39, 0.4);
+  font-size: 2rem;
+  width: 100%;
+  height: 100%;
+  min-height: 150px;
+}
+</style>

--- a/snippets/input.liquid
+++ b/snippets/input.liquid
@@ -1,0 +1,136 @@
+{%- comment -%}
+  Snippet: input
+  Verwendung: {% render 'input', name: 'email', type: 'email', label: 'E-Mail', required: true %}
+  Parameter:
+    - name: Input-Name (text, 'input-field')
+    - type: Input-Typ (text, 'text')
+    - value: Vorbefüllter Wert (text, nil)
+    - label: Beschriftung (text, nil)
+    - placeholder: Platzhalter (text, nil)
+    - helper_text: Hilfetext unter dem Feld (text, nil)
+    - error: Fehlermeldung (text, nil)
+    - required: Pflichtfeld (boolean, false)
+    - disabled: Deaktiviert (boolean, false)
+    - autocomplete: Autocomplete-Attribut (text, nil)
+    - inputmode: Inputmode-Attribut (text, nil)
+    - form: Formular-ID (text, nil)
+    - pattern: Regex-Pattern (text, nil)
+    - maxlength: Maximale Länge (number, nil)
+    - minlength: Minimale Länge (number, nil)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign name = name | default: 'input-field'
+  assign type = type | default: 'text'
+  assign value = value | default: nil
+  assign label = label | default: nil
+  assign placeholder = placeholder | default: nil
+  assign helper_text = helper_text | default: nil
+  assign error = error | default: nil
+  assign required = required | default: false
+  assign disabled = disabled | default: false
+  assign autocomplete = autocomplete | default: nil
+  assign inputmode = inputmode | default: nil
+  assign form = form | default: nil
+  assign pattern = pattern | default: nil
+  assign maxlength = maxlength | default: nil
+  assign minlength = minlength | default: nil
+  assign id = id | default: name | handle | prepend: 'input-'
+
+  assign wrapper_classes = 'input'
+  if error
+    assign wrapper_classes = wrapper_classes | append: ' input--error'
+  endif
+
+  assign describedby = ''
+  if helper_text
+    assign describedby = describedby | append: id | append: '-helper'
+  endif
+  if error
+    if describedby != ''
+      assign describedby = describedby | append: ' ' | append: id | append: '-error'
+    else
+      assign describedby = describedby | append: id | append: '-error'
+    endif
+  endif
+-%}
+
+<div class="{{ wrapper_classes }}">
+  {%- if label -%}
+    <label class="input__label" for="{{ id }}">
+      {{ label }}
+      {%- if required == true or required == 'true' -%}
+        <span class="input__required" aria-hidden="true">*</span>
+      {%- endif -%}
+    </label>
+  {%- endif -%}
+  <input
+    class="input__field"
+    type="{{ type }}"
+    name="{{ name }}"
+    id="{{ id }}"
+    {% if value != nil %}value="{{ value }}"{% endif %}
+    {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
+    {% if required == true or required == 'true' %}required aria-required="true"{% endif %}
+    {% if disabled == true or disabled == 'true' %}disabled aria-disabled="true"{% endif %}
+    {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
+    {% if inputmode %}inputmode="{{ inputmode }}"{% endif %}
+    {% if form %}form="{{ form }}"{% endif %}
+    {% if pattern %}pattern="{{ pattern }}"{% endif %}
+    {% if maxlength %}maxlength="{{ maxlength }}"{% endif %}
+    {% if minlength %}minlength="{{ minlength }}"{% endif %}
+    {% if describedby != '' %}aria-describedby="{{ describedby }}"{% endif %}
+  >
+  {%- if helper_text -%}
+    <p class="input__helper" id="{{ id }}-helper">{{ helper_text }}</p>
+  {%- endif -%}
+  {%- if error -%}
+    <p class="input__error" role="alert" id="{{ id }}-error">{{ error }}</p>
+  {%- endif -%}
+</div>
+
+<style>
+.input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.input__label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.input__required { color: var(--color-required, #dc2626); }
+
+.input__field {
+  font: inherit;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(17, 24, 39, 0.15);
+  border-radius: 0.375rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input__field:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.input__helper {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.input__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #dc2626;
+}
+
+.input--error .input__field {
+  border-color: #dc2626;
+}
+</style>

--- a/snippets/link.liquid
+++ b/snippets/link.liquid
@@ -1,0 +1,87 @@
+{%- comment -%}
+  Snippet: link
+  Verwendung: {% render 'link', text: 'Mehr erfahren', url: section.settings.link, icon: 'arrow-right' %}
+  Parameter:
+    - text: Linktext (text, 'Link')
+    - url: Ziel-URL (url, '#')
+    - style: Variante default | subtle | button (text, 'default')
+    - icon: Icon-Name für {% render 'icon' %} (text, nil)
+    - icon_position: Position des Icons left | right (text, 'right')
+    - target_blank: Öffnet Link in neuem Tab (boolean, false)
+    - underline: Erzwingt Unterstreichung (boolean, false)
+    - aria_label: Überschreibt aria-label (text, nil)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign text = text | default: 'Link'
+  assign url = url | default: '#'
+  assign style = style | default: 'default'
+  assign icon_position = icon_position | default: 'right'
+  assign target_blank = target_blank | default: false
+  assign underline = underline | default: false
+  assign aria_label = aria_label | default: text
+  assign id = id | default: null
+
+  assign has_icon = icon | default: false
+  assign link_classes = 'link link--' | append: style
+  if underline == true or underline == 'true'
+    assign link_classes = link_classes | append: ' link--underline'
+  endif
+  if has_icon
+    assign link_classes = link_classes | append: ' link--with-icon link--icon-' | append: icon_position
+  endif
+-%}
+
+<a
+  class="{{ link_classes }}"
+  href="{{ url }}"
+  aria-label="{{ aria_label | escape }}"
+  {% if id %}id="{{ id }}"{% endif %}
+  {% if target_blank %}target="_blank" rel="noopener noreferrer"{% endif %}
+>
+  {%- if has_icon and icon_position == 'left' -%}
+    <span class="link__icon" aria-hidden="true">{% render 'icon', name: icon %}</span>
+  {%- endif -%}
+  <span class="link__text">{{ text }}</span>
+  {%- if has_icon and icon_position == 'right' -%}
+    <span class="link__icon" aria-hidden="true">{% render 'icon', name: icon %}</span>
+  {%- endif -%}
+</a>
+
+<style>
+.link {
+  --link-color: var(--color-link, currentColor);
+  --link-color-hover: var(--color-link-hover, currentColor);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--link-color);
+  text-decoration: none;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.link--underline { text-decoration: underline; }
+.link--underline:hover,
+.link--underline:focus-visible { text-decoration: none; }
+
+.link--subtle { opacity: 0.8; font-weight: 400; }
+.link--subtle:hover,
+.link--subtle:focus-visible { opacity: 1; }
+
+.link--button { padding: 0.25rem 0.75rem; border-radius: 999px; background-color: rgba(17, 24, 39, 0.08); }
+.link--button:hover,
+.link--button:focus-visible { background-color: rgba(17, 24, 39, 0.15); }
+
+.link--with-icon .link__icon {
+  display: inline-flex;
+  width: 1em;
+  height: 1em;
+}
+
+.link:hover,
+.link:focus-visible {
+  color: var(--link-color-hover);
+}
+</style>

--- a/snippets/loading-spinner.liquid
+++ b/snippets/loading-spinner.liquid
@@ -1,0 +1,49 @@
+{%- comment -%}
+  Snippet: loading-spinner
+  Verwendung: {% render 'loading-spinner', label: 'Wird geladen', size: 'sm' %}
+  Parameter:
+    - label: ARIA-Label (text, 'Lädt...')
+    - size: sm | md | lg (text, 'md')
+    - inline: Inline-Darstellung (boolean, false)
+{%- endcomment -%}
+
+{%- liquid
+  assign label = label | default: 'Lädt...'
+  assign size = size | default: 'md'
+  assign inline = inline | default: false
+-%}
+
+<div class="spinner spinner--{{ size }}{% if inline == true or inline == 'true' %} spinner--inline{% endif %}" role="status" aria-live="polite" aria-label="{{ label }}">
+  <span class="spinner__circle" aria-hidden="true"></span>
+</div>
+
+<style>
+.spinner {
+  --spinner-size-sm: 1.5rem;
+  --spinner-size-md: 2rem;
+  --spinner-size-lg: 3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--spinner-size-md);
+  height: var(--spinner-size-md);
+}
+
+.spinner--sm { width: var(--spinner-size-sm); height: var(--spinner-size-sm); }
+.spinner--lg { width: var(--spinner-size-lg); height: var(--spinner-size-lg); }
+
+.spinner__circle {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 2px solid rgba(17, 24, 39, 0.1);
+  border-top-color: #2563eb;
+  animation: spinner-rotate 0.8s linear infinite;
+}
+
+.spinner--inline { display: inline-flex; }
+
+@keyframes spinner-rotate {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/snippets/menu-item.liquid
+++ b/snippets/menu-item.liquid
@@ -1,0 +1,102 @@
+{%- comment -%}
+  Snippet: menu-item
+  Verwendung: {% render 'menu-item', link: link, depth: 1 %}
+  Parameter:
+    - link: Linklist-Objekt (link, nil)
+    - depth: Verschachtelungstiefe (number, 1)
+    - show_indicator: Pfeil für Untermenüs anzeigen (boolean, true)
+    - is_active: Erzwingt Active-State (boolean, false)
+{%- endcomment -%}
+
+{%- liquid
+  assign link = link | default: nil
+  assign depth = depth | default: 1 | plus: 0
+  assign show_indicator = show_indicator | default: true
+  assign is_active = is_active | default: false
+
+  if link == nil
+    echo '<!-- menu-item: Link fehlt -->'
+  endif
+-%}
+
+{%- if link -%}
+  <li class="menu-item menu-item--depth-{{ depth }}{% if link.active or is_active == true or is_active == 'true' %} is-active{% endif %}">
+    <a href="{{ link.url }}" class="menu-item__link" {% if link.current %}aria-current="page"{% endif %}>{{ link.title }}</a>
+    {%- if link.links and link.links.size > 0 -%}
+      <button class="menu-item__toggle" type="button" aria-expanded="false" aria-controls="submenu-{{ link.handle | default: link.title | handle }}" {% if show_indicator != true and show_indicator != 'true' %}hidden{% endif %}>
+        {% render 'icon', name: 'arrow-right', decorative: true %}
+      </button>
+      <ul class="menu-item__submenu" id="submenu-{{ link.handle | default: link.title | handle }}" hidden>
+        {%- for child in link.links -%}
+          {% render 'menu-item', link: child, depth: depth | plus: 1, show_indicator: show_indicator %}
+        {%- endfor -%}
+      </ul>
+    {%- endif -%}
+  </li>
+{%- endif -%}
+
+<style>
+.menu-item {
+  position: relative;
+  list-style: none;
+}
+
+.menu-item__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.75rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.menu-item.is-active > .menu-item__link {
+  font-weight: 600;
+}
+
+.menu-item__toggle {
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  margin-left: 0.5rem;
+  cursor: pointer;
+}
+
+.menu-item__submenu {
+  margin: 0;
+  padding-left: 1rem;
+  list-style: none;
+}
+
+.menu-item__toggle svg {
+  transition: transform 0.2s ease;
+}
+
+.menu-item__toggle[aria-expanded="true"] svg {
+  transform: rotate(90deg);
+}
+</style>
+
+<script>
+(function () {
+  var script = document.currentScript;
+  if (!script) return;
+  var node = script.previousElementSibling;
+  while (node && node.tagName === 'STYLE') {
+    node = node.previousElementSibling;
+  }
+  if (!node) return;
+  var toggle = node.querySelector('.menu-item__toggle');
+  var submenu = node.querySelector('.menu-item__submenu');
+  if (!toggle || !submenu) return;
+  toggle.addEventListener('click', function () {
+    var expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', (!expanded).toString());
+    if (expanded) {
+      submenu.setAttribute('hidden', '');
+    } else {
+      submenu.removeAttribute('hidden');
+    }
+  });
+})();
+</script>

--- a/snippets/pagination.liquid
+++ b/snippets/pagination.liquid
@@ -1,0 +1,98 @@
+{%- comment -%}
+  Snippet: pagination
+  Verwendung: {% render 'pagination', paginate: paginate %}
+  Parameter:
+    - paginate: Shopify Paginate Objekt (paginate, nil)
+    - show_summary: Seitensummary anzeigen (boolean, true)
+    - show_prev_next: Vor/Zurück anzeigen (boolean, true)
+{%- endcomment -%}
+
+{%- liquid
+  assign paginate = paginate | default: nil
+  assign show_summary = show_summary | default: true
+  assign show_prev_next = show_prev_next | default: true
+
+  if paginate == nil or paginate.pages <= 1
+    assign render_pagination = false
+  else
+    assign render_pagination = true
+  endif
+-%}
+
+{%- if render_pagination -%}
+  <nav class="pagination" role="navigation" aria-label="Pagination">
+    {%- if show_summary == true or show_summary == 'true' -%}
+      <div class="pagination__summary">{{ 'general.pagination.summary' | t: current_page: paginate.current_page, pages: paginate.pages }}</div>
+    {%- endif -%}
+    <ol class="pagination__list">
+      {%- if (show_prev_next == true or show_prev_next == 'true') and paginate.previous -%}
+        <li class="pagination__item pagination__item--prev">
+          <a href="{{ paginate.previous.url }}" class="pagination__link" rel="prev">&larr;</a>
+        </li>
+      {%- endif -%}
+      {%- for part in paginate.parts -%}
+        <li class="pagination__item{% if part.is_link != true %} is-active{% endif %}">
+          {%- if part.is_link -%}
+            <a href="{{ part.url }}" class="pagination__link">{{ part.title }}</a>
+          {%- else -%}
+            <span class="pagination__link" aria-current="page">{{ part.title }}</span>
+          {%- endif -%}
+        </li>
+      {%- endfor -%}
+      {%- if (show_prev_next == true or show_prev_next == 'true') and paginate.next -%}
+        <li class="pagination__item pagination__item--next">
+          <a href="{{ paginate.next.url }}" class="pagination__link" rel="next">&rarr;</a>
+        </li>
+      {%- endif -%}
+    </ol>
+  </nav>
+{%- endif -%}
+
+<style>
+.pagination {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.pagination__summary {
+  font-size: 0.8125rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.pagination__list {
+  display: inline-flex;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+}
+
+.pagination__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  padding: 0 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid rgba(17, 24, 39, 0.15);
+  text-decoration: none;
+  color: inherit;
+  font-size: 0.875rem;
+}
+
+.pagination__link:hover,
+.pagination__link:focus-visible {
+  border-color: #2563eb;
+}
+
+.pagination__item.is-active .pagination__link,
+.pagination__item.is-active span.pagination__link {
+  background: #2563eb;
+  color: #ffffff;
+  border-color: #2563eb;
+}
+</style>

--- a/snippets/paragraph.liquid
+++ b/snippets/paragraph.liquid
@@ -1,0 +1,60 @@
+{%- comment -%}
+  Snippet: paragraph
+  Verwendung: {% render 'paragraph', text: section.settings.body, size: 'lg', align: 'center' %}
+  Parameter:
+    - text: Absatztext (text, 'Lorem ipsum dolor sit amet')
+    - size: Größenvariante xs | sm | md | lg (text, 'md')
+    - align: Textausrichtung left | center | right (text, 'left')
+    - color: Textfarbe (color, 'inherit')
+    - max_width: Maximale Breite (text, '60ch')
+    - is_richtext: Rendert den Text als HTML (boolean, false)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign text = text | default: 'Lorem ipsum dolor sit amet'
+  assign size = size | default: 'md'
+  assign align = align | default: 'left'
+  assign color = color | default: 'inherit'
+  assign max_width = max_width | default: '60ch'
+  assign is_richtext = is_richtext | default: false
+  assign id = id | default: null
+
+  assign paragraph_classes = 'paragraph paragraph--' | append: size | append: ' paragraph--align-' | append: align
+-%}
+
+<p
+  class="{{ paragraph_classes }}"
+  style="--paragraph-color: {{ color }}; --paragraph-max-width: {{ max_width }};"
+  {% if id %}id="{{ id }}"{% endif %}
+>
+  {%- if is_richtext == true or is_richtext == 'true' -%}
+    {{ text }}
+  {%- else -%}
+    {{ text | escape }}
+  {%- endif -%}
+</p>
+
+<style>
+.paragraph {
+  --paragraph-color: inherit;
+  --paragraph-max-width: none;
+  color: var(--paragraph-color);
+  margin: 0;
+  max-width: var(--paragraph-max-width);
+}
+
+.paragraph--align-left { text-align: left; }
+.paragraph--align-center { text-align: center; margin-left: auto; margin-right: auto; }
+.paragraph--align-right { text-align: right; margin-left: auto; }
+
+.paragraph--xs { font-size: clamp(0.75rem, 1.5vw, 0.875rem); }
+.paragraph--sm { font-size: clamp(0.875rem, 1.75vw, 0.95rem); }
+.paragraph--md { font-size: clamp(1rem, 2vw, 1.0625rem); }
+.paragraph--lg { font-size: clamp(1.0625rem, 2.5vw, 1.125rem); line-height: 1.8; }
+
+.paragraph--lg,
+.paragraph--md,
+.paragraph--sm,
+.paragraph--xs { line-height: 1.6; }
+</style>

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -1,0 +1,109 @@
+{%- comment -%}
+  Snippet: price
+  Verwendung: {% render 'price', product: product, show_discount: true %}
+  Parameter:
+    - product: Produktobjekt (product, nil)
+    - variant: Variantenobjekt (variant, nil)
+    - price: Preis in Cent (number, nil)
+    - compare_at_price: Vergleichspreis in Cent (number, nil)
+    - unit_price: Grundpreis in Cent (number, nil)
+    - unit_price_measurement: Einheit (text, nil)
+    - show_discount: Rabatt-Badge anzeigen (boolean, false)
+    - alignment: Textausrichtung left | center | right (text, 'left')
+{%- endcomment -%}
+
+{%- liquid
+  assign product = product | default: nil
+  assign variant = variant | default: nil
+  assign price = price | default: nil
+  assign compare_at_price = compare_at_price | default: nil
+  assign unit_price = unit_price | default: nil
+  assign unit_price_measurement = unit_price_measurement | default: nil
+  assign show_discount = show_discount | default: false
+  assign alignment = alignment | default: 'left'
+
+  if variant
+    assign price = variant.price
+    assign compare_at_price = variant.compare_at_price
+    assign unit_price = variant.unit_price
+    assign unit_price_measurement = variant.unit_price_measurement
+  elsif product
+    if price == nil
+      assign price = product.price | default: product.price_min
+    endif
+    if compare_at_price == nil
+      assign compare_at_price = product.compare_at_price
+      if compare_at_price == blank and product.compare_at_price_max > product.compare_at_price_min
+        assign compare_at_price = product.compare_at_price_max
+      endif
+    endif
+    if unit_price == nil and product.variants.size > 0
+      assign first_variant = product.variants | first
+      assign unit_price = first_variant.unit_price
+      assign unit_price_measurement = first_variant.unit_price_measurement
+    endif
+  endif
+
+  assign has_compare = compare_at_price and compare_at_price > price
+  assign discount_percentage = 0
+  if has_compare
+    assign discount_percentage = 100 | times: price | divided_by: compare_at_price
+    assign discount_percentage = 100 | minus: discount_percentage
+  endif
+-%}
+
+<div class="price price--align-{{ alignment }}">
+  <div class="price__main">
+    {%- if price -%}
+      <span class="price__current">{{ price | money_with_currency }}</span>
+    {%- else -%}
+      <span class="price__current">—</span>
+    {%- endif -%}
+    {%- if has_compare -%}
+      <span class="price__compare">{{ compare_at_price | money_with_currency }}</span>
+    {%- endif -%}
+    {%- if show_discount and has_compare -%}
+      {% render 'badge', text: discount_percentage | round | append: '%', style: 'danger' %}
+    {%- endif -%}
+  </div>
+  {%- if unit_price and unit_price_measurement and unit_price_measurement.reference_value -%}
+    <div class="price__unit">
+      {{ 'products.product.price.unit_price_html' | t: total_quantity: unit_price_measurement.reference_value, unit_price: unit_price | money_with_currency, unit_measure: unit_price_measurement.reference_unit }}
+    </div>
+  {%- endif -%}
+</div>
+
+<style>
+.price {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: flex-start;
+}
+
+.price--align-center { align-items: center; text-align: center; }
+.price--align-right { align-items: flex-end; text-align: right; }
+
+.price__main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.price__current {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.price__compare {
+  font-size: 1rem;
+  color: rgba(17, 24, 39, 0.5);
+  text-decoration: line-through;
+}
+
+.price__unit {
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+</style>

--- a/snippets/product-badge.liquid
+++ b/snippets/product-badge.liquid
@@ -1,0 +1,91 @@
+{%- comment -%}
+  Snippet: product-badge
+  Verwendung: {% render 'product-badge', product: product, new_days: 21 %}
+  Parameter:
+    - product: Produktobjekt (product, nil)
+    - badges: Array eigener Badges [{ text, style, icon }] (array, nil)
+    - new_days: Tage für "Neu" (number, 14)
+    - show_sale: Sale-Badge anzeigen (boolean, true)
+    - show_new: Neu-Badge anzeigen (boolean, true)
+    - show_sold_out: Ausverkauft-Badge anzeigen (boolean, true)
+{%- endcomment -%}
+
+{%- liquid
+  assign product = product | default: nil
+  assign badges = badges | default: nil
+  assign new_days = new_days | default: 14 | plus: 0
+  assign show_sale = show_sale | default: true
+  assign show_new = show_new | default: true
+  assign show_sold_out = show_sold_out | default: true
+
+  assign auto_badges = ''
+
+  if product
+    assign on_sale = false
+    if show_sale == true or show_sale == 'true'
+      if product.compare_at_price_max > product.price
+        assign on_sale = true
+      endif
+    endif
+
+    assign is_new = false
+    if show_new == true or show_new == 'true'
+      if product.published_at
+        assign now_time = 'now' | date: '%s'
+        assign publish_time = product.published_at | date: '%s'
+        assign diff = now_time | minus: publish_time
+        assign days = diff | divided_by: 86400
+        if days <= new_days
+          assign is_new = true
+        endif
+      endif
+    endif
+
+    assign sold_out = false
+    if show_sold_out == true or show_sold_out == 'true'
+      if product.available != true
+        assign sold_out = true
+      endif
+    endif
+  endif
+-%}
+
+{%- capture auto_badge_markup -%}
+  {%- if product -%}
+    {%- if on_sale -%}
+      {% render 'badge', text: 'Sale', style: 'danger' %}
+    {%- endif -%}
+    {%- if is_new -%}
+      {% render 'badge', text: 'Neu', style: 'info' %}
+    {%- endif -%}
+    {%- if sold_out -%}
+      {% render 'badge', text: 'Ausverkauft', style: 'warning' %}
+    {%- endif -%}
+  {%- endif -%}
+{%- endcapture -%}
+
+{%- assign custom_badge_markup = '' -%}
+{%- if badges and badges.size > 0 -%}
+  {%- capture custom -%}
+    {%- for badge_item in badges -%}
+      {% render 'badge', text: badge_item.text, style: badge_item.style, icon: badge_item.icon %}
+    {%- endfor -%}
+  {%- endcapture -%}
+  {%- assign custom_badge_markup = custom -%}
+{%- endif -%}
+
+{%- assign combined = auto_badge_markup | append: custom_badge_markup -%}
+
+{%- if combined != '' -%}
+  <div class="product-badge">
+    {{ combined | strip }}
+  </div>
+{%- endif -%}
+
+<style>
+.product-badge {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+</style>

--- a/snippets/quantity-selector.liquid
+++ b/snippets/quantity-selector.liquid
@@ -1,0 +1,134 @@
+{%- comment -%}
+  Snippet: quantity-selector
+  Verwendung: {% render 'quantity-selector', id: 'Quantity-{{ section.id }}', value: 1, min: 1, max: 10 %}
+  Parameter:
+    - id: Feld-ID (text, 'quantity-input')
+    - name: Feldname (text, 'quantity')
+    - value: Ausgangswert (number, 1)
+    - min: Mindestwert (number, 1)
+    - max: Maximalwert (number, nil)
+    - step: Schrittweite (number, 1)
+    - form_id: Verknüpftes Formular (text, nil)
+    - label: Beschriftung (text, 'Menge')
+{%- endcomment -%}
+
+{%- liquid
+  assign id = id | default: 'quantity-input'
+  assign name = name | default: 'quantity'
+  assign value = value | default: 1 | plus: 0
+  assign min = min | default: 1 | plus: 0
+  assign max = max | default: nil
+  assign step = step | default: 1 | plus: 0
+  assign form_id = form_id | default: nil
+  assign label = label | default: 'Menge'
+-%}
+
+<div class="quantity" data-quantity>
+  <label class="quantity__label" for="{{ id }}">{{ label }}</label>
+  <div class="quantity__controls">
+    <button class="quantity__button" type="button" data-quantity-decrease aria-label="{{ 'cart.general.reduce_quantity' | t | default: 'Menge verringern' }}">
+      {% render 'icon', name: 'arrow-left', decorative: true %}
+    </button>
+    <input
+      class="quantity__input"
+      type="number"
+      id="{{ id }}"
+      name="{{ name }}"
+      value="{{ value }}"
+      min="{{ min }}"
+      {% if max %}max="{{ max }}"{% endif %}
+      step="{{ step }}"
+      inputmode="numeric"
+      pattern="[0-9]*"
+      {% if form_id %}form="{{ form_id }}"{% endif %}
+    >
+    <button class="quantity__button" type="button" data-quantity-increase aria-label="{{ 'cart.general.increase_quantity' | t | default: 'Menge erhöhen' }}">
+      {% render 'icon', name: 'arrow-right', decorative: true %}
+    </button>
+  </div>
+</div>
+
+<style>
+.quantity {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quantity__controls {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid rgba(17, 24, 39, 0.15);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.quantity__button {
+  background: transparent;
+  border: none;
+  width: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.quantity__button:hover,
+.quantity__button:focus-visible {
+  background-color: rgba(17, 24, 39, 0.08);
+}
+
+.quantity__input {
+  width: 3rem;
+  text-align: center;
+  border: none;
+  font: inherit;
+  appearance: textfield;
+}
+
+.quantity__input:focus {
+  outline: none;
+}
+
+.quantity__input::-webkit-inner-spin-button,
+.quantity__input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+</style>
+
+<script>
+(function () {
+  var script = document.currentScript;
+  if (!script) return;
+  var el = script.previousElementSibling;
+  while (el && el.tagName === 'STYLE') {
+    el = el.previousElementSibling;
+  }
+  if (!el || !el.hasAttribute('data-quantity')) return;
+  var input = el.querySelector('.quantity__input');
+  if (!input) return;
+  var decrease = el.querySelector('[data-quantity-decrease]');
+  var increase = el.querySelector('[data-quantity-increase]');
+  var step = parseFloat(input.getAttribute('step')) || 1;
+  var min = input.hasAttribute('min') ? parseFloat(input.getAttribute('min')) : null;
+  var max = input.hasAttribute('max') ? parseFloat(input.getAttribute('max')) : null;
+  var updateValue = function(delta) {
+    var current = parseFloat(input.value);    var next = current + delta;
+    if (min !== null && next < min) next = min;
+    if (max !== null && next > max) next = max;
+    if (next !== current) {
+      input.value = next;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  };
+  if (decrease) {
+    decrease.addEventListener('click', function() { updateValue(-step); });
+  }
+  if (increase) {
+    increase.addEventListener('click', function() { updateValue(step); });
+  }
+})();
+</script>

--- a/snippets/radio.liquid
+++ b/snippets/radio.liquid
@@ -1,0 +1,136 @@
+{%- comment -%}
+  Snippet: radio
+  Verwendung: {% render 'radio', name: 'shipping', label: 'Versandart', options: shipping_options, selected: 'express' %}
+  Parameter:
+    - name: Gruppenname (text, 'radio-field')
+    - label: Feldlabel (text, nil)
+    - options: Array { value, label, helper, disabled } (array, nil)
+    - selected: Vorauswahl (text, nil)
+    - required: Pflichtfeld (boolean, false)
+    - orientation: Layout vertical | horizontal (text, 'vertical')
+    - id_prefix: ID-Präfix (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign name = name | default: 'radio-field'
+  assign label = label | default: nil
+  assign options = options | default: nil
+  assign selected = selected | default: nil
+  assign required = required | default: false
+  assign orientation = orientation | default: 'vertical'
+  assign id_prefix = id_prefix | default: name | handle
+
+  assign wrapper_classes = 'radio radio--' | append: orientation
+-%}
+
+<fieldset class="{{ wrapper_classes }}">
+  {%- if label -%}
+    <legend class="radio__legend">
+      {{ label }}
+      {%- if required == true or required == 'true' -%}<span class="radio__required" aria-hidden="true">*</span>{%- endif -%}
+    </legend>
+  {%- endif -%}
+  <div class="radio__group">
+    {%- if options -%}
+      {%- for option in options -%}
+        {%- assign option_id = id_prefix | append: '-' | append: forloop.index -%}
+        {%- assign option_classes = 'radio__option' -%}
+        {%- if option.disabled -%}
+          {%- assign option_classes = option_classes | append: ' radio__option--disabled' -%}
+        {%- endif -%}
+        <label class="{{ option_classes }}" for="{{ option_id }}"{% if option.disabled %} aria-disabled="true"{% endif %}>
+          <input
+            class="radio__field"
+            type="radio"
+            name="{{ name }}"
+            id="{{ option_id }}"
+            value="{{ option.value }}"
+            {% if option.value == selected %}checked{% endif %}
+            {% if required == true or required == 'true' and forloop.first %}required aria-required="true"{% endif %}
+            {% if option.disabled %}disabled aria-disabled="true"{% endif %}
+          >
+          <span class="radio__indicator" aria-hidden="true"></span>
+          <span class="radio__text">
+            {{ option.label }}
+            {%- if option.helper -%}
+              <span class="radio__helper">{{ option.helper }}</span>
+            {%- endif -%}
+          </span>
+        </label>
+      {%- endfor -%}
+    {%- else -%}
+      <p class="radio__empty">Keine Optionen verfügbar.</p>
+    {%- endif -%}
+  </div>
+</fieldset>
+
+<style>
+.radio {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.radio__legend {
+  font-size: 0.9rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.radio__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.radio--horizontal .radio__group {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.radio__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  position: relative;
+}
+
+.radio__field {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.radio__indicator {
+  width: 1.125rem;
+  height: 1.125rem;
+  border-radius: 999px;
+  border: 1.5px solid rgba(17, 24, 39, 0.6);
+  position: relative;
+  transition: border-color 0.2s ease;
+}
+
+.radio__indicator::after {
+  content: '';
+  position: absolute;
+  inset: 0.1875rem;
+  border-radius: 999px;
+  background: #2563eb;
+  transform: scale(0);
+  transition: transform 0.2s ease;
+}
+
+.radio__field:checked + .radio__indicator { border-color: #2563eb; }
+.radio__field:checked + .radio__indicator::after { transform: scale(1); }
+
+.radio__text { font-size: 0.875rem; display: flex; flex-direction: column; }
+.radio__helper { font-size: 0.75rem; color: rgba(17, 24, 39, 0.6); }
+
+.radio__option--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.radio__empty { font-size: 0.875rem; color: rgba(17, 24, 39, 0.6); margin: 0; }
+</style>

--- a/snippets/select.liquid
+++ b/snippets/select.liquid
@@ -1,0 +1,137 @@
+{%- comment -%}
+  Snippet: select
+  Verwendung: {% render 'select', name: 'size', label: 'Größe', options: size_options, placeholder: 'Bitte wählen' %}
+  Parameter:
+    - name: Feldname (text, 'select-field')
+    - label: Beschriftung (text, nil)
+    - options: Array mit { value, label, disabled } (array, nil)
+    - selected: Ausgewählter Wert (text, nil)
+    - placeholder: Placeholder-Option (text, nil)
+    - helper_text: Hilfetext (text, nil)
+    - error: Fehlermeldung (text, nil)
+    - required: Pflichtfeld (boolean, false)
+    - disabled: Deaktiviert (boolean, false)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign name = name | default: 'select-field'
+  assign label = label | default: nil
+  assign options = options | default: nil
+  assign selected = selected | default: nil
+  assign placeholder = placeholder | default: nil
+  assign helper_text = helper_text | default: nil
+  assign error = error | default: nil
+  assign required = required | default: false
+  assign disabled = disabled | default: false
+  assign id = id | default: name | handle | prepend: 'select-'
+
+  assign wrapper_classes = 'select'
+  if error
+    assign wrapper_classes = wrapper_classes | append: ' select--error'
+  endif
+
+  assign describedby = ''
+  if helper_text
+    assign describedby = describedby | append: id | append: '-helper'
+  endif
+  if error
+    if describedby != ''
+      assign describedby = describedby | append: ' ' | append: id | append: '-error'
+    else
+      assign describedby = describedby | append: id | append: '-error'
+    endif
+  endif
+-%}
+
+<div class="{{ wrapper_classes }}">
+  {%- if label -%}
+    <label class="select__label" for="{{ id }}">
+      {{ label }}
+      {%- if required == true or required == 'true' -%}<span class="select__required" aria-hidden="true">*</span>{%- endif -%}
+    </label>
+  {%- endif -%}
+  <div class="select__wrapper">
+    <select
+      class="select__field"
+      name="{{ name }}"
+      id="{{ id }}"
+      {% if required == true or required == 'true' %}required aria-required="true"{% endif %}
+      {% if disabled == true or disabled == 'true' %}disabled aria-disabled="true"{% endif %}
+      {% if describedby != '' %}aria-describedby="{{ describedby }}"{% endif %}
+    >
+      {%- if placeholder -%}
+        <option value="" disabled {% if selected == blank or selected == '' %}selected{% endif %}>{{ placeholder }}</option>
+      {%- endif -%}
+      {%- if options -%}
+        {%- for option in options -%}
+          <option value="{{ option.value }}" {% if option.value == selected %}selected{% endif %} {% if option.disabled %}disabled{% endif %}>{{ option.label }}</option>
+        {%- endfor -%}
+      {%- endif -%}
+    </select>
+    <span class="select__icon" aria-hidden="true">▼</span>
+  </div>
+  {%- if helper_text -%}
+    <p class="select__helper" id="{{ id }}-helper">{{ helper_text }}</p>
+  {%- endif -%}
+  {%- if error -%}
+    <p class="select__error" role="alert" id="{{ id }}-error">{{ error }}</p>
+  {%- endif -%}
+</div>
+
+<style>
+.select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.select__label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.select__wrapper {
+  position: relative;
+}
+
+.select__field {
+  appearance: none;
+  width: 100%;
+  font: inherit;
+  padding: 0.75rem 2.5rem 0.75rem 0.9rem;
+  border: 1px solid rgba(17, 24, 39, 0.15);
+  border-radius: 0.375rem;
+  background-color: #ffffff;
+}
+
+.select__field:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.select__icon {
+  position: absolute;
+  inset-inline-end: 0.75rem;
+  inset-block-start: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.5);
+}
+
+.select__helper {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.select__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #dc2626;
+}
+
+.select--error .select__field { border-color: #dc2626; }
+</style>

--- a/snippets/spacer.liquid
+++ b/snippets/spacer.liquid
@@ -1,0 +1,29 @@
+{%- comment -%}
+  Snippet: spacer
+  Verwendung: {% render 'spacer', size: '2rem' %}
+  Parameter:
+    - size: Abstandshöhe (text, '1rem')
+    - show_line: Optional Linie anzeigen (boolean, false)
+    - aria_hidden: Visuell unsichtbar für Screenreader (boolean, true)
+{%- endcomment -%}
+
+{%- liquid
+  assign size = size | default: '1rem'
+  assign show_line = show_line | default: false
+  assign aria_hidden = aria_hidden | default: true
+-%}
+
+<div class="spacer{% if show_line == true or show_line == 'true' %} spacer--line{% endif %}" style="--spacer-size: {{ size }};" {% if aria_hidden == true or aria_hidden == 'true' %}aria-hidden="true"{% endif %}></div>
+
+<style>
+.spacer {
+  width: 100%;
+  height: var(--spacer-size);
+}
+
+.spacer--line {
+  height: auto;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.1);
+  padding-bottom: var(--spacer-size);
+}
+</style>

--- a/snippets/success-message.liquid
+++ b/snippets/success-message.liquid
@@ -1,0 +1,69 @@
+{%- comment -%}
+  Snippet: success-message
+  Verwendung: {% render 'success-message', message: 'Danke für deine Anmeldung!' %}
+  Parameter:
+    - message: Erfolgstext (text, 'Aktion erfolgreich abgeschlossen.')
+    - icon: Icon-Name (text, 'check')
+    - dismissible: Schließen-Button (boolean, false)
+{%- endcomment -%}
+
+{%- liquid
+  assign message = message | default: 'Aktion erfolgreich abgeschlossen.'
+  assign icon = icon | default: 'check'
+  assign dismissible = dismissible | default: false
+-%}
+
+<div class="alert alert--success" role="status">
+  <span class="alert__icon">{% render 'icon', name: icon, decorative: true %}</span>
+  <div class="alert__content">{{ message }}</div>
+  {%- if dismissible == true or dismissible == 'true' -%}
+    <button type="button" class="alert__close" aria-label="{{ 'general.close' | t | default: 'Schließen' }}">{% render 'icon', name: 'close', decorative: true %}</button>
+  {%- endif -%}
+</div>
+
+<style>
+.alert {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: rgba(17, 24, 39, 0.05);
+  color: #111827;
+}
+
+.alert--success {
+  background: rgba(34, 197, 94, 0.1);
+  color: #047857;
+}
+
+.alert__icon { display: inline-flex; }
+.alert__content { font-size: 0.875rem; }
+.alert__close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+</style>
+
+{%- if dismissible == true or dismissible == 'true' -%}
+<script>
+(function () {
+  var script = document.currentScript;
+  if (!script) return;
+  var alertEl = script.previousElementSibling.previousElementSibling;
+  while (alertEl && alertEl.tagName === 'STYLE') {
+    alertEl = alertEl.previousElementSibling;
+  }
+  if (!alertEl || !alertEl.classList.contains('alert')) return;
+  var closeBtn = alertEl.querySelector('.alert__close');
+  if (!closeBtn) return;
+  closeBtn.addEventListener('click', function () {
+    alertEl.remove();
+  });
+})();
+</script>
+{%- endif -%}

--- a/snippets/textarea.liquid
+++ b/snippets/textarea.liquid
@@ -1,0 +1,115 @@
+{%- comment -%}
+  Snippet: textarea
+  Verwendung: {% render 'textarea', name: 'message', label: 'Nachricht', rows: 5 %}
+  Parameter:
+    - name: Feldname (text, 'textarea-field')
+    - label: Beschriftung (text, nil)
+    - value: Vorbefüllter Text (text, nil)
+    - placeholder: Platzhalter (text, nil)
+    - rows: Anzahl Zeilen (number, 4)
+    - helper_text: Hilfetext (text, nil)
+    - error: Fehlermeldung (text, nil)
+    - required: Pflichtfeld (boolean, false)
+    - disabled: Deaktiviert (boolean, false)
+    - maxlength: Maximale Länge (number, nil)
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign name = name | default: 'textarea-field'
+  assign label = label | default: nil
+  assign value = value | default: nil
+  assign placeholder = placeholder | default: nil
+  assign rows = rows | default: 4
+  assign helper_text = helper_text | default: nil
+  assign error = error | default: nil
+  assign required = required | default: false
+  assign disabled = disabled | default: false
+  assign maxlength = maxlength | default: nil
+  assign id = id | default: name | handle | prepend: 'textarea-'
+
+  assign wrapper_classes = 'textarea'
+  if error
+    assign wrapper_classes = wrapper_classes | append: ' textarea--error'
+  endif
+
+  assign describedby = ''
+  if helper_text
+    assign describedby = describedby | append: id | append: '-helper'
+  endif
+  if error
+    if describedby != ''
+      assign describedby = describedby | append: ' ' | append: id | append: '-error'
+    else
+      assign describedby = describedby | append: id | append: '-error'
+    endif
+  endif
+-%}
+
+<div class="{{ wrapper_classes }}">
+  {%- if label -%}
+    <label class="textarea__label" for="{{ id }}">
+      {{ label }}
+      {%- if required == true or required == 'true' -%}<span class="textarea__required" aria-hidden="true">*</span>{%- endif -%}
+    </label>
+  {%- endif -%}
+  <textarea
+    class="textarea__field"
+    name="{{ name }}"
+    id="{{ id }}"
+    rows="{{ rows }}"
+    {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
+    {% if required == true or required == 'true' %}required aria-required="true"{% endif %}
+    {% if disabled == true or disabled == 'true' %}disabled aria-disabled="true"{% endif %}
+    {% if maxlength %}maxlength="{{ maxlength }}"{% endif %}
+    {% if describedby != '' %}aria-describedby="{{ describedby }}"{% endif %}
+  >{{ value }}</textarea>
+  {%- if helper_text -%}
+    <p class="textarea__helper" id="{{ id }}-helper">{{ helper_text }}</p>
+  {%- endif -%}
+  {%- if error -%}
+    <p class="textarea__error" role="alert" id="{{ id }}-error">{{ error }}</p>
+  {%- endif -%}
+</div>
+
+<style>
+.textarea {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.textarea__label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.textarea__field {
+  font: inherit;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(17, 24, 39, 0.15);
+  border-radius: 0.375rem;
+  min-height: 3rem;
+  resize: vertical;
+}
+
+.textarea__field:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.textarea__helper {
+  margin: 0;
+  font-size: 0.75rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.textarea__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #dc2626;
+}
+
+.textarea--error .textarea__field { border-color: #dc2626; }
+</style>

--- a/snippets/tooltip.liquid
+++ b/snippets/tooltip.liquid
@@ -1,0 +1,118 @@
+{%- comment -%}
+  Snippet: tooltip
+  Verwendung: {% render 'tooltip', trigger_text: 'Info', content: 'Weitere Details', id: 'tooltip-1' %}
+  Parameter:
+    - trigger_text: Trigger-Beschriftung (text, 'Info')
+    - content: Tooltip-Inhalt (text, 'Tooltip Text')
+    - id: Tooltip-ID (text, 'tooltip')
+    - position: top | right | bottom | left (text, 'top')
+    - icon: Optionales Icon (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign trigger_text = trigger_text | default: 'Info'
+  assign content = content | default: 'Tooltip Text'
+  assign id = id | default: 'tooltip'
+  assign position = position | default: 'top'
+  assign icon = icon | default: nil
+  assign tooltip_id = id
+-%}
+
+<div class="tooltip tooltip--{{ position }}" data-tooltip>
+  <button type="button" class="tooltip__trigger" aria-describedby="{{ tooltip_id }}" aria-expanded="false">
+    {%- if icon -%}
+      {% render 'icon', name: icon, decorative: true %}
+    {%- endif -%}
+    <span class="tooltip__text">{{ trigger_text }}</span>
+  </button>
+  <span class="tooltip__content" role="tooltip" id="{{ tooltip_id }}">{{ content }}</span>
+</div>
+
+<style>
+.tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.tooltip__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.tooltip__content {
+  position: absolute;
+  z-index: 20;
+  max-width: 16rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  background: #111827;
+  color: #ffffff;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  box-shadow: 0 10px 20px rgb(17 24 39 / 0.2);
+  opacity: 0;
+  transform: translateY(-0.5rem);
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.tooltip[data-open="true"] .tooltip__content,
+.tooltip__trigger:focus + .tooltip__content,
+.tooltip__trigger:hover + .tooltip__content {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.tooltip--top .tooltip__content { bottom: 100%; left: 50%; transform: translate(-50%, -0.5rem); }
+.tooltip--top[data-open="true"] .tooltip__content,
+.tooltip--top .tooltip__trigger:focus + .tooltip__content,
+.tooltip--top .tooltip__trigger:hover + .tooltip__content { transform: translate(-50%, -0.25rem); }
+
+.tooltip--bottom .tooltip__content { top: 100%; left: 50%; transform: translate(-50%, 0.5rem); }
+.tooltip--bottom[data-open="true"] .tooltip__content,
+.tooltip--bottom .tooltip__trigger:focus + .tooltip__content,
+.tooltip--bottom .tooltip__trigger:hover + .tooltip__content { transform: translate(-50%, 0.25rem); }
+
+.tooltip--left .tooltip__content { right: 100%; top: 50%; transform: translate(-0.5rem, -50%); }
+.tooltip--left[data-open="true"] .tooltip__content,
+.tooltip--left .tooltip__trigger:focus + .tooltip__content,
+.tooltip--left .tooltip__trigger:hover + .tooltip__content { transform: translate(-0.25rem, -50%); }
+
+.tooltip--right .tooltip__content { left: 100%; top: 50%; transform: translate(0.5rem, -50%); }
+.tooltip--right[data-open="true"] .tooltip__content,
+.tooltip--right .tooltip__trigger:focus + .tooltip__content,
+.tooltip--right .tooltip__trigger:hover + .tooltip__content { transform: translate(0.25rem, -50%); }
+</style>
+
+<script>
+(function () {
+  var script = document.currentScript;
+  if (!script) return;
+  var tooltip = script.previousElementSibling.previousElementSibling;
+  while (tooltip && tooltip.tagName === 'STYLE') {
+    tooltip = tooltip.previousElementSibling;
+  }
+  if (!tooltip || !tooltip.hasAttribute('data-tooltip')) return;
+  var trigger = tooltip.querySelector('.tooltip__trigger');
+  var content = tooltip.querySelector('.tooltip__content');
+  if (!trigger || !content) return;
+  var toggle = function (open) {
+    tooltip.setAttribute('data-open', open ? 'true' : 'false');
+    trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+  };
+  trigger.addEventListener('click', function (event) {
+    event.preventDefault();
+    var isOpen = tooltip.getAttribute('data-open') === 'true';
+    toggle(!isOpen);
+  });
+  trigger.addEventListener('blur', function () { toggle(false); });
+})();
+</script>

--- a/snippets/variant-picker.liquid
+++ b/snippets/variant-picker.liquid
@@ -1,0 +1,172 @@
+{%- comment -%}
+  Snippet: variant-picker
+  Verwendung: {% render 'variant-picker', product: product, option_position: 1, picker_type: 'button', selected_value: current_option %}
+  Parameter:
+    - product: Produktobjekt (product, nil)
+    - option_position: Option 1-3 (number, 1)
+    - picker_type: button | dropdown | swatch (text, 'button')
+    - selected_value: Vorbelegung (text, nil)
+    - form_id: Verknüpftes Formular (text, nil)
+    - option_name: Überschreibt den Optionsnamen (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign product = product | default: nil
+  assign option_position = option_position | default: 1 | plus: 0
+  assign picker_type = picker_type | default: 'button'
+  assign selected_value = selected_value | default: nil
+  assign form_id = form_id | default: nil
+  assign option_name = option_name | default: nil
+
+  assign render_picker = true
+  if product == nil or product.options_with_values.size == 0
+    assign render_picker = false
+  endif
+
+  assign option_index = option_position | minus: 1
+  assign option = nil
+  if render_picker
+    assign option = product.options_with_values[option_index]
+    if option == blank
+      assign render_picker = false
+    endif
+  endif
+
+  assign option_label = option_name
+  if option_label == nil and option
+    assign option_label = option.name
+  endif
+  assign option_id = 'Option-' | append: option_position | append: '-' | append: product.id
+-%}
+
+{%- if render_picker != true -%}
+  <!-- variant-picker: keine gültigen Daten -->
+{%- elsif picker_type == 'dropdown' -%}
+  <label class="variant-picker variant-picker--dropdown" for="{{ option_id }}">
+    <span class="variant-picker__label">{{ option_label }}</span>
+    <select
+      class="variant-picker__select"
+      id="{{ option_id }}"
+      name="options[{{ option_position }}]"
+      {% if form_id %}form="{{ form_id }}"{% endif %}
+    >
+      {%- for value in option.values -%}
+        {%- assign is_selected = false -%}
+        {%- if selected_value and selected_value == value -%}
+          {%- assign is_selected = true -%}
+        {%- endif -%}
+        <option value="{{ value }}" {% if is_selected %}selected{% endif %}>{{ value }}</option>
+      {%- endfor -%}
+    </select>
+  </label>
+{%- else -%}
+  <fieldset class="variant-picker variant-picker--{{ picker_type }}">
+    <legend class="variant-picker__legend">{{ option_label }}</legend>
+    <div class="variant-picker__options">
+      {%- for value in option.values -%}
+        {%- assign is_selected = false -%}
+        {%- assign is_available = false -%}
+        {%- for variant in product.variants -%}
+          {%- if variant.options[option_index] == value and variant.available -%}
+            {%- assign is_available = true -%}
+            {%- break -%}
+          {%- endif -%}
+        {%- endfor -%}
+        {%- if selected_value and selected_value == value -%}
+          {%- assign is_selected = true -%}
+        {%- endif -%}
+        {%- assign value_id = option_id | append: '-' | append: forloop.index -%}
+        <label class="variant-picker__option{% if is_selected %} is-selected{% endif %}{% unless is_available %} is-unavailable{% endunless %}" for="{{ value_id }}">
+          <input
+            class="variant-picker__input"
+            type="radio"
+            name="options[{{ option_position }}]"
+            id="{{ value_id }}"
+            value="{{ value }}"
+            {% if form_id %}form="{{ form_id }}"{% endif %}
+            {% if is_selected %}checked{% endif %}
+            {% unless is_available %}disabled aria-disabled="true"{% endunless %}
+          >
+          <span class="variant-picker__value" data-value="{{ value | escape }}">{{ value }}</span>
+        </label>
+      {%- endfor -%}
+    </div>
+  </fieldset>
+{%- endif -%}
+
+<style>
+.variant-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.variant-picker__legend,
+.variant-picker__label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.variant-picker__select {
+  width: 100%;
+  font: inherit;
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.375rem;
+  border: 1px solid rgba(17, 24, 39, 0.15);
+}
+
+.variant-picker__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.variant-picker__option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  border: 1px solid rgba(17, 24, 39, 0.15);
+  border-radius: 0.375rem;
+  cursor: pointer;
+  min-width: 3rem;
+  position: relative;
+  background: #fff;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.variant-picker__option.is-selected {
+  border-color: #2563eb;
+  background-color: rgba(37, 99, 235, 0.08);
+}
+
+.variant-picker__option.is-unavailable {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.variant-picker__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.variant-picker__value {
+  font-size: 0.875rem;
+}
+
+.variant-picker--swatch .variant-picker__option {
+  padding: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+}
+
+.variant-picker--swatch .variant-picker__value {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: currentColor;
+  color: transparent;
+}
+</style>

--- a/snippets/video.liquid
+++ b/snippets/video.liquid
@@ -1,0 +1,97 @@
+{%- comment -%}
+  Snippet: video
+  Verwendung: {% render 'video', video: section.settings.video, poster: section.settings.poster, autoplay: true %}
+  Parameter:
+    - video: Shopify Video/Media-Objekt (video, nil)
+    - video_url: MP4-URL als Fallback (url, nil)
+    - poster: Poster-Bild (image, nil)
+    - autoplay: Autoplay aktivieren (boolean, false)
+    - loop: Loop aktivieren (boolean, false)
+    - muted: Ton stummschalten (boolean, true)
+    - controls: Steuerelemente anzeigen (boolean, true)
+    - aspect_ratio: Seitenverhältnis (text, '16/9')
+    - id: HTML-ID (text, nil)
+{%- endcomment -%}
+
+{%- liquid
+  assign autoplay = autoplay | default: false
+  assign loop = loop | default: false
+  assign muted = muted | default: true
+  assign controls = controls | default: true
+  assign aspect_ratio = aspect_ratio | default: '16/9'
+  assign id = id | default: null
+  assign poster = poster | default: nil
+
+  assign wrapper_classes = 'video'
+  assign style_attr = '--video-aspect-ratio: ' | append: aspect_ratio | append: ';'
+
+  assign show_controls = controls
+  if autoplay == true or autoplay == 'true'
+    assign show_controls = false
+  endif
+-%}
+
+<div class="{{ wrapper_classes }}" style="{{ style_attr }}" {% if id %}id="{{ id }}"{% endif %}>
+  <div class="video__inner">
+    {%- if video -%}
+      {{ video | video_tag:
+        image_size: '1920x',
+        autoplay: autoplay,
+        loop: loop,
+        muted: muted,
+        controls: show_controls,
+        class: 'video__media',
+        poster: poster
+      }}
+    {%- elsif video_url -%}
+      <video
+        class="video__media"
+        {% if autoplay %}autoplay playsinline{% endif %}
+        {% if loop %}loop{% endif %}
+        {% if muted %}muted{% endif %}
+        {% if show_controls %}controls{% endif %}
+        preload="metadata"
+        {% if poster %}poster="{{ poster | image_url: width: 1920 }}"{% endif %}
+      >
+        <source src="{{ video_url }}" type="video/mp4">
+        {{ 'Video kann nicht geladen werden.' | escape }}
+      </video>
+    {%- else -%}
+      <div class="video__placeholder" role="img" aria-label="Video-Platzhalter">
+        <span class="video__placeholder-icon" aria-hidden="true">▶</span>
+      </div>
+    {%- endif -%}
+  </div>
+</div>
+
+<style>
+.video {
+  position: relative;
+  width: 100%;
+}
+
+.video__inner {
+  position: relative;
+  padding-bottom: calc(100% / (var(--video-aspect-ratio)));
+  height: 0;
+}
+
+.video__media,
+.video__placeholder {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border: 0;
+}
+
+.video__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(17, 24, 39, 0.08);
+  color: rgba(17, 24, 39, 0.5);
+  font-size: clamp(2rem, 10vw, 3rem);
+}
+</style>


### PR DESCRIPTION
## Summary
- add a full library of reusable Shopify Liquid snippets for typography, actions, media, forms, layout, product merchandising, navigation, and feedback patterns
- introduce four modular block templates (Hero Banner, Produktkarte, Testimonial Slider, Newsletter Signup) that compose the new snippets and provide Theme Editor schema support

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6909fbb2ae2083298367fb233641830f